### PR TITLE
Add serverReachableGate shell task and triage process to shared library

### DIFF
--- a/plugins/babysitter-codex/upstream/babysitter/skills/babysit/process/contrib/rogelsm/serverReachableGate.js
+++ b/plugins/babysitter-codex/upstream/babysitter/skills/babysit/process/contrib/rogelsm/serverReachableGate.js
@@ -1,0 +1,34 @@
+/**
+ * @module contrib/rogelsm/serverReachableGate
+ * @description Zero-token shell task factory that hard-fails if the dev server is unreachable.
+ * Designed as Phase 0 for bugfix processes to prevent misdiagnosis when dev environment is down.
+ *
+ * Usage:
+ *   import { serverReachableGate } from './serverReachableGate.js';
+ *   // In your process tasks array:
+ *   serverReachableGate(3010),  // checks localhost:3010
+ *
+ * @see https://github.com/a5c-ai/babysitter/issues/70
+ * @see https://github.com/a5c-ai/babysitter/issues/71
+ */
+
+import { defineTask } from '@a5c-ai/babysitter-sdk';
+
+/**
+ * Hard shell gate: dev server must be reachable.
+ * Zero tokens — instant fail if server is down.
+ *
+ * @param {number} [port=3010] - Port to check
+ * @returns {TaskDefinition}
+ */
+export function serverReachableGate(port = 3010) {
+  return defineTask({
+    name: 'server-reachable-gate',
+    kind: 'shell',
+    command: `curl -sf http://localhost:${port} -o /dev/null`,
+    expectedExitCode: 0,
+    description:
+      `Hard gate: dev server must be reachable at http://localhost:${port}. ` +
+      'If this fails, run your dev server startup script before proceeding with diagnosis.',
+  });
+}

--- a/plugins/babysitter-codex/upstream/babysitter/skills/babysit/process/contrib/rogelsm/triage.js
+++ b/plugins/babysitter-codex/upstream/babysitter/skills/babysit/process/contrib/rogelsm/triage.js
@@ -1,0 +1,77 @@
+/**
+ * @process triage
+ * @description Lightweight triage process to classify incoming issues before routing
+ * to a specialized process (generic-bugfix, infra-diagnostic, generic-feature, etc.).
+ *
+ * Structure: 2 phases
+ *   Phase 1: Health check (dev environment reachability)
+ *   Phase 2: Categorize (agent classifies the issue and recommends a process)
+ *
+ * @inputs
+ *   port {number} - Port the dev server listens on (default: 3010)
+ *   projectDir {string} - Absolute path to the project directory
+ *   issueDescription {string} - Plain-English description of the issue
+ *
+ * @outputs
+ *   healthCheck: pass/fail from the server reachable gate
+ *   category: { issueType, confidence, recommendedProcess, reasoning }
+ *
+ * @agent triage-analyst (Phase 2)
+ *
+ * @see ./serverReachableGate.js
+ * @see https://github.com/a5c-ai/babysitter/issues/70
+ * @see https://github.com/a5c-ai/babysitter/issues/71
+ */
+
+import { defineTask } from '@a5c-ai/babysitter-sdk';
+import { serverReachableGate } from './serverReachableGate.js';
+
+/**
+ * @param {{ port?: number, projectDir: string, issueDescription: string }} args
+ */
+export async function process(args) {
+  const { port = 3010, projectDir, issueDescription } = args;
+
+  return {
+    tasks: [
+      // ── Phase 1: Health check ───────────────────────────────────────────────
+      serverReachableGate(port),
+
+      // ── Phase 2: Categorize ─────────────────────────────────────────────────
+      defineTask({
+        name: 'categorize',
+        kind: 'agent',
+        role: 'triage-analyst',
+        description:
+          `Classify the following issue and recommend which process template to use.\n\n` +
+          `Issue description: ${issueDescription}\n\n` +
+          `Project directory: ${projectDir}\n\n` +
+          `Available process templates:\n` +
+          `  - generic-bugfix: For application-level bugs (UI glitches, logic errors, data issues)\n` +
+          `  - infra-diagnostic: For infrastructure issues (server won't start, DB down, /tmp wiped, ` +
+          `    Prisma errors, port conflicts)\n` +
+          `  - generic-feature: For new feature implementation or enhancements\n\n` +
+          `Classification steps:\n` +
+          `1. Read the issue description carefully\n` +
+          `2. Check the health check results from Phase 1 — if the dev stack is unhealthy, ` +
+          `   the issue is likely infra regardless of how it was described\n` +
+          `3. Determine the issue type: "bug", "infrastructure", or "feature"\n` +
+          `4. Recommend the appropriate process template\n` +
+          `5. Provide reasoning for the classification\n\n` +
+          `Output schema:\n` +
+          `{\n` +
+          `  issueType: string,          // "bug" | "infrastructure" | "feature"\n` +
+          `  confidence: string,         // "high" | "medium" | "low"\n` +
+          `  recommendedProcess: string, // "generic-bugfix" | "infra-diagnostic" | "generic-feature"\n` +
+          `  reasoning: string           // why this classification was chosen\n` +
+          `}`,
+        outputSchema: {
+          issueType: 'string',
+          confidence: 'string',
+          recommendedProcess: 'string',
+          reasoning: 'string',
+        },
+      }),
+    ],
+  };
+}

--- a/plugins/babysitter/skills/babysit/process/contrib/rogelsm/serverReachableGate.js
+++ b/plugins/babysitter/skills/babysit/process/contrib/rogelsm/serverReachableGate.js
@@ -1,0 +1,34 @@
+/**
+ * @module contrib/rogelsm/serverReachableGate
+ * @description Zero-token shell task factory that hard-fails if the dev server is unreachable.
+ * Designed as Phase 0 for bugfix processes to prevent misdiagnosis when dev environment is down.
+ *
+ * Usage:
+ *   import { serverReachableGate } from './serverReachableGate.js';
+ *   // In your process tasks array:
+ *   serverReachableGate(3010),  // checks localhost:3010
+ *
+ * @see https://github.com/a5c-ai/babysitter/issues/70
+ * @see https://github.com/a5c-ai/babysitter/issues/71
+ */
+
+import { defineTask } from '@a5c-ai/babysitter-sdk';
+
+/**
+ * Hard shell gate: dev server must be reachable.
+ * Zero tokens — instant fail if server is down.
+ *
+ * @param {number} [port=3010] - Port to check
+ * @returns {TaskDefinition}
+ */
+export function serverReachableGate(port = 3010) {
+  return defineTask({
+    name: 'server-reachable-gate',
+    kind: 'shell',
+    command: `curl -sf http://localhost:${port} -o /dev/null`,
+    expectedExitCode: 0,
+    description:
+      `Hard gate: dev server must be reachable at http://localhost:${port}. ` +
+      'If this fails, run your dev server startup script before proceeding with diagnosis.',
+  });
+}

--- a/plugins/babysitter/skills/babysit/process/contrib/rogelsm/triage.js
+++ b/plugins/babysitter/skills/babysit/process/contrib/rogelsm/triage.js
@@ -1,0 +1,77 @@
+/**
+ * @process triage
+ * @description Lightweight triage process to classify incoming issues before routing
+ * to a specialized process (generic-bugfix, infra-diagnostic, generic-feature, etc.).
+ *
+ * Structure: 2 phases
+ *   Phase 1: Health check (dev environment reachability)
+ *   Phase 2: Categorize (agent classifies the issue and recommends a process)
+ *
+ * @inputs
+ *   port {number} - Port the dev server listens on (default: 3010)
+ *   projectDir {string} - Absolute path to the project directory
+ *   issueDescription {string} - Plain-English description of the issue
+ *
+ * @outputs
+ *   healthCheck: pass/fail from the server reachable gate
+ *   category: { issueType, confidence, recommendedProcess, reasoning }
+ *
+ * @agent triage-analyst (Phase 2)
+ *
+ * @see ./serverReachableGate.js
+ * @see https://github.com/a5c-ai/babysitter/issues/70
+ * @see https://github.com/a5c-ai/babysitter/issues/71
+ */
+
+import { defineTask } from '@a5c-ai/babysitter-sdk';
+import { serverReachableGate } from './serverReachableGate.js';
+
+/**
+ * @param {{ port?: number, projectDir: string, issueDescription: string }} args
+ */
+export async function process(args) {
+  const { port = 3010, projectDir, issueDescription } = args;
+
+  return {
+    tasks: [
+      // ── Phase 1: Health check ───────────────────────────────────────────────
+      serverReachableGate(port),
+
+      // ── Phase 2: Categorize ─────────────────────────────────────────────────
+      defineTask({
+        name: 'categorize',
+        kind: 'agent',
+        role: 'triage-analyst',
+        description:
+          `Classify the following issue and recommend which process template to use.\n\n` +
+          `Issue description: ${issueDescription}\n\n` +
+          `Project directory: ${projectDir}\n\n` +
+          `Available process templates:\n` +
+          `  - generic-bugfix: For application-level bugs (UI glitches, logic errors, data issues)\n` +
+          `  - infra-diagnostic: For infrastructure issues (server won't start, DB down, /tmp wiped, ` +
+          `    Prisma errors, port conflicts)\n` +
+          `  - generic-feature: For new feature implementation or enhancements\n\n` +
+          `Classification steps:\n` +
+          `1. Read the issue description carefully\n` +
+          `2. Check the health check results from Phase 1 — if the dev stack is unhealthy, ` +
+          `   the issue is likely infra regardless of how it was described\n` +
+          `3. Determine the issue type: "bug", "infrastructure", or "feature"\n` +
+          `4. Recommend the appropriate process template\n` +
+          `5. Provide reasoning for the classification\n\n` +
+          `Output schema:\n` +
+          `{\n` +
+          `  issueType: string,          // "bug" | "infrastructure" | "feature"\n` +
+          `  confidence: string,         // "high" | "medium" | "low"\n` +
+          `  recommendedProcess: string, // "generic-bugfix" | "infra-diagnostic" | "generic-feature"\n` +
+          `  reasoning: string           // why this classification was chosen\n` +
+          `}`,
+        outputSchema: {
+          issueType: 'string',
+          confidence: 'string',
+          recommendedProcess: 'string',
+          reasoning: 'string',
+        },
+      }),
+    ],
+  };
+}


### PR DESCRIPTION
## Summary

Adds two shared utilities to prevent bugfix process misdiagnosis when the dev environment is down:

1. **`serverReachableGate(port)`** — Zero-token shell task factory that hard-fails if the dev server is unreachable (`curl -sf http://localhost:PORT`). Designed as Phase 0 for bugfix processes. Instant fail = no wasted agent tokens.

2. **`triage.js`** — Lightweight 2-phase triage process that checks environment health and categorizes issues before routing to the correct process type (`bugfix` / `infra` / `feature` / `config`).

## Motivation

In a real session (2026-03-23), a user reported "the link for the site is broken again." Without triage, a bugfix process was selected. The dev server was actually down (`ERR_CONNECTION_REFUSED`), but the diagnosis agent performed static code analysis and found a plausible but irrelevant Navbar CSS bug. **46 minutes and 5 tasks were wasted** fixing the wrong problem. A follow-up infra-first run fixed the actual issue in **4 minutes**.

A `serverReachableGate()` at Phase 0 would have caught this in milliseconds.

## Files Added

- `plugins/babysitter/skills/babysit/process/contrib/rogelsm/serverReachableGate.js`
- `plugins/babysitter/skills/babysit/process/contrib/rogelsm/triage.js`

## Related Issues

- Closes #70 (bug: generic-bugfix missing pre-flight health check)
- Closes #71 (feature: triage process for issue routing)

## Testing

- Both files follow library patterns (JSDoc, defineTask import, no `kind: node`)
- `serverReachableGate` uses `kind: 'shell'` with `expectedExitCode: 0`
- `triage.js` uses `kind: 'agent'` for categorization
- Port is configurable (default 3010)