### PR TITLE
fix(scripts): validate TAG format before git push in rollback-release.sh

### DIFF
--- a/scripts/rollback-release.sh
+++ b/scripts/rollback-release.sh
@@ -15,6 +15,11 @@ fi
 
 TAG="$1"
 
+if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "error: TAG must match vX.Y.Z format (e.g. v1.2.3), got: ${TAG}" >&2
+  exit 1
+fi
+
 if ! command -v gh >/dev/null 2>&1; then
   echo "error: gh CLI is required for release rollback" >&2
   exit 1


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

`scripts/rollback-release.sh` passes the caller-supplied `$TAG` argument directly into `git push origin ":refs/tags/$TAG"` without validation. A tag value like `HEAD`, a refspec containing `/`, or a string with shell metacharacters could trigger unintended git operations or push unexpected refs to the remote.

## Why it matters

The script is intended exclusively for version tags in `vX.Y.Z` format. Any other value is a usage error that should be caught early, not silently forwarded to `git push`.

## Fix

Added a regex guard immediately after reading `$TAG`:

```bash
if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
  echo "error: TAG must match vX.Y.Z format (e.g. v1.2.3), got: ${TAG}" >&2
  exit 1
fi
```

This fails fast with a clear message before any network operations occur, and matches the documented usage (`vX.Y.Z`) shown in the script's own help text.

## Scope

Single-file, four-line addition. No logic changes to the happy path.