### PR TITLE
fix: remove duplicate babysitter bin from SDK package

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -7,7 +7,6 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
-    "babysitter": "dist/cli/main.js",
     "babysitter-sdk": "dist/cli/main.js"
   },
   "files": [


### PR DESCRIPTION
## Problem

Installing all three packages globally fails on [Volta](https://volta.sh/):

```
npm i -g @a5c-ai/babysitter@latest @a5c-ai/babysitter-sdk@latest @a5c-ai/babysitter-breakpoints@latest
```

```
Volta error: Executable 'babysitter' is already installed by @a5c-ai/babysitter
Please remove @a5c-ai/babysitter before installing @a5c-ai/babysitter-sdk
```

Volta tracks which globally-installed package owns each binary name. Both `@a5c-ai/babysitter` and `@a5c-ai/babysitter-sdk` register `"babysitter"` in their `bin` field, so Volta refuses to install the second one.

## Fix

Remove the `"babysitter"` key from `@a5c-ai/babysitter-sdk`'s `bin` field, keeping only `"babysitter-sdk"`. Both entries pointed to the same `dist/cli/main.js`.

```diff
  "bin": {
-   "babysitter": "dist/cli/main.js",
    "babysitter-sdk": "dist/cli/main.js"
  },
```

## Why this is non-breaking

1. **Metapackage users** (`@a5c-ai/babysitter`) — The metapackage's `bin/babysitter.js` is a thin proxy that already calls `require("@a5c-ai/babysitter-sdk/dist/cli/main.js")`. The `babysitter` command continues to work exactly as before.

2. **Standalone SDK users** (`@a5c-ai/babysitter-sdk`) — The `babysitter-sdk` command is retained and points to the same CLI entry point. If someone needs the shorter `babysitter` name, they should install the metapackage (which is its purpose).

3. **Non-Volta users** (npm, pnpm, yarn) — The duplicate bin was silently resolved by last-writer-wins. Removing it just makes the ownership explicit with no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)