### PR TITLE
feat(hooks): auto-discover and inject skill context during task orchestration

### DIFF
--- a/plugins/babysitter/hooks/babysitter-stop-hook.sh
+++ b/plugins/babysitter/hooks/babysitter-stop-hook.sh
@@ -337,6 +337,19 @@ else
   SYSTEM_MSG="🔄 Babysitter iteration $NEXT_ITERATION | Agent should continue orchestration (run:iterate)"
 fi
 
+# ─────────────────────────────────────────────────
+# Inject available skill context into system message
+# ─────────────────────────────────────────────────
+SKILL_CONTEXT=""
+SKILL_RESOLVER="${CLAUDE_PLUGIN_ROOT:-}/hooks/skill-context-resolver.sh"
+if [[ -x "$SKILL_RESOLVER" ]]; then
+  SKILL_CONTEXT=$(bash "$SKILL_RESOLVER" "${RUN_ID:-}" "${CLAUDE_PLUGIN_ROOT:-}" 2>/dev/null || echo "")
+  if [[ -n "$SKILL_CONTEXT" ]]; then
+    SYSTEM_MSG="$SYSTEM_MSG | 🧩 Available skills for this task: $SKILL_CONTEXT. Use the Skill tool or skill-discovery to load any of these."
+    echo "✅ Babysitter run: Injected skill context ($SKILL_CONTEXT)" >> /tmp/babysitter-stop-hook.log
+  fi
+fi
+
 echo "✅ Babysitter run: Outputting JSON to block the stop and feed prompt back" >> /tmp/babysitter-stop-hook.log
 echo "   State file: $BABYSITTER_STATE_FILE" >> /tmp/babysitter-stop-hook.log
 echo "   Session ID: $SESSION_ID" >> /tmp/babysitter-stop-hook.log

--- a/plugins/babysitter/hooks/skill-context-resolver.sh
+++ b/plugins/babysitter/hooks/skill-context-resolver.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+# Skill Context Resolver
+#
+# Resolves available skills relevant to the current task/run.
+# Combines local skill library scanning with external discovery.
+#
+# Usage:
+#   skill-context-resolver.sh <RUN_ID> <PLUGIN_ROOT>
+#
+# Output: Compact skill summary string for injection into systemMessage
+#   e.g., "cuda-toolkit (CUDA kernel dev), deep-linking (mobile deep links), ..."
+#
+# Also outputs full JSON to stderr for structured consumption.
+
+set -euo pipefail
+
+RUN_ID="${1:-}"
+PLUGIN_ROOT="${2:-}"
+
+if [[ -z "$PLUGIN_ROOT" ]]; then
+  echo ""
+  exit 0
+fi
+
+# ─────────────────────────────────────────────────
+# Cache: avoid re-scanning on every iteration
+# Cache keyed by RUN_ID, valid for 5 minutes
+# ─────────────────────────────────────────────────
+CACHE_DIR="/tmp/babysitter-skill-cache"
+mkdir -p "$CACHE_DIR"
+CACHE_FILE="$CACHE_DIR/${RUN_ID:-default}.json"
+CACHE_SUMMARY="$CACHE_DIR/${RUN_ID:-default}.summary"
+CACHE_TTL=300 # 5 minutes
+
+if [[ -f "$CACHE_SUMMARY" ]]; then
+  CACHE_AGE=$(( $(date +%s) - $(stat -f%m "$CACHE_SUMMARY" 2>/dev/null || stat -c%Y "$CACHE_SUMMARY" 2>/dev/null || echo 0) ))
+  if [[ $CACHE_AGE -lt $CACHE_TTL ]]; then
+    cat "$CACHE_SUMMARY"
+    exit 0
+  fi
+fi
+
+# ─────────────────────────────────────────────────
+# 1. Detect run domain/category from process definition
+# ─────────────────────────────────────────────────
+DOMAIN=""
+CATEGORY=""
+if [[ -n "$RUN_ID" ]] && [[ -d ".a5c/runs/$RUN_ID" ]]; then
+  # Try to read process metadata for domain hints
+  PROCESS_FILE=$(find ".a5c/runs/$RUN_ID" -name "*.js" -maxdepth 1 -type f 2>/dev/null | head -1)
+  if [[ -n "$PROCESS_FILE" ]]; then
+    # Extract domain hints from process file comments or metadata
+    DOMAIN=$(grep -oP '(?:domain|category|specialization)[:\s]*["\x27]?\K[a-z-]+' "$PROCESS_FILE" 2>/dev/null | head -1 || echo "")
+  fi
+fi
+
+# ─────────────────────────────────────────────────
+# 2. Scan local skill library
+# ─────────────────────────────────────────────────
+SKILLS_ROOT="$PLUGIN_ROOT/skills/babysit/process/specializations"
+LOCAL_SKILLS="[]"
+
+if [[ -d "$SKILLS_ROOT" ]]; then
+  # Find all SKILL.md files and extract name + description
+  while IFS= read -r skill_file; do
+    [[ -z "$skill_file" ]] && continue
+
+    # Parse frontmatter
+    name=$(sed -n '/^---$/,/^---$/{ /^---$/d; p; }' "$skill_file" | grep '^name:' | sed 's/name: *//' | head -1)
+    desc=$(sed -n '/^---$/,/^---$/{ /^---$/d; p; }' "$skill_file" | grep '^description:' | sed 's/description: *//' | head -1)
+    cat_meta=$(sed -n '/^---$/,/^---$/{ /^---$/d; p; }' "$skill_file" | grep -oP '(?:category|domain): *\K.*' | head -1 || echo "")
+
+    if [[ -n "$name" ]]; then
+      # Truncate description to 80 chars for compactness
+      short_desc="${desc:0:80}"
+      LOCAL_SKILLS=$(echo "$LOCAL_SKILLS" | jq --arg n "$name" --arg d "$short_desc" --arg c "$cat_meta" --arg f "$skill_file" \
+        '. + [{"name": $n, "description": $d, "category": $c, "source": "local", "file": $f}]')
+    fi
+  done < <(find "$SKILLS_ROOT" -name "SKILL.md" -type f 2>/dev/null | head -50)
+fi
+
+# Also scan plugin-level skills (the main registered ones)
+PLUGIN_SKILLS_DIR="$PLUGIN_ROOT/skills"
+if [[ -d "$PLUGIN_SKILLS_DIR" ]]; then
+  while IFS= read -r skill_file; do
+    [[ -z "$skill_file" ]] && continue
+    # Skip specializations (already scanned)
+    [[ "$skill_file" == *"/specializations/"* ]] && continue
+
+    name=$(sed -n '/^---$/,/^---$/{ /^---$/d; p; }' "$skill_file" | grep '^name:' | sed 's/name: *//' | head -1)
+    desc=$(sed -n '/^---$/,/^---$/{ /^---$/d; p; }' "$skill_file" | grep '^description:' | sed 's/description: *//' | head -1)
+
+    if [[ -n "$name" ]]; then
+      short_desc="${desc:0:80}"
+      LOCAL_SKILLS=$(echo "$LOCAL_SKILLS" | jq --arg n "$name" --arg d "$short_desc" --arg f "$skill_file" \
+        '. + [{"name": $n, "description": $d, "category": "", "source": "local-plugin", "file": $f}]')
+    fi
+  done < <(find "$PLUGIN_SKILLS_DIR" -maxdepth 2 -name "SKILL.md" -type f 2>/dev/null)
+fi
+
+# ─────────────────────────────────────────────────
+# 3. External discovery (if configured)
+# ─────────────────────────────────────────────────
+EXTERNAL_SKILLS="[]"
+DISCOVERY_SCRIPT="$PLUGIN_ROOT/hooks/skill-discovery.sh"
+
+# Default external sources - the babysitter skills repo
+EXTERNAL_SOURCES=(
+  "github|https://github.com/MaTriXy/babysitter/tree/main/plugins/babysitter/skills"
+)
+
+# Check for additional sources in .a5c/skill-sources.json
+if [[ -f ".a5c/skill-sources.json" ]]; then
+  while IFS= read -r source; do
+    [[ -z "$source" ]] && continue
+    EXTERNAL_SOURCES+=("$source")
+  done < <(jq -r '.sources[]? | "\(.type)|\(.url)"' ".a5c/skill-sources.json" 2>/dev/null)
+fi
+
+if [[ -x "$DISCOVERY_SCRIPT" ]]; then
+  for source_spec in "${EXTERNAL_SOURCES[@]}"; do
+    IFS='|' read -r stype surl <<< "$source_spec"
+    discovered=$(bash "$DISCOVERY_SCRIPT" "$stype" "$surl" 2>/dev/null || echo "[]")
+    if [[ "$discovered" != "[]" ]]; then
+      EXTERNAL_SKILLS=$(echo "$EXTERNAL_SKILLS" | jq --argjson d "$discovered" '. + $d')
+    fi
+  done
+fi
+
+# ─────────────────────────────────────────────────
+# 4. Merge and filter skills
+# ─────────────────────────────────────────────────
+ALL_SKILLS=$(echo "$LOCAL_SKILLS" | jq --argjson ext "$EXTERNAL_SKILLS" '. + $ext')
+
+# If we have a domain, prioritize matching skills
+if [[ -n "$DOMAIN" ]]; then
+  ALL_SKILLS=$(echo "$ALL_SKILLS" | jq --arg d "$DOMAIN" '
+    sort_by(if (.category // "" | ascii_downcase | contains($d | ascii_downcase)) then 0 else 1 end)
+  ')
+fi
+
+# Deduplicate by name
+ALL_SKILLS=$(echo "$ALL_SKILLS" | jq '[group_by(.name)[] | .[0]]')
+
+# Limit to top 30 for context window efficiency
+ALL_SKILLS=$(echo "$ALL_SKILLS" | jq '.[0:30]')
+
+# ─────────────────────────────────────────────────
+# 5. Output
+# ─────────────────────────────────────────────────
+
+# Full JSON to cache
+echo "$ALL_SKILLS" > "$CACHE_FILE"
+
+# Compact summary for systemMessage injection
+SUMMARY=$(echo "$ALL_SKILLS" | jq -r '
+  map("\(.name) (\(.description // "no description" | .[0:60]))")
+  | join(", ")
+')
+
+# If empty, indicate no skills found
+if [[ -z "$SUMMARY" ]] || [[ "$SUMMARY" == "null" ]]; then
+  SUMMARY=""
+fi
+
+echo "$SUMMARY" > "$CACHE_SUMMARY"
+echo "$SUMMARY"
+
+# Full JSON to stderr for structured consumers
+echo "$ALL_SKILLS" >&2

--- a/plugins/babysitter/hooks/skill-discovery.sh
+++ b/plugins/babysitter/hooks/skill-discovery.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+# Skill Discovery - External Skill Fetching
+#
+# Discovers skills from external sources:
+# 1. GitHub repositories (raw SKILL.md files from a skills/ directory)
+# 2. Well-known URLs (.well-known/skills/index.json - Vercel convention)
+#
+# Usage:
+#   skill-discovery.sh <source-type> <url>
+#   skill-discovery.sh github "https://github.com/MaTriXy/babysitter/tree/main/plugins/babysitter/skills"
+#   skill-discovery.sh well-known "https://example.com"
+#
+# Output: JSON array of discovered skills on stdout
+#   [{"name": "...", "description": "...", "source": "remote", "url": "..."}]
+
+set -euo pipefail
+
+SOURCE_TYPE="${1:-}"
+SOURCE_URL="${2:-}"
+
+if [[ -z "$SOURCE_TYPE" ]] || [[ -z "$SOURCE_URL" ]]; then
+  echo "[]"
+  exit 0
+fi
+
+# Helper: fetch URL content with timeout
+fetch_url() {
+  local url="$1"
+  curl -sL --max-time 10 --fail "$url" 2>/dev/null || echo ""
+}
+
+# Helper: parse SKILL.md frontmatter for name and description
+parse_skill_frontmatter() {
+  local content="$1"
+  local name desc
+  name=$(echo "$content" | sed -n '/^---$/,/^---$/{ /^---$/d; p; }' | grep '^name:' | sed 's/name: *//' | head -1)
+  desc=$(echo "$content" | sed -n '/^---$/,/^---$/{ /^---$/d; p; }' | grep '^description:' | sed 's/description: *//' | head -1)
+  if [[ -n "$name" ]]; then
+    echo "$name|$desc"
+  fi
+}
+
+# ─────────────────────────────────────────────────
+# GitHub Discovery
+# Fetches skill listing from a GitHub repo directory
+# ─────────────────────────────────────────────────
+discover_github() {
+  local url="$1"
+  local skills_json="[]"
+
+  # Convert GitHub web URL to API URL
+  # https://github.com/OWNER/REPO/tree/BRANCH/PATH -> https://api.github.com/repos/OWNER/REPO/contents/PATH?ref=BRANCH
+  local api_url=""
+  if [[ "$url" =~ github\.com/([^/]+)/([^/]+)/tree/([^/]+)/(.*) ]]; then
+    local owner="${BASH_REMATCH[1]}"
+    local repo="${BASH_REMATCH[2]}"
+    local branch="${BASH_REMATCH[3]}"
+    local path="${BASH_REMATCH[4]}"
+    api_url="https://api.github.com/repos/$owner/$repo/contents/$path?ref=$branch"
+  elif [[ "$url" =~ github\.com/([^/]+)/([^/]+)/? ]]; then
+    local owner="${BASH_REMATCH[1]}"
+    local repo="${BASH_REMATCH[2]}"
+    api_url="https://api.github.com/repos/$owner/$repo/contents/skills?ref=main"
+  else
+    echo "[]"
+    return
+  fi
+
+  # Fetch directory listing
+  local listing
+  listing=$(fetch_url "$api_url")
+  if [[ -z "$listing" ]]; then
+    echo "[]"
+    return
+  fi
+
+  # Find directories that likely contain SKILL.md
+  local dirs
+  dirs=$(echo "$listing" | jq -r '.[] | select(.type == "dir") | .name' 2>/dev/null || echo "")
+
+  if [[ -z "$dirs" ]]; then
+    # Maybe it's a flat listing with SKILL.md files directly
+    local skill_files
+    skill_files=$(echo "$listing" | jq -r '.[] | select(.name == "SKILL.md") | .download_url' 2>/dev/null || echo "")
+    if [[ -n "$skill_files" ]]; then
+      local content
+      content=$(fetch_url "$skill_files")
+      if [[ -n "$content" ]]; then
+        local parsed
+        parsed=$(parse_skill_frontmatter "$content")
+        if [[ -n "$parsed" ]]; then
+          local sname sdesc
+          sname=$(echo "$parsed" | cut -d'|' -f1)
+          sdesc=$(echo "$parsed" | cut -d'|' -f2-)
+          skills_json=$(jq -n --arg n "$sname" --arg d "$sdesc" --arg u "$url" \
+            '[{"name": $n, "description": $d, "source": "remote", "url": $u}]')
+        fi
+      fi
+    fi
+    echo "$skills_json"
+    return
+  fi
+
+  # For each subdirectory, try to fetch SKILL.md
+  local results="[]"
+  local count=0
+  while IFS= read -r dir; do
+    [[ -z "$dir" ]] && continue
+    # Limit to 20 skills to avoid rate limiting
+    ((count++)) && [[ $count -gt 20 ]] && break
+
+    # Build raw URL for SKILL.md in this subdirectory
+    local raw_base=""
+    if [[ "$url" =~ github\.com/([^/]+)/([^/]+)/tree/([^/]+)/(.*) ]]; then
+      raw_base="https://raw.githubusercontent.com/${BASH_REMATCH[1]}/${BASH_REMATCH[2]}/${BASH_REMATCH[3]}/${BASH_REMATCH[4]}"
+    fi
+
+    if [[ -n "$raw_base" ]]; then
+      local skill_url="$raw_base/$dir/SKILL.md"
+      local content
+      content=$(fetch_url "$skill_url")
+      if [[ -n "$content" ]]; then
+        local parsed
+        parsed=$(parse_skill_frontmatter "$content")
+        if [[ -n "$parsed" ]]; then
+          local sname sdesc
+          sname=$(echo "$parsed" | cut -d'|' -f1)
+          sdesc=$(echo "$parsed" | cut -d'|' -f2-)
+          results=$(echo "$results" | jq --arg n "$sname" --arg d "$sdesc" --arg u "$skill_url" \
+            '. + [{"name": $n, "description": $d, "source": "remote", "url": $u}]')
+        fi
+      fi
+    fi
+  done <<< "$dirs"
+
+  echo "$results"
+}
+
+# ─────────────────────────────────────────────────
+# Well-Known Discovery (Vercel convention)
+# Fetches .well-known/skills/index.json
+# ─────────────────────────────────────────────────
+discover_well_known() {
+  local base_url="$1"
+  # Strip trailing slash
+  base_url="${base_url%/}"
+
+  # Try path-relative first, then root
+  local index_content=""
+  local index_url="$base_url/.well-known/skills/index.json"
+  index_content=$(fetch_url "$index_url")
+
+  if [[ -z "$index_content" ]]; then
+    # Try root well-known
+    local host
+    host=$(echo "$base_url" | sed -E 's|^https?://([^/]+).*|\1|')
+    index_url="https://$host/.well-known/skills/index.json"
+    index_content=$(fetch_url "$index_url")
+  fi
+
+  if [[ -z "$index_content" ]]; then
+    echo "[]"
+    return
+  fi
+
+  # Validate and extract skills from index
+  local skills
+  skills=$(echo "$index_content" | jq -r '
+    .skills // [] |
+    map({
+      name: .name,
+      description: (.description // ""),
+      source: "remote",
+      url: "'"$base_url"'"
+    })
+  ' 2>/dev/null || echo "[]")
+
+  echo "$skills"
+}
+
+# ─────────────────────────────────────────────────
+# Main dispatch
+# ─────────────────────────────────────────────────
+case "$SOURCE_TYPE" in
+  github)
+    discover_github "$SOURCE_URL"
+    ;;
+  well-known)
+    discover_well_known "$SOURCE_URL"
+    ;;
+  *)
+    echo "[]"
+    ;;
+esac


### PR DESCRIPTION
## Summary

Adds dynamic skill awareness to the babysitter orchestration loop. When the agent is in an active task state, it now **automatically knows which skills are available** — from both the local skill library (1,864 specialization skills) and external sources (GitHub repos, `.well-known/skills/` endpoints).

- **Skill context injection** via the stop hook's `systemMessage` — agent sees available skills on every iteration
- **External skill discovery** supporting GitHub repos and Vercel-style `.well-known/skills/index.json` convention
- **`kind: "skill"` task support** in the native orchestrator alongside `node`, `breakpoint`, and `sleep`

## Architecture & Data Flow

```
┌─────────────────────────────────────────────────────┐
│ Stop Hook (babysitter-stop-hook.sh)                 │
│  blocks exit → builds systemMessage                 │
│         ↓                                           │
│  calls skill-context-resolver.sh                    │
│         ↓                                           │
│  appends "🧩 Available skills: ..." to systemMessage│
│         ↓                                           │
│  agent sees skills on next iteration                │
└─────────────────────────────────────────────────────┘

┌─────────────────────────────────────────────────────┐
│ skill-context-resolver.sh                           │
│  1. Scans local specializations/ for SKILL.md files │
│  2. Calls skill-discovery.sh for external sources   │
│  3. Merges, deduplicates, domain-prioritizes        │
│  4. Caches per run ID (5-min TTL)                   │
│  5. Returns compact summary string                  │
└─────────────────────────────────────────────────────┘

┌─────────────────────────────────────────────────────┐
│ skill-discovery.sh                                  │
│  GitHub mode:                                       │
│    web URL → GitHub API → list dirs → fetch SKILL.md│
│    parse frontmatter → return JSON                  │
│  Well-known mode (Vercel convention):               │
│    base URL → .well-known/skills/index.json         │
│    validate schema → return JSON                    │
└─────────────────────────────────────────────────────┘

┌─────────────────────────────────────────────────────┐
│ Native Orchestrator (on-iteration-start)            │
│  Now handles kind:"skill" pending effects:          │
│  extracts skill name/context → returns              │
│  "invoke-skills" action for the agent               │
└─────────────────────────────────────────────────────┘
```

## Files Changed

| File | Change | Purpose |
|------|--------|---------|
| `plugins/babysitter/hooks/skill-discovery.sh` | **NEW** | Fetch skills from GitHub repos and `.well-known/skills/` endpoints |
| `plugins/babysitter/hooks/skill-context-resolver.sh` | **NEW** | Combine local scan + external discovery with 5-min caching |
| `plugins/babysitter/hooks/babysitter-stop-hook.sh` | **MODIFIED** | Inject skill context into `systemMessage` (+13 lines) |
| `plugins/babysitter/hooks/on-iteration-start/native-orchestrator.sh` | **MODIFIED** | Handle `kind: "skill"` task effects (+32 lines) |

## How It Works

1. **During an active babysitter run**, the stop hook fires on every iteration
2. Before outputting the JSON block, it calls `skill-context-resolver.sh` with the current `RUN_ID`
3. The resolver scans local `specializations/` SKILL.md files and optionally fetches external skills
4. A compact skill list is appended to `systemMessage`: `"🧩 Available skills: cuda-toolkit (CUDA kernel dev), deep-linking (mobile deep links), ..."`
5. The agent can then load any discovered skill via the `Skill` tool
6. When a process defines `kind: "skill"` tasks, the native orchestrator now returns `invoke-skills` action instead of treating them as unknown

## External Source Configuration

Additional skill sources can be configured via `.a5c/skill-sources.json`:
```json
{
  "sources": [
    { "type": "github", "url": "https://github.com/owner/repo/tree/main/skills" },
    { "type": "well-known", "url": "https://example.com/docs" }
  ]
}
```

## Test plan
- [ ] Start a babysitter run and verify `systemMessage` includes available skills
- [ ] Verify `kind: "skill"` tasks are handled by the native orchestrator
- [ ] Test external discovery against a GitHub skills directory
- [ ] Verify caching works (second iteration should use cached results)
- [ ] Confirm agent can load a discovered skill via the Skill tool