### PR TITLE
fix(hooks): replace npx -y auto-install fallback with graceful no-op

### DIFF
--- a/plugins/babysitter/hooks/babysitter-pre-tool-use-hook.sh
+++ b/plugins/babysitter/hooks/babysitter-pre-tool-use-hook.sh
@@ -4,19 +4,14 @@
 
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 
-# Resolve babysitter CLI: installed binary, user-local prefix, or npx fallback
+# Resolve babysitter CLI: installed binary, user-local prefix, or no-op fallback
 if ! command -v babysitter &>/dev/null; then
   if [ -x "$HOME/.local/bin/babysitter" ]; then
     export PATH="$HOME/.local/bin:$PATH"
   else
-    SDK_VERSION=$(node -e "try{console.log(JSON.parse(require('fs').readFileSync('${PLUGIN_ROOT}/versions.json','utf8')).sdkVersion||'latest')}catch{console.log('latest')}" 2>/dev/null || echo "latest")
-    if [ -n "$SDK_VERSION" ]; then
-      babysitter() { npx -y "@a5c-ai/babysitter-sdk@${SDK_VERSION}" "$@"; }
-      export -f babysitter
-    else
-      # No CLI available — exit 0 (no-op, proceed with original command)
-      exit 0
-    fi
+    # SDK not installed — session-start hook is responsible for installation.
+    # Exit 0 so the tool call proceeds with the original command.
+    exit 0
   fi
 fi
 

--- a/plugins/babysitter/hooks/babysitter-stop-hook.sh
+++ b/plugins/babysitter/hooks/babysitter-stop-hook.sh
@@ -4,21 +4,17 @@
 
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 
-# Resolve babysitter CLI: installed binary, user-local prefix, or npx fallback
+# Resolve babysitter CLI: installed binary, user-local prefix, or no-op fallback
 if ! command -v babysitter &>/dev/null; then
   # Try user-local prefix (set by session-start hook)
   if [ -x "$HOME/.local/bin/babysitter" ]; then
     export PATH="$HOME/.local/bin:$PATH"
   else
-    # Last resort: npx fallback
-    SDK_VERSION=$(node -e "try{console.log(JSON.parse(require('fs').readFileSync('${PLUGIN_ROOT}/versions.json','utf8')).sdkVersion||'latest')}catch{console.log('latest')}" 2>/dev/null || echo "latest")
-    if [ -n "$SDK_VERSION" ]; then
-      babysitter() { npx -y "@a5c-ai/babysitter-sdk@${SDK_VERSION}" "$@"; }
-    else
-      # No CLI available at all — allow exit silently
-      echo '{}'
-      exit 0
-    fi
+    # SDK not installed — session-start hook is responsible for installation.
+    # SDK not installed — session-start hook is responsible for installation.
+    # Exit silently so stop is not blocked.
+    echo '{}'
+    exit 0
   fi
 fi
 LOG_DIR="${BABYSITTER_LOG_DIR:-$PLUGIN_ROOT/.a5c/logs}"

--- a/plugins/babysitter/hooks/babysitter-user-prompt-submit-hook.sh
+++ b/plugins/babysitter/hooks/babysitter-user-prompt-submit-hook.sh
@@ -4,20 +4,15 @@
 
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 
-# Resolve babysitter CLI: installed binary, user-local prefix, or npx fallback
+# Resolve babysitter CLI: installed binary, user-local prefix, or no-op fallback
 if ! command -v babysitter &>/dev/null; then
   if [ -x "$HOME/.local/bin/babysitter" ]; then
     export PATH="$HOME/.local/bin:$PATH"
   else
-    SDK_VERSION=$(node -e "try{console.log(JSON.parse(require('fs').readFileSync('${PLUGIN_ROOT}/versions.json','utf8')).sdkVersion||'latest')}catch{console.log('latest')}" 2>/dev/null || echo "latest")
-    if [ -n "$SDK_VERSION" ]; then
-      babysitter() { npx -y "@a5c-ai/babysitter-sdk@${SDK_VERSION}" "$@"; }
-      export -f babysitter
-    else
-      # No CLI available — pass through unchanged
-      cat
-      exit 0
-    fi
+    # SDK not installed — session-start hook is responsible for installation.
+    # Pass through unchanged so the prompt is not blocked.
+    cat
+    exit 0
   fi
 fi
 


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

Three hook scripts — `babysitter-stop-hook.sh`, `babysitter-pre-tool-use-hook.sh`, and `babysitter-user-prompt-submit-hook.sh` — each contain an `npx -y` fallback that silently downloads and executes the SDK from the npm registry when the babysitter CLI is not found:

```bash
babysitter() { npx -y "@a5c-ai/babysitter-sdk@${SDK_VERSION}" "$@"; }
```

This runs on high-frequency events:
- **pre-tool-use**: fires before every Bash tool call
- **user-prompt-submit**: fires on every user prompt
- **stop**: fires on every session stop

Each unresolved invocation triggers a network fetch and silent auto-execution of an external npm package. The version is pinned via `versions.json`, but the download itself happens without any user confirmation.

## Why it matters

`npx -y` skips the interactive confirmation prompt, meaning the network fetch and package execution happen completely silently during normal Claude Code operation. For hooks that fire frequently, this can cause unexpected latency and represents an unaudited execution surface.

## Fix

Replaced the `npx -y` fallback in the three high-frequency hooks with a graceful no-op. The session-start hook is already the correct place for SDK installation; the other hooks can safely exit cleanly when the CLI is absent:

- **stop hook**: exits `0` with `{}` (allows session to end normally)
- **pre-tool-use hook**: exits `0` (allows the tool call to proceed unchanged)
- **user-prompt-submit hook**: passes stdin through and exits `0` (allows the prompt to proceed unchanged)

The session-start hook (`babysitter-session-start-hook.sh`) is unchanged — it already handles installation correctly with a proper install marker (`MARKER_FILE`) to prevent repeated installs.

## Scope

Three shell scripts, removing ~7 lines each. The happy path (CLI installed) is unaffected.