### PR TITLE
Fix agent-mux user-event test imports

### DIFF
--- a/packages/agent-mux/ui/src/screens/SessionDetailScreen.test.tsx
+++ b/packages/agent-mux/ui/src/screens/SessionDetailScreen.test.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { userEvent } from '@testing-library/user-event';
 
 import { createGatewayStore } from '../store/index.js';
 import { SessionDetailScreen } from './SessionDetailScreen.js';

--- a/packages/agent-mux/webui/src/pages/SessionDetailPage.route.test.tsx
+++ b/packages/agent-mux/webui/src/pages/SessionDetailPage.route.test.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { userEvent } from '@testing-library/user-event';
 
 import { SessionDetailPage } from './SessionDetailPage.js';
 


### PR DESCRIPTION
Summary:
- switch session detail tests to the named userEvent export
- align the test imports with the installed @testing-library/user-event v14 type surface under the workspace TypeScript config

Verification:
- npm run build --workspace=@a5c-ai/agent-mux-ui
- npm run build --workspace=@a5c-ai/agent-mux-webui
