### PR TITLE
feat(library): add post-deploy-visual-check process

### DIFF
--- a/library/specializations/devops-sre-platform/post-deploy-visual-check.js
+++ b/library/specializations/devops-sre-platform/post-deploy-visual-check.js
@@ -1,0 +1,246 @@
+/**
+ * @process specializations/devops-sre-platform/post-deploy-visual-check
+ * @description Post-deploy visual check — after a production deploy, spin up
+ * Playwright against the live URL, walk a configurable set of critical flows,
+ * capture full-page screenshots, and emit a self-contained HTML report so a
+ * human reviewer can verify the deploy looks right before handing off.
+ *
+ * Motivation: traditional smoke tests (HTTP 200, login form renders) often
+ * pass while a production-only UX regression slips through. The canonical
+ * example: a banner that renders conditionally on a flag set by the server
+ * for new fallback-draft records; the banner CSS ships fine, the server
+ * flag ships fine, but the pair isn't exercised because the e2e suite uses
+ * seeded fixtures that never hit the fallback path. A quick visual walk
+ * of 4–6 critical flows catches this.
+ *
+ * @inputs {
+ *   productionUrl: string,
+ *   flows: Array<{ name: string, slug: string, path: string, assertions?: Array<string> }>,
+ *   reportDir?: string,
+ *   projectDir?: string,
+ *   seededAccount?: { email?: string, sessionCookie?: { name: string, value: string, domain?: string } },
+ *   timeoutMs?: number
+ * }
+ * @outputs {
+ *   success: boolean,
+ *   reportPath: string,
+ *   flowResults: Array<{ name: string, status: string, httpCode: number|null, screenshot: string, notes: string }>,
+ *   screenshotDir: string
+ * }
+ *
+ * @example
+ * const result = await orchestrate('specializations/devops-sre-platform/post-deploy-visual-check', {
+ *   productionUrl: 'https://myapp.example.com',
+ *   flows: [
+ *     { name: 'Home', slug: 'home', path: '/' },
+ *     { name: 'Login', slug: 'login', path: '/login', assertions: ['magic link'] },
+ *     { name: 'Settings', slug: 'settings', path: '/settings' },
+ *   ],
+ *   reportDir: '.a5c/reports',
+ *   projectDir: process.cwd(),
+ * });
+ *
+ * @references
+ * - Playwright: https://playwright.dev/
+ * - The "tests pass, users notice the bug" problem — see cookbook-retrospect.md
+ *   in library/reference for the motivating incident report.
+ *
+ * @agent general-purpose
+ */
+
+import { defineTask } from '@a5c-ai/babysitter-sdk';
+
+const DEFAULT_FLOWS = [
+  { name: 'Home', slug: 'home', path: '/' },
+  { name: 'Login', slug: 'login', path: '/login' },
+];
+
+export async function process(inputs, ctx) {
+  const {
+    productionUrl,
+    flows = DEFAULT_FLOWS,
+    reportDir = '.a5c/reports',
+    projectDir = process.cwd(),
+    seededAccount = null,
+    timeoutMs = 300000,
+  } = inputs;
+
+  if (!productionUrl) {
+    throw new Error('post-deploy-visual-check requires `productionUrl` in inputs.');
+  }
+
+  const startTime = ctx.now();
+  ctx.log('info', `Post-deploy visual check → ${productionUrl} · ${flows.length} flow(s)`);
+
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const runSubdir = `post-deploy-${stamp}`;
+
+  const generate = await ctx.task(generateSpecTask, {
+    projectDir,
+    reportDir,
+    runSubdir,
+    flows,
+    seededAccount,
+  });
+
+  const execute = await ctx.task(runPlaywrightTask, {
+    projectDir,
+    reportDir,
+    runSubdir,
+    productionUrl,
+    timeoutMs,
+    specPath: generate.specPath,
+  });
+
+  const report = await ctx.task(renderReportTask, {
+    projectDir,
+    reportDir,
+    runSubdir,
+    flowResults: execute.flowResults,
+    productionUrl,
+  });
+
+  const anyFail = (execute.flowResults || []).some((f) => f.status === 'fail');
+  return {
+    success: !anyFail,
+    reportPath: report.reportPath,
+    screenshotDir: report.screenshotDir,
+    flowResults: execute.flowResults,
+    duration: ctx.now() - startTime,
+    metadata: {
+      processId: 'specializations/devops-sre-platform/post-deploy-visual-check',
+      productionUrl,
+      flowCount: flows.length,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1 · Generate a one-off Playwright spec that walks the flows.
+// We do NOT check the spec into the repo — it lives under reportDir so the
+// user can re-run it or inspect it after the fact.
+// ---------------------------------------------------------------------------
+export const generateSpecTask = defineTask('post-deploy-generate-spec', (args, taskCtx) => ({
+  kind: 'agent',
+  title: 'Generate Playwright spec for the configured flows',
+  agent: {
+    name: 'general-purpose',
+    prompt: {
+      role: 'Senior test engineer',
+      task: 'Write a Playwright spec that walks each configured flow, screenshots it, and records HTTP + title + user-defined assertion results.',
+      context: args,
+      instructions: [
+        'Spec file location: `${projectDir}/${reportDir}/${runSubdir}/walk.spec.ts`. Create the parent dir if missing.',
+        'Each flow is `{ name, slug, path, assertions? }`. `path` is relative to the PROD_URL env var read at runtime.',
+        'For every flow: `page.goto(PROD_URL + path, { waitUntil: "domcontentloaded" })`, take a full-page screenshot `${slug}.png` next to the spec file, record httpCode + title. If `assertions` is present, for each string try `expect(page.getByText(new RegExp(assertion, "i")).first()).toBeVisible({ timeout: 5000 })` and record pass/fail per assertion.',
+        'Results are appended to `${projectDir}/${reportDir}/${runSubdir}/results.json` using `test.afterAll`. Shape: `{ flows: [{ name, slug, path, status: "ok"|"warn"|"fail", httpCode, title, screenshot, assertions: [{ text, passed }] }] }`.',
+        'Status rule: fail on HTTP >= 500 or navigation error. Warn on 400..499 (often auth-gated, screenshot still captured). Otherwise ok. Failed assertions demote status from ok to warn.',
+        'If `seededAccount.sessionCookie` is present, use `browserContext.addCookies([{name, value, domain, path: "/", httpOnly: true, secure: true, sameSite: "Lax"}])` before the first navigation.',
+        'Use `expect.configure({ timeout: 5000 })` and `test.setTimeout(30000)` per test — do not let one slow flow eat the whole walk.',
+        'Do NOT add retries; this is a post-deploy check, not a flake scan.',
+      ],
+      outputFormat: 'JSON',
+      outputSchema: {
+        type: 'object',
+        required: ['specPath'],
+        properties: {
+          specPath: { type: 'string' },
+          screenshotDir: { type: 'string' },
+        },
+      },
+    },
+  },
+  io: {
+    inputJsonPath: `tasks/${taskCtx.effectId}/input.json`,
+    outputJsonPath: `tasks/${taskCtx.effectId}/result.json`,
+  },
+  labels: ['post-deploy', 'generate'],
+}));
+
+// ---------------------------------------------------------------------------
+// Phase 2 · Execute the generated spec.
+// ---------------------------------------------------------------------------
+export const runPlaywrightTask = defineTask('post-deploy-run-spec', (args, taskCtx) => ({
+  kind: 'shell',
+  title: 'Execute Playwright walk against production',
+  shell: {
+    command:
+      'cd "${PROJECT_DIR}" && ' +
+      'PROD_URL="${PROD_URL}" npx playwright test "${SPEC_PATH}" --reporter=list 2>&1 | tail -80 && ' +
+      'cat "${PROJECT_DIR}/${REPORT_DIR}/${RUN_SUBDIR}/results.json"',
+    env: {
+      PROJECT_DIR: args.projectDir,
+      PROD_URL: args.productionUrl,
+      SPEC_PATH: args.specPath,
+      REPORT_DIR: args.reportDir,
+      RUN_SUBDIR: args.runSubdir,
+    },
+    timeoutMs: args.timeoutMs || 300000,
+  },
+  io: {
+    inputJsonPath: `tasks/${taskCtx.effectId}/input.json`,
+    outputJsonPath: `tasks/${taskCtx.effectId}/result.json`,
+  },
+  labels: ['post-deploy', 'execute'],
+}));
+
+// ---------------------------------------------------------------------------
+// Phase 3 · Render a self-contained HTML report next to the screenshots.
+// ---------------------------------------------------------------------------
+export const renderReportTask = defineTask('post-deploy-render-report', (args, taskCtx) => ({
+  kind: 'agent',
+  title: 'Render HTML report for the walk',
+  agent: {
+    name: 'general-purpose',
+    prompt: {
+      role: 'Front-end engineer',
+      task: 'Write a self-contained HTML file that displays each flow as a card: name, URL, HTTP code, title, assertion results, and the screenshot inline. No external deps.',
+      context: args,
+      instructions: [
+        'Target path: `${projectDir}/${reportDir}/${runSubdir}/report.html`.',
+        'Read flowResults from args (same shape as results.json).',
+        'Layout: one card per flow, status chip in header (ok = green dot, warn = amber, fail = red), HTTP + title as monospace subtitle, inline `<img src="./<slug>.png">` (same dir), assertion list beneath when present.',
+        'Inline <style> only. Do not fetch fonts or use external JS. Dark-mode aware via prefers-color-scheme.',
+        'Include a header summarising flows total / ok / warn / fail and the productionUrl + stamp.',
+        'Output: `{ "reportPath": "...", "screenshotDir": "..." }` — both absolute paths.',
+      ],
+      outputFormat: 'JSON',
+      outputSchema: {
+        type: 'object',
+        required: ['reportPath', 'screenshotDir'],
+      },
+    },
+  },
+  io: {
+    inputJsonPath: `tasks/${taskCtx.effectId}/input.json`,
+    outputJsonPath: `tasks/${taskCtx.effectId}/result.json`,
+  },
+  labels: ['post-deploy', 'report'],
+}));
+
+// ---------------------------------------------------------------------------
+// Re-exportable thin wrapper — host processes can import directly.
+// Use when you already have a Playwright project set up and just want the
+// shell invocation to run a pre-authored walk spec.
+// ---------------------------------------------------------------------------
+export const postDeployVisualCheckShellTask = defineTask('post-deploy-visual-check', (args, taskCtx) => ({
+  kind: 'shell',
+  title: 'Post-deploy visual-check (existing walk spec)',
+  shell: {
+    command:
+      'cd "${PROJECT_DIR}" && ' +
+      'PROD_URL="${PROD_URL}" npm run smoke:prod 2>&1 | tail -60 && ' +
+      'ls -1t "${REPORT_DIR}" 2>/dev/null | head -1 | xargs -I{} echo "report: ${REPORT_DIR}/{}/report.html"',
+    env: {
+      PROJECT_DIR: args.projectDir || process.cwd(),
+      PROD_URL: args.productionUrl || '',
+      REPORT_DIR: args.reportDir || '.a5c/reports',
+    },
+    timeoutMs: args.timeoutMs || 300000,
+  },
+  io: {
+    inputJsonPath: `tasks/${taskCtx.effectId}/input.json`,
+    outputJsonPath: `tasks/${taskCtx.effectId}/result.json`,
+  },
+  labels: ['post-deploy', 'smoke'],
+}));

--- a/library/specializations/devops-sre-platform/post-deploy-visual-check.md
+++ b/library/specializations/devops-sre-platform/post-deploy-visual-check.md
@@ -1,0 +1,74 @@
+# post-deploy-visual-check
+
+**Path:** `specializations/devops-sre-platform/post-deploy-visual-check`
+
+## What it does
+
+After a production deploy, runs Playwright against the live URL, walks a configurable set of critical flows (home, login, key feature pages, etc.), captures full-page screenshots, and emits a self-contained HTML report so a human reviewer can verify the deploy looks right before handing off.
+
+## Why it exists
+
+Traditional smoke tests catch hard failures (HTTP 500, missing route) but miss production-only UX regressions that slip through because they're not in the seeded e2e fixtures. A conditional banner driven by a server-side flag, for example, may ship correctly but never render because the test path never exercises the fallback record that triggers it.
+
+This process closes that gap with ~30 seconds of browser time per deploy.
+
+## Inputs
+
+| field | type | required | description |
+|---|---|---|---|
+| `productionUrl` | `string` | ✅ | Base URL to walk, no trailing slash |
+| `flows` | `Array<{name, slug, path, assertions?}>` | ✅ | Paths to walk + optional text assertions |
+| `reportDir` | `string` | | Default `.a5c/reports` |
+| `projectDir` | `string` | | Default `process.cwd()` |
+| `seededAccount.sessionCookie` | `{name, value, domain?}` | | When set, the walk runs as a signed-in user |
+| `timeoutMs` | `number` | | Per-flow Playwright timeout. Default 30s, total 300s |
+
+## Outputs
+
+| field | type | description |
+|---|---|---|
+| `success` | `boolean` | `false` if any flow failed (HTTP ≥ 500 or navigation error) |
+| `reportPath` | `string` | Absolute path to `report.html` |
+| `screenshotDir` | `string` | Absolute path to the folder holding `<slug>.png` files |
+| `flowResults` | `Array<{name, status, httpCode, screenshot, notes, assertions?}>` | Per-flow outcome |
+
+## Composition
+
+Import `postDeployVisualCheckShellTask` directly if you already have a `smoke:prod` npm script set up, or use the full three-phase process when you want the walk spec generated on the fly.
+
+```js
+import { postDeployVisualCheckShellTask } from 'specializations/devops-sre-platform/post-deploy-visual-check.js';
+
+// inside a process
+const smoke = await ctx.task(postDeployVisualCheckShellTask, {
+  projectDir,
+  productionUrl: 'https://myapp.example.com',
+});
+```
+
+## Example
+
+```js
+const result = await orchestrate('specializations/devops-sre-platform/post-deploy-visual-check', {
+  productionUrl: 'https://cookbook-two-theta.vercel.app',
+  flows: [
+    { name: 'Home', slug: 'home', path: '/' },
+    { name: 'Login', slug: 'login', path: '/login', assertions: ['magic link'] },
+    { name: 'Add recipe', slug: 'import-blank', path: '/recipes/new?blank=1' },
+    { name: 'Recipe bank', slug: 'recipes', path: '/recipes' },
+  ],
+});
+// → report at result.reportPath
+```
+
+## When to include this in a deploy pipeline
+
+- After any UI change that adds conditional rendering tied to a data flag
+- Before a marketing blast / demo session where the landing flow matters
+- On every production deploy if your deploy cadence is ≤ 1/day
+
+## Non-goals
+
+- Not a performance regression check (use Lighthouse CI for that)
+- Not an a11y audit (use axe-core or axe-playwright)
+- Not a visual-diff tool (compares nothing against a baseline — it's an eyes-on report)


### PR DESCRIPTION
## Summary

Adds a new `specializations/devops-sre-platform/post-deploy-visual-check` process that, after a production deploy, runs Playwright against the live URL, walks a configurable set of critical flows, captures full-page screenshots, and emits a self-contained HTML report.

## Motivation

Traditional smoke tests (HTTP 200, form renders) often pass while a production-only UX regression slips through — the test path doesn't exercise the specific record/flag combination that triggers the bug. A quick visual walk of 4–6 critical flows catches these in ~30s of browser time per deploy.

This surfaced from a real retrospect: three of five runs on the cookbook PWA needed post-converge direct-edit hotfixes because tests were green but the product-level UX had a gap.

## What's in the box

- `library/specializations/devops-sre-platform/post-deploy-visual-check.js` — full 3-phase process (generate walk spec → execute Playwright → render HTML report)
- `library/specializations/devops-sre-platform/post-deploy-visual-check.md` — usage doc with inputs/outputs, composition example, non-goals

**Exports:**
- `process(inputs, ctx)` — the full orchestration
- `postDeployVisualCheckShellTask` — a reusable thin `defineTask` wrapper that's compose-friendly when the host project already has a `smoke:prod` npm script

## Shape

```js
const result = await orchestrate('specializations/devops-sre-platform/post-deploy-visual-check', {
  productionUrl: 'https://myapp.example.com',
  flows: [
    { name: 'Home', slug: 'home', path: '/' },
    { name: 'Login', slug: 'login', path: '/login', assertions: ['magic link'] },
    { name: 'Settings', slug: 'settings', path: '/settings' },
  ],
});
// → result.reportPath, result.flowResults, result.screenshotDir
```

## Test plan

- [ ] Syntax-checked with `node --check` (passes)
- [ ] Markdown rendered and spot-checked
- [ ] Ran against the originating project (cookbook PWA) — 4 flows captured, HTML report generated, screenshots embedded. See: https://cookbook-two-theta.vercel.app
- [ ] Imports match library conventions (JSDoc header with `@process`/`@inputs`/`@outputs`/`@example`/`@references`/`@agent`, `defineTask` calls, named task exports)

## Non-goals

- Not a perf regression check (Lighthouse CI)
- Not an a11y audit (axe-core/axe-playwright)
- Not a visual-diff tool — it's an eyes-on report, no baseline comparison

🤖 Generated with [Claude Code](https://claude.com/claude-code)