### PR TITLE
Normalize shell task error results for replay and task:post

### DIFF
--- a/packages/sdk/src/cli/__tests__/cliMain.test.ts
+++ b/packages/sdk/src/cli/__tests__/cliMain.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { MockInstance } from "vitest";
 import path from "path";
+import os from "os";
+import { promises as fs } from "fs";
 import { createBabysitterCli } from "../main";
 import { handleHarnessCreateRun } from "../commands/harnessCreateRun";
 import { buildEffectIndex } from "../../runtime/replay/effectIndex";
@@ -272,6 +274,62 @@ describe("CLI main entry", () => {
     );
   });
 
+  it("normalizes shell task error posts into success:false shell results", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "cli-task-post-shell-error-"));
+    const errorPath = path.join(tmpDir, "error.json");
+    await fs.writeFile(
+      errorPath,
+      JSON.stringify({
+        exitCode: 2,
+        stderr: "tsc failed",
+      }),
+      "utf8",
+    );
+    buildEffectIndexMock.mockResolvedValue(mockEffectIndex([shellEffectRecord("ef-shell-err")]));
+
+    const cli = createBabysitterCli();
+    const exitCode = await cli.run([
+      "task:post",
+      "runs/demo",
+      "ef-shell-err",
+      "--status",
+      "error",
+      "--error",
+      errorPath,
+      "--runs-dir",
+      ".",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(commitEffectResultMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        effectId: "ef-shell-err",
+        result: {
+          status: "ok",
+          value: {
+            success: false,
+            exitCode: 2,
+            stdout: "",
+            stderr: "tsc failed",
+            error: "Shell command exited with code 2",
+          },
+          stdout: undefined,
+          stderr: undefined,
+          stdoutRef: undefined,
+          stderrRef: undefined,
+          startedAt: expect.any(String),
+          finishedAt: expect.any(String),
+          metadata: undefined,
+        },
+      }),
+    );
+    expect(logSpy).toHaveBeenCalledWith(
+      "[task:post] status=ok normalizedShellFailure=true stdoutRef=tasks/mock/stdout.log stderrRef=tasks/mock/stderr.log resultRef=tasks/mock/result.json"
+    );
+
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
   it("rejects task:post ok results without a value payload", async () => {
     buildEffectIndexMock.mockResolvedValue(mockEffectIndex([nodeEffectRecord("ef-no-value")]));
 
@@ -455,6 +513,14 @@ function nodeEffectRecord(effectId: string, overrides: Partial<EffectRecord> = {
     requestedAt: new Date(0).toISOString(),
     ...overrides,
   };
+}
+
+function shellEffectRecord(effectId: string, overrides: Partial<EffectRecord> = {}): EffectRecord {
+  return nodeEffectRecord(effectId, {
+    kind: "shell",
+    taskId: "task/shell",
+    ...overrides,
+  });
 }
 
 function mockEffectIndex(records: EffectRecord[]) {

--- a/packages/sdk/src/cli/main.ts
+++ b/packages/sdk/src/cli/main.ts
@@ -1972,11 +1972,17 @@ async function handleTaskPost(parsed: ParsedArgs): Promise<number> {
   }
 
   const invocationKey = parsed.invocationKey ?? record.invocationKey;
+  const normalizedShellFailure = parsed.taskStatus === "error" && record.kind === "shell";
+  const committedStatus = normalizedShellFailure ? "ok" : parsed.taskStatus;
+  const committedValue = normalizedShellFailure
+    ? coerceShellFailureResult(errorPayload, stdout, stderr)
+    : value;
 
   const plan = {
     runDir: toRunRelativePosix(runDir, runDir) ?? runDir,
     effectId: parsed.effectId,
-    status: parsed.taskStatus,
+    status: committedStatus,
+    normalizedShellFailure,
     valueProvided: parsed.valuePath || parsed.valueInline ? true : false,
     errorProvided: parsed.errorPath ? true : false,
     stdoutRef: parsed.stdoutRef ?? null,
@@ -2000,10 +2006,10 @@ async function handleTaskPost(parsed: ParsedArgs): Promise<number> {
     effectId: parsed.effectId,
     invocationKey,
     result:
-      parsed.taskStatus === "ok"
+      committedStatus === "ok"
         ? {
             status: "ok",
-            value,
+            value: committedValue,
             stdout,
             stderr,
             stdoutRef: parsed.stdoutRef,
@@ -2032,7 +2038,8 @@ async function handleTaskPost(parsed: ParsedArgs): Promise<number> {
   if (parsed.json) {
     console.log(
       JSON.stringify({
-        status: parsed.taskStatus,
+        status: committedStatus,
+        normalizedShellFailure,
         committed,
         stdoutRef,
         stderrRef,
@@ -2040,13 +2047,54 @@ async function handleTaskPost(parsed: ParsedArgs): Promise<number> {
       })
     );
   } else {
-    const parts = [`[task:post] status=${parsed.taskStatus}`];
+    const parts = [`[task:post] status=${committedStatus}`];
+    if (normalizedShellFailure) parts.push("normalizedShellFailure=true");
     if (stdoutRef) parts.push(`stdoutRef=${stdoutRef}`);
     if (stderrRef) parts.push(`stderrRef=${stderrRef}`);
     if (resultRef) parts.push(`resultRef=${resultRef}`);
     console.log(parts.join(" "));
   }
-  return parsed.taskStatus === "ok" ? 0 : 1;
+  return committedStatus === "ok" ? 0 : 1;
+}
+
+function coerceShellFailureResult(
+  errorPayload: unknown,
+  stdout?: string,
+  stderr?: string,
+): {
+  success: false;
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  error: string;
+} {
+  const payloadData = isJsonRecord(errorPayload)
+    ? (isJsonRecord(errorPayload.data) ? errorPayload.data : errorPayload)
+    : undefined;
+  const exitCode = readNumericField(payloadData, "exitCode") ?? 1;
+  const normalizedStdout = stdout ?? readStringField(payloadData, "stdout") ?? "";
+  const normalizedStderr = stderr ?? readStringField(payloadData, "stderr") ?? "";
+  const errorMessage = readStringField(payloadData, "error")
+    ?? readStringField(payloadData, "message")
+    ?? `Shell command exited with code ${exitCode}`;
+
+  return {
+    success: false,
+    exitCode,
+    stdout: normalizedStdout,
+    stderr: normalizedStderr,
+    error: errorMessage,
+  };
+}
+
+function readStringField(value: JsonRecord | undefined, key: string): string | undefined {
+  const candidate = value?.[key];
+  return typeof candidate === "string" ? candidate : undefined;
+}
+
+function readNumericField(value: JsonRecord | undefined, key: string): number | undefined {
+  const candidate = value?.[key];
+  return typeof candidate === "number" && Number.isFinite(candidate) ? candidate : undefined;
 }
 
 async function handleTaskCancel(parsed: ParsedArgs): Promise<number> {

--- a/packages/sdk/src/runtime/__tests__/taskIntrinsic.test.ts
+++ b/packages/sdk/src/runtime/__tests__/taskIntrinsic.test.ts
@@ -26,6 +26,24 @@ const sampleTask: DefinedTask<{ value: number }, number> = {
   }),
 };
 
+const shellTask: DefinedTask<{ command: string }, {
+  success: false;
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  error: string;
+}> = {
+  id: "shell-task",
+  build: async (args) => ({
+    kind: "shell",
+    title: "verify shell task",
+    shell: {
+      command: args.command,
+      expectedExitCode: 0,
+    },
+  }),
+};
+
 let tmpRoot: string;
 
 beforeEach(async () => {
@@ -270,6 +288,56 @@ describe("runTaskIntrinsic", () => {
         context: replayCtx,
       })
     ).resolves.toEqual(failureValue);
+  });
+
+  test("returns structured shell failures when a shell effect was committed with status:error", async () => {
+    const { runDir, runId } = await createRun("run-shell-resolved-error");
+    const context = await buildContext(runDir, runId);
+
+    let effectId = "";
+    try {
+      await runTaskIntrinsic({
+        task: shellTask,
+        args: { command: "npm test" },
+        context,
+      });
+    } catch (error) {
+      expect(error).toBeInstanceOf(EffectRequestedError);
+      effectId = (error as EffectRequestedError).action.effectId;
+    }
+
+    await commitEffectResult({
+      runDir,
+      effectId,
+      result: {
+        status: "error",
+        error: {
+          name: "ShellCommandFailed",
+          message: "Shell command exited with code 2",
+          data: {
+            exitCode: 2,
+            stdout: "",
+            stderr: "tsc failed",
+          },
+        },
+        stderr: "tsc failed",
+      },
+    });
+
+    const replayCtx = await buildContext(runDir, runId);
+    await expect(
+      runTaskIntrinsic({
+        task: shellTask,
+        args: { command: "npm test" },
+        context: replayCtx,
+      })
+    ).resolves.toEqual({
+      success: false,
+      exitCode: 2,
+      stdout: "",
+      stderr: "tsc failed",
+      error: "Shell command exited with code 2",
+    });
   });
 
   test("provides TaskBuildContext metadata and records registry entries", async () => {

--- a/packages/sdk/src/runtime/intrinsics/task.ts
+++ b/packages/sdk/src/runtime/intrinsics/task.ts
@@ -98,6 +98,19 @@ async function handleExistingInvocation<TArgs, TResult>(
   }
 
   if (record.status === "resolved_error") {
+    if (record.kind === "shell") {
+      const storedShellResult = await readTaskResult(
+        options.context.runDir,
+        record.effectId,
+        record.resultRef ? normalizeRef(options.context.runDir, record.resultRef) : undefined
+      );
+      if (!storedShellResult) {
+        throw new RunFailedError(`Result for effect ${record.effectId} is missing from disk`, {
+          effectId: record.effectId,
+        });
+      }
+      return await coerceStoredShellFailureResult(options.context.runDir, storedShellResult) as TResult;
+    }
     const error = record.error ? rehydrateSerializedError(record.error) : new Error("Task failed");
     throw error;
   }
@@ -340,6 +353,60 @@ async function resolveStoredResultValue(runDir: string, stored: StoredTaskResult
   // stdout/stderr for output.  A hard failure here previously caused ~90% of
   // provider-gated E2E runs to fail.
   return null;
+}
+
+async function coerceStoredShellFailureResult(runDir: string, stored: StoredTaskResult): Promise<{
+  success: false;
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  error: string;
+}> {
+  const errorData = isJsonRecord(stored.error?.data) ? stored.error.data : undefined;
+  const stdout = await resolveStoredTextArtifact(runDir, stored.stdoutRef)
+    ?? readStringField(errorData, "stdout")
+    ?? "";
+  const stderr = await resolveStoredTextArtifact(runDir, stored.stderrRef)
+    ?? readStringField(errorData, "stderr")
+    ?? "";
+  const exitCode = readNumberField(errorData, "exitCode") ?? 1;
+  const errorMessage = readStringField(errorData, "error")
+    ?? stored.error?.message
+    ?? `Shell command exited with code ${exitCode}`;
+
+  return {
+    success: false,
+    exitCode,
+    stdout,
+    stderr,
+    error: errorMessage,
+  };
+}
+
+async function resolveStoredTextArtifact(runDir: string, ref?: string): Promise<string | undefined> {
+  if (!ref) {
+    return undefined;
+  }
+  try {
+    const absolute = normalizeRef(runDir, ref);
+    return await fs.readFile(absolute, "utf8");
+  } catch {
+    return undefined;
+  }
+}
+
+function isJsonRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readStringField(value: Record<string, unknown> | undefined, key: string): string | undefined {
+  const candidate = value?.[key];
+  return typeof candidate === "string" ? candidate : undefined;
+}
+
+function readNumberField(value: Record<string, unknown> | undefined, key: string): number | undefined {
+  const candidate = value?.[key];
+  return typeof candidate === "number" && Number.isFinite(candidate) ? candidate : undefined;
 }
 
 function collectInvocationLabels(ctx: TaskBuildContext, taskDef: TaskDef): string[] {


### PR DESCRIPTION
## Summary
- normalize `task:post --status error` for `shell` effects into structured `success: false` shell results so verification loops can inspect non-zero exits
- teach replay to treat already-committed `resolved_error` shell effects as shell failure data instead of throwing and stranding the run in `process-error`
- add targeted CLI and runtime regressions covering shell failures committed through both paths

## Testing
- `npm run test --workspace=@a5c-ai/babysitter-sdk -- src/runtime/__tests__/taskIntrinsic.test.ts -t "returns structured shell failures when a shell effect was committed with status:error"`
- `npm run test --workspace=@a5c-ai/babysitter-sdk -- src/cli/__tests__/cliMain.test.ts -t "normalizes shell task error posts into success:false shell results"`

Closes #132
