### PR TITLE
Fix stale Claude session binding precedence in run creation

### DIFF
--- a/packages/sdk/src/cli/__tests__/cliRuns.test.ts
+++ b/packages/sdk/src/cli/__tests__/cliRuns.test.ts
@@ -11,6 +11,11 @@ import { createStateCacheSnapshot, writeStateCache } from "../../runtime/replay/
 import * as orchestrateIterationModule from "../../runtime/orchestrateIteration";
 import * as runFilesModule from "../../storage/runFiles";
 import { deriveCompletionProof } from "../completionProof";
+import {
+  __resetCacheForTests,
+  __setAncestorResolverForTests,
+  getSessionMarkerPath,
+} from "../../harness/sessionMarker";
 
 const realReadRunMetadata = readRunMetadata;
 
@@ -20,6 +25,9 @@ describe("babysitter run:create CLI", () => {
   let errorSpy: ReturnType<typeof vi.spyOn>;
   const sessionEnvKeys = [
     "BABYSITTER_SESSION_ID",
+    "BABYSITTER_GLOBAL_STATE_DIR",
+    "BABYSITTER_TRUST_ENV_SESSION",
+    "CLAUDE_ENV_FILE",
     "CODEX_THREAD_ID",
     "CODEX_SESSION_ID",
     "CODEX_PLUGIN_ROOT",
@@ -32,6 +40,9 @@ describe("babysitter run:create CLI", () => {
     errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
     savedSessionEnv = {
       BABYSITTER_SESSION_ID: process.env.BABYSITTER_SESSION_ID,
+      BABYSITTER_GLOBAL_STATE_DIR: process.env.BABYSITTER_GLOBAL_STATE_DIR,
+      BABYSITTER_TRUST_ENV_SESSION: process.env.BABYSITTER_TRUST_ENV_SESSION,
+      CLAUDE_ENV_FILE: process.env.CLAUDE_ENV_FILE,
       CODEX_THREAD_ID: process.env.CODEX_THREAD_ID,
       CODEX_SESSION_ID: process.env.CODEX_SESSION_ID,
       CODEX_PLUGIN_ROOT: process.env.CODEX_PLUGIN_ROOT,
@@ -51,6 +62,8 @@ describe("babysitter run:create CLI", () => {
         process.env[key] = savedSessionEnv[key];
       }
     }
+    __resetCacheForTests();
+    __setAncestorResolverForTests(undefined);
     await fs.rm(runsRoot, { recursive: true, force: true });
   });
 
@@ -125,6 +138,50 @@ describe("babysitter run:create CLI", () => {
       runDir,
       entry: `${metadata.entrypoint.importPath}#${metadata.entrypoint.exportName}`,
     });
+  });
+
+  it("binds claude-code runs to the current marker-backed session instead of a leaked BABYSITTER_SESSION_ID", async () => {
+    const entryFile = await writeEntrypoint("processes/claude-session.mjs", `export async function process() { return true; }\n`);
+    const globalStateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "cli-run-create-claude-state-"));
+    const currentSessionId = "current-claude-session";
+    const leakedSessionId = "leaked-background-shell-session";
+
+    process.env.BABYSITTER_GLOBAL_STATE_DIR = globalStateRoot;
+    process.env.BABYSITTER_SESSION_ID = leakedSessionId;
+    __resetCacheForTests();
+    __setAncestorResolverForTests(() => ({ pid: process.pid }));
+
+    const markerPath = getSessionMarkerPath("claude-code", process.pid);
+    await fs.mkdir(path.dirname(markerPath), { recursive: true });
+    await fs.writeFile(markerPath, `${currentSessionId}\n`);
+
+    const cli = createBabysitterCli();
+    const exitCode = await cli.run([
+      "run:create",
+      "--runs-dir",
+      runsRoot,
+      "--process-id",
+      "ci/claude-session",
+      "--entry",
+      `${entryFile}#process`,
+      "--harness",
+      "claude-code",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    const payload = readLastJsonLine(logSpy);
+    expect(payload.session).toMatchObject({
+      harness: "claude-code",
+      sessionId: currentSessionId,
+      resolvedFrom: "pid-marker",
+    });
+    expect(String(payload.session.stateFile).replace(/\\/g, "/")).toContain(`/state/${currentSessionId}.md`);
+    await expect(
+      fs.access(path.join(globalStateRoot, "state", `${currentSessionId}.md`)),
+    ).resolves.toBeUndefined();
+
+    await fs.rm(globalStateRoot, { recursive: true, force: true });
   });
 
   it("describes dry-run plans without creating run directories", async () => {

--- a/packages/sdk/src/cli/commands/__tests__/harnessCreateRun.test.ts
+++ b/packages/sdk/src/cli/commands/__tests__/harnessCreateRun.test.ts
@@ -9,6 +9,11 @@ import * as path from "node:path";
 import type { HarnessDiscoveryResult, HarnessInvokeResult } from "../../../harness/types";
 import type { IterationResult } from "../../../runtime/types";
 import { RunFailedError } from "../../../runtime/exceptions";
+import {
+  __resetCacheForTests,
+  __setAncestorResolverForTests,
+  getSessionMarkerPath,
+} from "../../../harness/sessionMarker";
 
 // ── Mocks ─────────────────────────────────────────────────────────────
 
@@ -327,6 +332,8 @@ describe("selectHarness", () => {
 
 describe("handleHarnessCreateRun", () => {
   let tempDirs: string[] = [];
+  let savedGlobalStateDir: string | undefined;
+  let savedBabysitterSessionId: string | undefined;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -347,6 +354,12 @@ describe("handleHarnessCreateRun", () => {
     vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
     detectCallerHarnessMock.mockReturnValue(null);
+    savedGlobalStateDir = process.env.BABYSITTER_GLOBAL_STATE_DIR;
+    savedBabysitterSessionId = process.env.BABYSITTER_SESSION_ID;
+    delete process.env.BABYSITTER_GLOBAL_STATE_DIR;
+    delete process.env.BABYSITTER_SESSION_ID;
+    __resetCacheForTests();
+    __setAncestorResolverForTests(undefined);
   });
 
   afterEach(async () => {
@@ -356,6 +369,18 @@ describe("handleHarnessCreateRun", () => {
       }),
     );
     tempDirs = [];
+    if (savedGlobalStateDir === undefined) {
+      delete process.env.BABYSITTER_GLOBAL_STATE_DIR;
+    } else {
+      process.env.BABYSITTER_GLOBAL_STATE_DIR = savedGlobalStateDir;
+    }
+    if (savedBabysitterSessionId === undefined) {
+      delete process.env.BABYSITTER_SESSION_ID;
+    } else {
+      process.env.BABYSITTER_SESSION_ID = savedBabysitterSessionId;
+    }
+    __resetCacheForTests();
+    __setAncestorResolverForTests(undefined);
   });
 
   describe("Phase A: --process flag skips generation", () => {
@@ -2478,6 +2503,47 @@ describe("handleHarnessCreateRun", () => {
       });
 
       expect(code).toBe(1);
+    });
+
+    it("binds claude-code orchestration to the current marker-backed session instead of a leaked BABYSITTER_SESSION_ID", async () => {
+      const globalStateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "harness-create-run-claude-state-"));
+      tempDirs.push(globalStateRoot);
+      process.env.BABYSITTER_GLOBAL_STATE_DIR = globalStateRoot;
+      process.env.BABYSITTER_SESSION_ID = "leaked-session-from-old-shell";
+      __resetCacheForTests();
+      __setAncestorResolverForTests(() => ({ pid: process.pid }));
+
+      const currentSessionId = "current-claude-session";
+      const markerPath = getSessionMarkerPath("claude-code", process.pid);
+      await fs.mkdir(path.dirname(markerPath), { recursive: true });
+      await fs.writeFile(markerPath, `${currentSessionId}\n`);
+
+      (discoverHarnesses as Mock).mockResolvedValue([
+        makeDiscoveryResult({ name: "claude-code" }),
+      ]);
+      (createRun as Mock).mockResolvedValue({
+        runId: "run-claude-marker",
+        runDir: "/tmp/runs/run-claude-marker",
+        metadata: {},
+      });
+      (orchestrateIteration as Mock).mockResolvedValue({
+        status: "completed",
+        output: "done",
+      });
+
+      const code = await handleHarnessCreateRun({
+        processPath: "/tmp/process.js",
+        runsDir: "/tmp/runs",
+        harness: "claude-code",
+        json: false,
+        verbose: false,
+        interactive: false,
+      });
+
+      expect(code).toBe(0);
+      await expect(
+        fs.access(path.join(globalStateRoot, "state", `${currentSessionId}.md`)),
+      ).resolves.toBeUndefined();
     });
   });
 

--- a/packages/sdk/src/cli/commands/harnessPhase2.ts
+++ b/packages/sdk/src/cli/commands/harnessPhase2.ts
@@ -212,6 +212,33 @@ function subscribeVerbosePiEvents(
   }
 }
 
+function resolveHarnessSessionIdForBinding(args: {
+  selectedHarnessName: string;
+}, adapter: NonNullable<ReturnType<typeof getAdapterByName>>, orchestrationSession?: PiSessionHandle | null): string | undefined {
+  if (
+    isInternalHarness(args.selectedHarnessName) &&
+    orchestrationSession?.sessionId
+  ) {
+    process.env.PI_SESSION_ID = process.env.PI_SESSION_ID || orchestrationSession.sessionId;
+    process.env.OMP_SESSION_ID = process.env.OMP_SESSION_ID || orchestrationSession.sessionId;
+  }
+
+  const resolved = adapter.resolveSessionId({});
+  if (resolved) {
+    return resolved;
+  }
+
+  if (args.selectedHarnessName === "codex") {
+    return process.env.CODEX_THREAD_ID || process.env.CODEX_SESSION_ID;
+  }
+
+  if (isInternalHarness(args.selectedHarnessName)) {
+    return orchestrationSession?.sessionId;
+  }
+
+  return undefined;
+}
+
 // ── Effect Resolution ────────────────────────────────────────────────
 
 export async function resolveEffect(
@@ -856,7 +883,7 @@ export async function runOrchestrationPhase(args: {
         { category: ErrorCategory.Configuration },
       );
     }
-    const sessionId = adapter.resolveSessionId({}) || process.env.CODEX_THREAD_ID || process.env.CODEX_SESSION_ID;
+    const sessionId = resolveHarnessSessionIdForBinding(args, adapter);
     if (!sessionId) {
       throw new BabysitterRuntimeError(
         "MissingHarnessSessionId",
@@ -1380,14 +1407,11 @@ export async function runOrchestrationPhase(args: {
             { category: ErrorCategory.Configuration },
           );
         }
-        if (
-          isInternalHarness(args.selectedHarnessName) &&
-          orchestrationSession?.sessionId
-        ) {
-          process.env.PI_SESSION_ID = process.env.PI_SESSION_ID || orchestrationSession.sessionId;
-          process.env.OMP_SESSION_ID = process.env.OMP_SESSION_ID || orchestrationSession.sessionId;
-        }
-        const sessionId = adapter.resolveSessionId({}) || orchestrationSession?.sessionId;
+        const sessionId = resolveHarnessSessionIdForBinding(
+          args,
+          adapter,
+          orchestrationSession,
+        );
         if (!sessionId) {
           throw new BabysitterRuntimeError(
             "MissingHarnessSessionId",


### PR DESCRIPTION
## Summary
- narrow Phase 2 session binding fallbacks so only harness-appropriate session sources are considered
- add a `run:create --harness claude-code` regression proving the current Claude marker-backed session beats a leaked `BABYSITTER_SESSION_ID`
- add a `harness:create-run --harness claude-code` regression covering the same stale-session scenario in Phase 2 orchestration

## Testing
- `npm run test --workspace=@a5c-ai/babysitter-sdk -- src/cli/__tests__/cliRuns.test.ts -t "binds claude-code runs to the current marker-backed session instead of a leaked BABYSITTER_SESSION_ID"`
- `npm run test --workspace=@a5c-ai/babysitter-sdk -- src/cli/commands/__tests__/harnessCreateRun.test.ts -t "binds claude-code orchestration to the current marker-backed session instead of a leaked BABYSITTER_SESSION_ID"`

Closes #133
