### PR TITLE
contrib(product-management): add skills prd-to-spec and task-to-prd

### DIFF
--- a/library/specializations/product-management/skills/prd-to-spec/SKILL.md
+++ b/library/specializations/product-management/skills/prd-to-spec/SKILL.md
@@ -1,0 +1,311 @@
+---
+name: prd-to-spec
+description: "Convert an approved PRD into a phase-gated implementation SPEC with verification ledger, TDD breakpoints, and quality gates. Stack-agnostic with optional integration hooks."
+author: Yehuda Yungstein
+---
+
+# PRD to SPEC Generator
+
+Convert a PRD into a production-ready, phase-gated SPEC file that an engineer
+(or an orchestrator agent) can execute task-by-task.
+
+This skill is **stack-agnostic**. Every step that integrates with a specific
+tool, tracker, or pipeline framework is wrapped as an **Optional Hook** —
+documented with examples but never required for the skill to function.
+
+## Input
+
+The user provides either:
+
+- A path to a PRD file: `/prd-to-spec <your-tasks-dir>/<task-id>-PRD.md`
+- Inline text describing the task: `/prd-to-spec "description..."`
+
+## Optional Hook Pattern
+
+Throughout this skill, every external-tool integration uses this template:
+
+> **<Capability> (optional):** <one-line description of what this step achieves>.
+> *Examples:* <2-4 concrete examples mixing ecosystems>.
+> *Skip if:* <when this step doesn't apply>.
+
+The skill works end-to-end without any of the optional hooks installed.
+
+## Execution
+
+### Phase 1: Discovery & Verification Ledger
+
+1. Read the PRD (file or inline text).
+2. Read your project's primary context document (e.g., `CLAUDE.md`, `AGENTS.md`,
+   or top-level README) for conventions and onboarding info.
+3. **Smart scope detection** — determine which layers the PRD affects
+   (data-pipeline, backend, frontend, infra, docs). Phases that target
+   irrelevant layers will be skipped in Phase 3.
+4. **Parallel codebase scan** — launch one subagent per affected layer.
+   Each one reads the files mentioned in the PRD and the surrounding code.
+   Examples of layer splits: data-pipeline (SQL/transforms), backend (services,
+   schemas, queues), frontend (components, types, API calls), infra (IaC,
+   deployment configs), docs.
+5. Build a **Verification Ledger** — for every claim in the PRD, verify
+   against actual code with `file:line` references. Note any discrepancies.
+6. **Auto-detect blocking PRs** — check `git log origin/<base-branch>` and
+   `gh pr list` for open PRs touching the same files. If found, note them
+   as dependencies. (`<base-branch>` = your repo's default integration
+   branch — typically `dev`, `develop`, or `main`.)
+7. Inspect your archive of previous SPECs (if you maintain one) for style
+   inspiration only — never as a rigid template. Each task is different.
+8. **Read the project-local `failure-log.md`** — see § Optional: Failure Log
+   Mechanism below. If the file doesn't exist, note "no prior failures
+   recorded" and continue.
+
+### Phase 2: SPEC Generation
+
+Create the SPEC file at `<your-tasks-dir>/<feature-branch>-SPEC.md` with
+these sections:
+
+**Header**
+
+```text
+# SPEC: <Title>
+Source PRD: <path>
+Tracker Task: <link, if applicable>
+Branch: <feature-branch> (from latest <base-branch>)
+Quality Gate: Each phase must reach quality score >= 0.85 before proceeding
+```
+
+**Prerequisites:** files to read before execution. **MUST include** the
+project-local `failure-log.md` (see § Optional: Failure Log Mechanism) with
+the note "every pattern there is a binding constraint from prior failures".
+
+**Known Divergences** *(if applicable)* — document intentional differences
+between related files or components.
+
+**Verification Ledger** — table of PRD claims vs. actual code findings.
+
+**Phase 1: Pre-Check**
+- **First step MUST be:** read the project-local `failure-log.md` and
+  internalize all patterns as binding constraints (not suggestions).
+  Add this as the literal first numbered step AND as the first Quality
+  Gate checkbox.
+- Branch from `<base-branch>`; verify any blocking PRs are merged.
+- Read project conventions document.
+- **Ticket-tracker integration (optional):** mark the task as in-progress
+  in your tracker.
+  *Examples:* Jira (`/jira` skill or `acli jira workitem update`), Linear
+  (`linear-cli` or MCP), GitHub Issues (`gh issue edit ... --add-label
+  in-progress`).
+  *Skip if:* you don't track tasks in an external system.
+- Quality Gate checklist (first item: "failure-log.md read and patterns
+  internalized").
+
+**Phase 2: Execute (TDD)**
+- For EVERY sub-task: write the failing test FIRST (RED) → implement
+  minimally (GREEN) → refactor (IMPROVE).
+- Sub-tasks list: exact file paths, line numbers, current code, target code.
+- Edge case matrix with expected results.
+- Quality Gate checklist.
+
+**Phase 3: Local Pipeline Verification & Data Quality**
+- Run the project's full test suite.
+  *Examples:* `pytest tests/ -v` (Python), `npm test` / `vitest` / `jest`
+  (JS/TS), `go test ./...` (Go), `cargo test` (Rust).
+- **If a data pipeline / backend layer changed — Pipeline Verification
+  BREAKPOINT (skip if not applicable):**
+  - Materialize / run affected pipeline assets locally; verify no errors.
+  - Run data-quality spot-check queries on materialized results.
+  - Verify downstream consumers (snapshots, write-backs, exports) succeed.
+  - If anything fails or hangs: guide the user step by step through
+    diagnosis. Do NOT silently skip or assume it works.
+  - **WAIT for user confirmation** that pipeline results look correct
+    before proceeding.
+  - *Examples:* `dagster asset materialize ...` (Dagster),
+    `airflow tasks test ...` (Airflow), `dbt run --select ...` (dbt),
+    `prefect deployment run ...` (Prefect),
+    `kubectl apply --dry-run=server ...` (K8s previews).
+- **If a UI layer changed — UI Verification BREAKPOINT (skip if not
+  applicable):**
+  - Start the project's dev server(s).
+    *Examples:* `npm run dev`, Vite (`vite`), Next (`next dev`),
+    Storybook (`storybook dev`).
+  - Seed test data if needed (DB fixtures, mock APIs, recorded responses).
+  - Present to user: URL, login credentials (if any), navigation steps,
+    what to look for.
+  - **WAIT for user confirmation** before proceeding.
+- **If neither applies:** skip to Phase 4.
+- Quality Gate checklist (includes "User confirmed pipeline results"
+  and/or "User confirmed UI" as applicable).
+
+**Phase 4: Conventions Fix**
+- **Project conventions check (optional):** run a project-specific
+  conventions check.
+  *Examples:* a custom `/conventions-check` skill, project-specific lint
+  rules, a pre-commit hook config.
+  *Skip if:* your project has no extra conventions beyond standard
+  linters/formatters.
+- Run the project's linter, formatter, and type checker — on changed
+  files only.
+  *Examples:*
+  - TypeScript: `eslint`, `prettier`, `tsc-files --noEmit`
+  - Python: `ruff`, `black`, `mypy`
+  - Go: `golangci-lint`, `gofmt`, `go vet`
+  - Ruby: `rubocop`, `standardrb`
+- Quality Gate checklist.
+
+**Phase 5: Completeness (Hard Gate)**
+- Verify every Definition-of-Done item with `file:line` evidence.
+- YES/NO gate questions — any NO blocks delivery.
+- **DoD verification (optional):** run a structured Definition-of-Done
+  verification step.
+  *Examples:* a `/verification-before-completion` skill, a manual
+  checklist walkthrough, a pre-merge bot.
+- Quality Gate checklist.
+
+**Phase 6: Code Review**
+- **Step 1 — Primary code review (mandatory):** run a thorough
+  quality + correctness review on the diff. Fix CRITICAL and HIGH
+  findings before continuing.
+- **Step 2 — Independent secondary review (optional but recommended):**
+  at least one reviewer that doesn't share context with Step 1.
+  *Examples:* Codex CLI (`/codex:review --wait` or equivalent), Gemini
+  (`/gemini-review`), GitHub Copilot review, peer review from a teammate.
+- **Step 3 — Project-conventions review (optional):** check the diff
+  against project-specific conventions.
+  *Examples:* a `/requesting-code-review` skill, a CODEOWNERS reviewer,
+  a custom convention bot.
+- Re-run tests after every fix.
+- Quality Gate checklist.
+
+**Phase 7: Deliver**
+- **BREAKPOINT** — present summary, WAIT for user approval.
+- **Pre-Push Personal Docs Check (mandatory gate before any push)** —
+  see § Pre-Push Personal Docs Check below for the full procedure.
+  Quality Gate must include "Pre-Push Personal Docs Check executed and
+  resolved with explicit per-file decisions".
+- **Update project status (optional):** update your status / changelog
+  file if you maintain one.
+- Commit, push, open PR against `<base-branch>`.
+- **Ticket-tracker update (optional):** mark the task as in-review and
+  add the PR link.
+  *Examples:* Jira (`/jira` skill or `acli`), Linear (CLI / MCP),
+  GitHub Issues (`gh issue edit`).
+- Do NOT move the PRD/SPEC to an archive folder until the PR is merged.
+- Rollback plan and post-deploy monitoring notes.
+- Quality Gate checklist.
+
+**Execution Constraints:** scope boundary, exhaustive file list,
+what does NOT change.
+
+### Phase 3 (Outer): Self-Verification
+
+After generating the SPEC:
+
+1. Self-review: check for internal contradictions, missing edge cases,
+   wrong line numbers, unfilled placeholders.
+2. **Plan-quality verifier (optional):** run an external/independent
+   verifier on the SPEC.
+   *Examples:* a `deep-verify-plan` skill, a `verify-plan` skill,
+   `/codex:review` on the SPEC file, a peer SPEC review.
+3. Fix any issues found.
+4. **BREAKPOINT** — present the SPEC to user for approval.
+
+### Phase 4 (Outer): Generate Execution Prompt
+
+After user approves the SPEC, output a short execution prompt in chat
+(NOT a file):
+
+```text
+Read <project-context-doc> for context. Then execute the SPEC at
+<path-to-SPEC>. Execute phase-by-phase, ensuring each phase reaches
+quality score >= 0.85 before proceeding.
+```
+
+The execution can be manual (engineer reads the SPEC and works through
+phases) or via an orchestrator agent.
+
+> **Orchestrator (optional):** automate phase-by-phase execution with
+> a runtime that respects breakpoints and quality gates.
+> *Examples:* a babysitter run, a claude-flow workflow, an autoclaude
+> session, a custom shell loop.
+> *Skip if:* you prefer manual execution.
+
+## Optional: Failure Log Mechanism
+
+The SPEC requires reading a project-local `failure-log.md` before each run.
+This file accumulates lessons learned from prior failed runs of the SPEC
+pipeline, so each new execution inherits patterns to avoid.
+
+### Setup (one-time)
+
+Create the file in either:
+
+- `~/.claude/skills/<your-namespace>/failure-log.md` — for cross-project
+  lessons that follow you everywhere.
+- `<repo-root>/.claude/failure-log.md` — for project-specific lessons that
+  travel with the repo.
+
+### Format
+
+A single markdown file. Each entry follows this template:
+
+```markdown
+### [YYYY-MM-DD] <short-pattern-name>
+
+**Context:** <what we tried to do>
+**What went wrong:** <the failure mode in 1-2 sentences>
+**Constraint going forward:** <the binding rule for future runs>
+```
+
+### When to write to it
+
+After any phase failure, code-review escalation, or production rollback —
+add an entry. The next SPEC run will read it as part of Phase 1 and treat
+each pattern as a binding constraint, not a suggestion.
+
+### When to read it
+
+Phase 1 of every SPEC execution. The first numbered step in Phase 1 must be:
+"Read `failure-log.md` and internalize all patterns as binding constraints."
+If the file doesn't exist yet, that's fine — skip and note "no prior
+failures recorded."
+
+## Pre-Push Personal Docs Check
+
+Personal/working documents often slip into commits — this gate catches them.
+
+**Procedure:**
+
+1. **List candidates** — run `git diff --name-only origin/<base-branch>...HEAD`
+   to see every file changing in the push.
+
+2. **Classify each file** as one of:
+   - `legitimate` — real product change, ship it.
+   - `personal-doc` — working note, scratch file, AI-generated planning
+     artifact.
+   - `ambiguous` — unclear, requires human judgment.
+
+3. **Common personal-doc patterns** (block by default):
+   - `SPEC*.md`, `PRD*.md`, `HANDOFF*.md`, `SUMMARY*.md`, `*-NOTES.md`
+   - Anything under `docs/plans/`, `ai_docs/`, `.claude/scratch/`, `tmp/`
+   - Files named like `investigation-*`, `analysis-*`, `playbook-*`
+   - AI-generated plans/specs not explicitly approved for shipping
+
+4. **Block-and-ask gate** — present blocked files to the user. For each
+   one, require an explicit decision:
+   - `unstage` — remove from this push (`git reset HEAD <file>`).
+   - `keep` — yes, intentionally part of the change.
+   - `gitignore` — add to `.gitignore` and unstage.
+
+   Do NOT skip this step even if the user is in a hurry. The cost of one
+   leaked working doc is much higher than the 30 seconds of friction.
+
+5. After all blocked files are resolved, proceed with the push.
+
+## Rules
+
+- The SPEC must be proportional to the task. A 1-line change gets a concise
+  SPEC. A multi-layer refactor gets a detailed one.
+- Every phase MUST have a Quality Gate checklist.
+- Previous SPECs are inspiration, not templates. Adapt to the task.
+- All clarification questions to the user follow this format: short
+  explanation of what's unclear + why it matters + recommendation +
+  2-4 options.
+- Do NOT implement anything. This skill only produces the SPEC file.

--- a/library/specializations/product-management/skills/task-to-prd/SKILL.md
+++ b/library/specializations/product-management/skills/task-to-prd/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: task-to-prd
+description: "Convert a raw task (tracker ticket, email, or text) into a fully characterized PRD via Five Whys + interactive clarification + adversarial review. Stack-agnostic with optional integration hooks."
+author: Yehuda Yungstein
+---
+
+# Task to PRD Generator
+
+Convert an unrefined task into a production-ready PRD through interactive
+clarification, automated codebase verification, and user-gated refinement.
+
+This skill is **stack-agnostic**. Tracker integrations, code-review tools,
+and external verifiers are all wrapped as **Optional Hooks** — the skill
+works end-to-end without any of them.
+
+The output is a PRD file ready to be consumed by `/prd-to-spec`.
+
+## Input Sources
+
+Accept one of:
+
+- **Tracker ticket ID:** `/task-to-prd <ticket-id>` — fetched via your
+  tracker integration (see Optional Hook in Phase 1).
+  *Examples:* `JIRA-1234`, `LIN-456`, `gh-issue-789`.
+- **Text description:** `/task-to-prd "Change the dashboard donut to show
+  lessons instead of points"`
+- **File path:** `/task-to-prd path/to/email.txt`
+
+## Optional Hook Pattern
+
+Every external-tool integration follows this template:
+
+> **<Capability> (optional):** <one-line description of what this step achieves>.
+> *Examples:* <2-4 concrete examples mixing ecosystems>.
+> *Skip if:* <when this step doesn't apply>.
+
+## Execution
+
+### Phase 1: Clarification (Interactive)
+
+1. **Load source:**
+   - If input is a tracker ticket ID → fetch summary, description, and
+     comments via your tracker integration (see Optional Hook below).
+   - If input is a file path → read the file.
+   - If input is inline text → use as-is.
+
+   > **Tracker fetch (optional):** retrieve the ticket's full content
+   > (summary, description, comments, linked issues) without creating
+   > a new ticket.
+   > *Examples:* Jira via a `/jira` skill or `acli jira workitem view`,
+   > Linear via `linear-cli` or MCP, GitHub Issues via `gh issue view`.
+   > *Skip if:* input is plain text or a local file.
+
+2. **Read project context:**
+   - Your project's primary context document (e.g., `CLAUDE.md`,
+     `AGENTS.md`, top-level README).
+   - Your archive of previous PRDs (if maintained) for style inspiration —
+     never as a rigid template.
+
+3. **Five Whys** — dig into the root cause before jumping to a solution:
+   - Why is this a problem?
+   - Why does it happen?
+   - Why was it not caught earlier?
+   - Why does the current design allow it?
+   - Why is the proposed solution the right one (if one was proposed)?
+
+4. **Interactive clarification** — ask questions one at a time using your
+   harness's interactive Q&A mechanism (e.g., `AskUserQuestion`):
+   - Each question follows this format: short explanation of what's
+     unclear + why it matters + recommendation + 2-4 options.
+   - The user may answer directly OR say "I'll ask <stakeholder>" — then
+     wait; the user will paste the answer back.
+   - Track every Q&A in a running **Decision Log** with attribution.
+
+5. **Scope detection** — identify which layers the task affects
+   (data-pipeline, backend, frontend, infra, docs).
+
+6. **BREAKPOINT — Scope Lock:** before writing anything, present:
+   - Summary of the problem.
+   - Proposed scope (files, layers).
+   - Known constraints.
+   - Decision Log so far.
+
+   **Wait for explicit user approval** before proceeding to Phase 2.
+
+### Phase 2: PRD Draft (Automatic)
+
+1. **Parallel codebase scan** — launch one subagent per affected layer.
+   Each one reads the files relevant to the locked scope and reports back.
+   *Example layer splits:* data-pipeline, backend, frontend, infra.
+
+2. **Draft PRD** at `<your-tasks-dir>/<feature-branch>-PRD.md` with
+   these sections:
+   - Background (including Five Whys findings)
+   - Root Cause
+   - Agreed Solution
+   - Scope (exhaustive file list by layer)
+   - Edge Cases
+   - Technical Constraints
+   - Data Flow (if applicable)
+   - **Decision Log** — every Q&A from Phase 1 with attribution
+     (user / `<stakeholder name>` such as product owner, tech lead,
+     designer)
+   - Definition of Done
+   - Open Questions (if any remain)
+
+### Phase 3: Automated Verification (with User Gates)
+
+Run these checks in order. **ANY proposed change to the PRD requires a
+BREAKPOINT** with user approval showing: old text, new text, reason,
+recommendation.
+
+1. **"What could go wrong" analysis** — examine:
+   - Downstream consumers affected.
+   - Hidden dependencies.
+   - Edge cases not covered.
+   - Rollback complexity.
+
+2. **Codebase consistency check** — verify PRD claims against actual code
+   (file paths, line numbers, identifiers, signatures, etc.).
+
+3. **Conventions check** — verify against your project's conventions
+   document (e.g., `CLAUDE.md`, `CONTRIBUTING.md`, project style guide).
+
+4. **Adversarial review** — one subagent tries to find flaws in the
+   proposed solution; another defends or refines.
+
+5. **Quality checklist** — auto-generate a quality checklist for the PRD
+   (completeness, clarity, testability, consistency) and validate.
+
+6. **Independent external PRD reviewer (optional):** run an external
+   reviewer that hasn't seen the drafting context.
+   *Examples:* Codex CLI (`/codex:review --wait` or equivalent), Gemini
+   (`/gemini-review`), peer review from a teammate.
+   *Skip if:* you don't have a secondary reviewer available.
+
+7. For EVERY finding that suggests a change:
+   - **BREAKPOINT** showing: finding, current PRD text, proposed change,
+     recommendation.
+   - Wait for user approval (approve / reject / modify).
+   - Apply only approved changes.
+
+### Phase 4: Finalize
+
+1. **BREAKPOINT — Final PRD Review:** present the complete PRD to the
+   user for final approval.
+
+2. After approval:
+   - **Tracker update (optional):** if input was a tracker ticket,
+     update its description with a reference to the PRD file path.
+     If input was text/file and no ticket exists, ask whether to create
+     one.
+     *Examples:* Jira (`/jira` or `acli`), Linear (CLI / MCP),
+     GitHub Issues (`gh issue edit` / `gh issue create`).
+     *Skip if:* you don't track tasks in an external system.
+   - **Project status update (optional):** append a "PRD created" entry
+     to your status / changelog file if you maintain one.
+
+3. **Output in chat** (NOT a file) — a short follow-up prompt to convert
+   the PRD into a SPEC:
+
+   ```text
+   Read <project-context-doc> for context. Then run /prd-to-spec <path-to-PRD>
+   ```
+
+## Rules
+
+- Phase 1 and Phase 4 are 100% under user control (interactive).
+- Phase 2 is fully automatic (no questions).
+- Phase 3 is automatic BUT pauses on every proposed change.
+- All clarification questions follow the format: short explanation +
+  why it matters + recommendation + 2-4 options.
+- Never modify the PRD silently — every change needs user approval.
+- Do NOT create a SPEC. That's `/prd-to-spec`.
+- Do NOT move the PRD to an archive folder until the PR for it is merged.
+- The PRD must be proportional to the task. A 1-line fix gets a concise
+  PRD; a multi-layer feature gets a detailed one.
+- Previous PRDs are inspiration, not templates.


### PR DESCRIPTION
## Library Contribution

**Type:** skill (×2, paired)
**Names:** `prd-to-spec`, `task-to-prd`
**Specialization:** product-management
**Location:** `library/specializations/product-management/skills/{prd-to-spec,task-to-prd}/SKILL.md`

## What's included

Two paired Claude Code skills for the PRD → SPEC → execute pipeline:

- **`task-to-prd`** — converts a raw task (tracker ticket / email / text) into a fully characterized PRD via Five Whys + interactive clarification + adversarial review. Pauses on every proposed change with explicit user gates.
- **`prd-to-spec`** — converts an approved PRD into a phase-gated implementation SPEC with verification ledger, TDD breakpoints, code-review gates, and quality gates per phase. Includes a self-contained Failure Log mechanism and a Pre-Push Personal Docs Check.

## How they fit alongside `prd-generator`

The existing `product-management/skills/prd-generator` skill is template-driven and focused on PRD authoring from structured inputs (templates, executive summaries, success metrics). The two skills in this PR are complementary:

- `task-to-prd` is **interview-driven** — handles the upstream "I have a vague request, turn it into a PRD" case via Five Whys + interactive clarification.
- `prd-to-spec` is **downstream** — turns an approved PRD into an executable, phase-gated SPEC.

Together they form a pipeline: `raw task → task-to-prd → PRD → prd-to-spec → SPEC → execute`. Users who already have a structured input flow can keep using `prd-generator`; users who start from a raw / fuzzy task can use `task-to-prd`.

## Design choices

- **Optional Hooks pattern:** every external-tool reference (ticket trackers, code reviewers, pipeline runners, orchestrators) is wrapped as a documented extension point with examples (Jira / Linear / GitHub Issues; Codex / Gemini / peer; Dagster / Airflow / dbt / Prefect; babysitter / claude-flow / autoclaude). No silent dependencies — both skills work end-to-end without any companion tools installed.
- **English-only clarifications** — short explanation + why it matters + recommendation + 2-4 options, every time.
- **Concrete cross-stack examples** — generic instructions paired with examples from multiple ecosystems so users immediately see how to adapt to their stack.
- **Inlined mechanisms** — the Failure Log and Pre-Push Docs Check are written into the SPEC skill itself rather than referenced as external dependencies, keeping each skill self-contained.

## Validation Results

- ✅ Frontmatter valid (`name`, `description`, `author`)
- ✅ kebab-case naming for skill directories
- ✅ Self-review pass: no project-specific leakage, no personal info beyond `author:` field
- ✅ Stack-agnostic — verified by cross-stack Examples in every Optional Hook

## Files Added

- `library/specializations/product-management/skills/prd-to-spec/SKILL.md` (311 lines)
- `library/specializations/product-management/skills/task-to-prd/SKILL.md` (178 lines)

Also published in parallel to a community skills repo: deedeeharris/claude-skills#3 (so the same skills are reachable via that distribution path too).

Happy to adjust if there's a different specialization or structure preference. First library contribution — let me know if I missed anything!