### PR TITLE
contrib(product-management): add processes prd-to-spec and task-to-prd

### DIFF
--- a/library/specializations/product-management/prd-to-spec.js
+++ b/library/specializations/product-management/prd-to-spec.js
@@ -1,0 +1,324 @@
+/**
+ * @process product-management/prd-to-spec
+ * @description Orchestrate conversion of an approved PRD into a phase-gated implementation SPEC. Stack-agnostic. Wraps the prd-to-spec skill with verification, self-review, and an execution-prompt output.
+ * @skill prd-to-spec library/specializations/product-management/skills/prd-to-spec/SKILL.md
+ * @inputs { prdPath: string, featureBranch: string, baseBranch?: string, contextDoc?: string, archiveDir?: string, failureLogPath?: string, secondaryReviewer?: string, requireApproval?: boolean }
+ * @outputs { success: boolean, specPath: string, executionPrompt: string, summary: string }
+ *
+ * Phases:
+ * 1. Discovery & Verification Ledger - read PRD + project context, scan affected layers, build ledger
+ * 2. SPEC Generation - invoke the prd-to-spec skill to produce the SPEC file
+ * 3. Self-Verification - internal review + optional secondary reviewer + user approval breakpoint
+ * 4. Execution Prompt - emit the short prompt that drives downstream execution
+ */
+
+import { defineTask } from '@a5c-ai/babysitter-sdk';
+
+export async function process(inputs, ctx) {
+  const {
+    prdPath,
+    featureBranch,
+    baseBranch = 'main',
+    contextDoc = 'CLAUDE.md',
+    archiveDir = '',
+    failureLogPath = '',
+    secondaryReviewer = null,
+    requireApproval = true
+  } = inputs;
+
+  if (!prdPath) {
+    return { success: false, reason: 'Missing required input: prdPath' };
+  }
+  if (!featureBranch) {
+    return { success: false, reason: 'Missing required input: featureBranch' };
+  }
+
+  ctx.log('info', `Starting prd-to-spec pipeline for PRD: ${prdPath}`);
+
+  // ============================================================================
+  // PHASE 1: DISCOVERY & VERIFICATION LEDGER
+  // ============================================================================
+
+  ctx.log('info', 'Phase 1: Discovery & Verification Ledger');
+
+  const discovery = await ctx.task(discoveryTask, {
+    prdPath,
+    contextDoc,
+    baseBranch,
+    archiveDir,
+    failureLogPath
+  });
+
+  // ============================================================================
+  // PHASE 2: SPEC GENERATION (delegates to prd-to-spec skill)
+  // ============================================================================
+
+  ctx.log('info', 'Phase 2: SPEC generation via prd-to-spec skill');
+
+  const specResult = await ctx.task(generateSpecTask, {
+    prdPath,
+    featureBranch,
+    baseBranch,
+    contextDoc,
+    discovery
+  });
+
+  if (!specResult.specPath) {
+    return { success: false, reason: 'SPEC generation produced no output path', discovery };
+  }
+
+  // ============================================================================
+  // PHASE 3: SELF-VERIFICATION
+  // ============================================================================
+
+  ctx.log('info', 'Phase 3: Self-verification');
+
+  const selfReview = await ctx.task(selfReviewTask, {
+    specPath: specResult.specPath
+  });
+
+  let secondaryReview = null;
+  if (secondaryReviewer) {
+    ctx.log('info', `Phase 3b: Secondary review via ${secondaryReviewer}`);
+    secondaryReview = await ctx.task(secondaryReviewTask, {
+      specPath: specResult.specPath,
+      reviewerHint: secondaryReviewer
+    });
+  }
+
+  if (requireApproval) {
+    const approval = await ctx.breakpoint({
+      question: [
+        `SPEC ready at \`${specResult.specPath}\`.`,
+        '',
+        `**Self-review:** ${selfReview.issuesFound} issue(s) found, ${selfReview.issuesFixed} fixed.`,
+        secondaryReview
+          ? `**Secondary review (${secondaryReviewer}):** ${secondaryReview.summary}`
+          : '**Secondary review:** skipped (no reviewer configured)',
+        '',
+        'Approve to emit the execution prompt, or reject to revise.'
+      ].join('\n'),
+      title: 'SPEC Approval',
+      context: { runId: ctx.runId }
+    });
+    if (!approval.approved) {
+      return {
+        success: false,
+        reason: 'User rejected at SPEC approval gate',
+        feedback: approval.response || approval.feedback,
+        specPath: specResult.specPath,
+        selfReview,
+        secondaryReview
+      };
+    }
+  }
+
+  // ============================================================================
+  // PHASE 4: EXECUTION PROMPT
+  // ============================================================================
+
+  ctx.log('info', 'Phase 4: Generating execution prompt');
+
+  const promptResult = await ctx.task(executionPromptTask, {
+    specPath: specResult.specPath,
+    contextDoc
+  });
+
+  return {
+    success: true,
+    specPath: specResult.specPath,
+    executionPrompt: promptResult.prompt,
+    summary: `SPEC generated at ${specResult.specPath}. Execution prompt emitted.`,
+    artifacts: [
+      { type: 'spec', path: specResult.specPath },
+      { type: 'verification-ledger', content: discovery.verificationLedger }
+    ],
+    metadata: {
+      processId: 'product-management/prd-to-spec',
+      timestamp: ctx.now(),
+      featureBranch,
+      baseBranch
+    }
+  };
+}
+
+// ============================================================================
+// TASK DEFINITIONS
+// ============================================================================
+
+export const discoveryTask = defineTask('discovery', (args, taskCtx) => ({
+  kind: 'agent',
+  title: 'Discovery & Verification Ledger',
+  agent: {
+    name: 'general-purpose',
+    prompt: {
+      role: 'Technical analyst performing PRD discovery against the codebase',
+      task: `Read the PRD and project context, then build a Verification Ledger that maps every PRD claim to actual code with file:line evidence.`,
+      context: {
+        prdPath: args.prdPath,
+        contextDoc: args.contextDoc,
+        baseBranch: args.baseBranch,
+        archiveDir: args.archiveDir,
+        failureLogPath: args.failureLogPath
+      },
+      instructions: [
+        `Read the PRD at: ${args.prdPath}`,
+        `Read the project context document at: ${args.contextDoc}`,
+        'Determine which layers the PRD affects (data-pipeline, backend, frontend, infra, docs)',
+        'Launch parallel subagents — one per affected layer — to verify PRD claims against the codebase',
+        'Build a Verification Ledger as a markdown table: | PRD claim | Verified? | Actual finding (file:line) |',
+        `Detect blocking PRs: run \`git log origin/${args.baseBranch}\` and \`gh pr list\` to find open PRs touching the same files`,
+        args.archiveDir
+          ? `Inspect previous SPECs in ${args.archiveDir} for style inspiration only — never as a rigid template`
+          : 'No archive directory configured — skip previous-SPEC inspection',
+        args.failureLogPath
+          ? `Read ${args.failureLogPath} and surface every pattern as a binding constraint for downstream phases`
+          : 'No failure-log path configured — note "no prior failures recorded" and continue'
+      ],
+      outputFormat: 'JSON with keys: scope (array of strings), verificationLedger (markdown), blockingPRs (array), priorFailures (array)'
+    },
+    outputSchema: {
+      type: 'object',
+      required: ['scope', 'verificationLedger'],
+      properties: {
+        scope: { type: 'array', items: { type: 'string' } },
+        verificationLedger: { type: 'string' },
+        blockingPRs: { type: 'array' },
+        priorFailures: { type: 'array' }
+      }
+    }
+  },
+  io: { inputJsonPath: `tasks/${taskCtx.effectId}/input.json`, outputJsonPath: `tasks/${taskCtx.effectId}/result.json` },
+  labels: ['agent', 'phase-1', 'discovery']
+}));
+
+export const generateSpecTask = defineTask('generate-spec', (args, taskCtx) => ({
+  kind: 'agent',
+  title: 'Generate SPEC by invoking the prd-to-spec skill',
+  agent: {
+    name: 'general-purpose',
+    prompt: {
+      role: 'SPEC generator wrapping the prd-to-spec Claude Code skill',
+      task: 'Invoke the prd-to-spec skill (via the Skill tool) to produce a phase-gated SPEC file from the PRD and discovery results. Return the SPEC file path.',
+      context: {
+        prdPath: args.prdPath,
+        featureBranch: args.featureBranch,
+        baseBranch: args.baseBranch,
+        contextDoc: args.contextDoc,
+        discovery: args.discovery
+      },
+      instructions: [
+        `Invoke the prd-to-spec skill with input: ${args.prdPath}`,
+        'The skill follows its own internal phases: Pre-Check, Execute (TDD), Pipeline/UI Verification, Conventions Fix, Completeness, Code Review, Deliver',
+        `Pass through: featureBranch=${args.featureBranch}, baseBranch=${args.baseBranch}, contextDoc=${args.contextDoc}`,
+        'Pass through the discovery results (Verification Ledger, scope, blocking PRs, prior failures) as Phase 1 inputs',
+        'After the skill produces the SPEC, return the absolute path to the SPEC file',
+        'If the skill encounters a hard error, report it back; do not silently continue'
+      ],
+      outputFormat: 'JSON with keys: specPath (string), generatedSections (array of strings)'
+    },
+    outputSchema: {
+      type: 'object',
+      required: ['specPath'],
+      properties: {
+        specPath: { type: 'string' },
+        generatedSections: { type: 'array', items: { type: 'string' } }
+      }
+    }
+  },
+  io: { inputJsonPath: `tasks/${taskCtx.effectId}/input.json`, outputJsonPath: `tasks/${taskCtx.effectId}/result.json` },
+  labels: ['agent', 'phase-2', 'spec-generation', 'invokes-skill']
+}));
+
+export const selfReviewTask = defineTask('self-review', (args, taskCtx) => ({
+  kind: 'agent',
+  title: 'Self-review the generated SPEC',
+  agent: {
+    name: 'general-purpose',
+    prompt: {
+      role: 'QA reviewer auditing a freshly generated SPEC',
+      task: `Read the SPEC at ${args.specPath} and audit it for internal contradictions, missing edge cases, wrong file:line references, and unfilled placeholders. Fix issues directly in the file.`,
+      context: { specPath: args.specPath },
+      instructions: [
+        'Read the entire SPEC end-to-end',
+        'Verify every file:line reference resolves in the codebase',
+        'Verify edge cases are exhaustive given the PRD scope',
+        'Verify each phase has a Quality Gate checklist',
+        'Check that placeholders like <feature-branch>, <task-id>, <base-branch> are filled in',
+        'Fix any issues found directly by editing the SPEC file',
+        'Report what was found and what was fixed'
+      ],
+      outputFormat: 'JSON with keys: issuesFound (number), issuesFixed (number), unfixedIssues (array of strings)'
+    },
+    outputSchema: {
+      type: 'object',
+      required: ['issuesFound', 'issuesFixed'],
+      properties: {
+        issuesFound: { type: 'number' },
+        issuesFixed: { type: 'number' },
+        unfixedIssues: { type: 'array', items: { type: 'string' } }
+      }
+    }
+  },
+  io: { inputJsonPath: `tasks/${taskCtx.effectId}/input.json`, outputJsonPath: `tasks/${taskCtx.effectId}/result.json` },
+  labels: ['agent', 'phase-3', 'self-review']
+}));
+
+export const secondaryReviewTask = defineTask('secondary-review', (args, taskCtx) => ({
+  kind: 'agent',
+  title: 'Secondary review (optional, configurable reviewer)',
+  agent: {
+    name: 'general-purpose',
+    prompt: {
+      role: 'Independent reviewer running a configurable secondary review of the SPEC',
+      task: `Run the secondary reviewer "${args.reviewerHint}" against the SPEC at ${args.specPath} and summarize findings.`,
+      context: { specPath: args.specPath, reviewerHint: args.reviewerHint },
+      instructions: [
+        `Reviewer hint: "${args.reviewerHint}". Map this to an available reviewer in your environment.`,
+        'Examples: "codex" → Codex CLI review skill (e.g., /codex:review), "gemini" → Gemini review skill (e.g., /gemini-review), "deep-verify-plan" → /deep-verify-plan skill, "peer" → notify a human reviewer and wait for response',
+        'If the named reviewer is not available, report that as `unavailable: true` and skip — do not silently substitute',
+        `Run the reviewer against ${args.specPath} and report findings`,
+        'Surface CRITICAL/HIGH findings clearly; group MEDIUM/LOW findings'
+      ],
+      outputFormat: 'JSON with keys: summary (string), findings (array of {severity, message}), unavailable (boolean)'
+    },
+    outputSchema: {
+      type: 'object',
+      required: ['summary'],
+      properties: {
+        summary: { type: 'string' },
+        findings: { type: 'array', items: { type: 'object' } },
+        unavailable: { type: 'boolean' }
+      }
+    }
+  },
+  io: { inputJsonPath: `tasks/${taskCtx.effectId}/input.json`, outputJsonPath: `tasks/${taskCtx.effectId}/result.json` },
+  labels: ['agent', 'phase-3', 'secondary-review', 'optional']
+}));
+
+export const executionPromptTask = defineTask('execution-prompt', (args, taskCtx) => ({
+  kind: 'agent',
+  title: 'Generate execution prompt',
+  agent: {
+    name: 'general-purpose',
+    prompt: {
+      role: 'Prompt generator emitting a short execution prompt',
+      task: 'Output a 3-4 line execution prompt to be returned in chat — not written as a file.',
+      context: { specPath: args.specPath, contextDoc: args.contextDoc },
+      instructions: [
+        `The prompt MUST reference: project context document (${args.contextDoc}), the SPEC path (${args.specPath}), and an instruction to execute phase-by-phase with quality score >= 0.85 per phase`,
+        'Keep it short — 3-4 lines maximum',
+        'The downstream executor can be manual or an orchestrator (babysitter, claude-flow, autoclaude). Mention "manual or orchestrator" without prescribing one',
+        'Output as plain text suitable for direct chat output'
+      ],
+      outputFormat: 'JSON with keys: prompt (string)'
+    },
+    outputSchema: {
+      type: 'object',
+      required: ['prompt'],
+      properties: { prompt: { type: 'string' } }
+    }
+  },
+  io: { inputJsonPath: `tasks/${taskCtx.effectId}/input.json`, outputJsonPath: `tasks/${taskCtx.effectId}/result.json` },
+  labels: ['agent', 'phase-4', 'execution-prompt']
+}));

--- a/library/specializations/product-management/task-to-prd.js
+++ b/library/specializations/product-management/task-to-prd.js
@@ -1,0 +1,618 @@
+/**
+ * @process product-management/task-to-prd
+ * @description Orchestrate conversion of a raw task (tracker ticket / file / inline text) into a fully characterized PRD via interactive clarification, automated verification, and user-gated refinement. Stack-agnostic. Wraps the task-to-prd skill.
+ * @skill task-to-prd library/specializations/product-management/skills/task-to-prd/SKILL.md
+ * @inputs { input: string, featureBranch: string, contextDoc?: string, archiveDir?: string, trackerHint?: string, secondaryReviewer?: string, requireFinalApproval?: boolean }
+ * @outputs { success: boolean, prdPath: string, decisionLog: array, followupPrompt: string, summary: string }
+ *
+ * Phases:
+ * 1. Clarification (interactive) - load source, Five Whys, interactive Q&A, scope-lock breakpoint
+ * 2. Draft (automatic) - parallel codebase scan + draft PRD via the task-to-prd skill
+ * 3. Verification (with user gates) - what-could-go-wrong, consistency, conventions, adversarial, quality checklist, optional secondary reviewer; every proposed change goes through a per-finding breakpoint
+ * 4. Finalize - final review breakpoint, optional tracker update, emit follow-up prompt
+ */
+
+import { defineTask } from '@a5c-ai/babysitter-sdk';
+
+export async function process(inputs, ctx) {
+  const {
+    input,
+    featureBranch,
+    contextDoc = 'CLAUDE.md',
+    archiveDir = '',
+    trackerHint = null,
+    secondaryReviewer = null,
+    requireFinalApproval = true
+  } = inputs;
+
+  if (!input) {
+    return { success: false, reason: 'Missing required input: input (tracker ID, file path, or inline text)' };
+  }
+  if (!featureBranch) {
+    return { success: false, reason: 'Missing required input: featureBranch' };
+  }
+
+  ctx.log('info', `Starting task-to-prd pipeline for: ${input}`);
+
+  // ============================================================================
+  // PHASE 1: CLARIFICATION (INTERACTIVE)
+  // ============================================================================
+
+  ctx.log('info', 'Phase 1: Loading task source');
+
+  const sourceLoad = await ctx.task(loadSourceTask, {
+    input,
+    contextDoc,
+    archiveDir,
+    trackerHint
+  });
+
+  ctx.log('info', 'Phase 1b: Five Whys analysis');
+
+  const fiveWhys = await ctx.task(fiveWhysTask, {
+    rawTask: sourceLoad.rawTask
+  });
+
+  // Interactive clarification — handed to the user; the task-to-prd skill drives the Q&A loop
+  const clarification = await ctx.breakpoint({
+    question: [
+      'Interactive Clarification phase begins now.',
+      '',
+      `**Task summary:** ${sourceLoad.summary || sourceLoad.rawTask?.slice(0, 200)}`,
+      `**Five Whys gaps:** ${(fiveWhys.openQuestions || []).length} open question(s)`,
+      '',
+      'The task-to-prd skill will ask one question at a time (explanation + recommendation + 2-4 options). You may answer directly or say "I will ask <stakeholder>" — paste their answer back when ready.',
+      '',
+      'Approve to start the clarification loop, or reject to cancel.'
+    ].join('\n'),
+    title: 'Begin Interactive Clarification',
+    context: { runId: ctx.runId }
+  });
+  if (!clarification.approved) {
+    return { success: false, reason: 'User cancelled at clarification gate' };
+  }
+
+  const decisionLog = await ctx.task(clarificationLoopTask, {
+    rawTask: sourceLoad.rawTask,
+    fiveWhys,
+    contextDoc
+  });
+
+  // Scope lock — explicit gate before any drafting
+  const scopeLock = await ctx.breakpoint({
+    question: [
+      '**Scope Lock — review and approve before PRD draft:**',
+      '',
+      `**Problem:** ${decisionLog.problemSummary}`,
+      `**Proposed scope:** ${(decisionLog.scope || []).join(', ')}`,
+      `**Constraints:** ${(decisionLog.constraints || []).join('; ') || 'none'}`,
+      `**Decisions captured:** ${(decisionLog.entries || []).length}`,
+      '',
+      'Approve to proceed to PRD draft, or reject to revise.'
+    ].join('\n'),
+    title: 'Scope Lock',
+    context: { runId: ctx.runId }
+  });
+  if (!scopeLock.approved) {
+    return { success: false, reason: 'User rejected at scope-lock gate', decisionLog };
+  }
+
+  // ============================================================================
+  // PHASE 2: DRAFT (AUTOMATIC)
+  // ============================================================================
+
+  ctx.log('info', 'Phase 2: Drafting PRD via task-to-prd skill');
+
+  const [scanResult, draftResult] = await ctx.parallel.all([
+    () => ctx.task(codebaseScanTask, { scope: decisionLog.scope, contextDoc }),
+    () => ctx.task(draftPrdTask, {
+      input,
+      featureBranch,
+      contextDoc,
+      archiveDir,
+      decisionLog,
+      fiveWhys
+    })
+  ]);
+
+  if (!draftResult.prdPath) {
+    return { success: false, reason: 'PRD draft produced no output path', decisionLog, scanResult };
+  }
+
+  // ============================================================================
+  // PHASE 3: VERIFICATION (WITH USER GATES)
+  // ============================================================================
+
+  ctx.log('info', 'Phase 3: Verification (parallel checks)');
+
+  const checks = await ctx.parallel.all([
+    () => ctx.task(whatCouldGoWrongTask, { prdPath: draftResult.prdPath }),
+    () => ctx.task(codebaseConsistencyTask, { prdPath: draftResult.prdPath, scanResult }),
+    () => ctx.task(conventionsCheckTask, { prdPath: draftResult.prdPath, contextDoc }),
+    () => ctx.task(adversarialReviewTask, { prdPath: draftResult.prdPath }),
+    () => ctx.task(qualityChecklistTask, { prdPath: draftResult.prdPath })
+  ]);
+
+  let secondaryReview = null;
+  if (secondaryReviewer) {
+    ctx.log('info', `Phase 3b: Secondary review via ${secondaryReviewer}`);
+    secondaryReview = await ctx.task(secondaryReviewerTask, {
+      prdPath: draftResult.prdPath,
+      reviewerHint: secondaryReviewer
+    });
+  }
+
+  // Aggregate findings and present per-finding breakpoint
+  const allFindings = [
+    ...(checks[0].findings || []),
+    ...(checks[1].findings || []),
+    ...(checks[2].findings || []),
+    ...(checks[3].findings || []),
+    ...(checks[4].findings || []),
+    ...(secondaryReview?.findings || [])
+  ];
+
+  if (allFindings.length > 0) {
+    const reviewApproval = await ctx.breakpoint({
+      question: [
+        `**${allFindings.length} verification finding(s)** propose changes to the PRD.`,
+        '',
+        'Each one will be presented separately for approve / reject / modify. Apply only approved changes.',
+        '',
+        'Approve to enter the per-finding loop, or reject to skip the verification stage.'
+      ].join('\n'),
+      title: 'Verification Findings — Per-Finding Review',
+      context: { runId: ctx.runId }
+    });
+    if (reviewApproval.approved) {
+      await ctx.task(applyFindingsTask, {
+        prdPath: draftResult.prdPath,
+        findings: allFindings
+      });
+    }
+  }
+
+  // ============================================================================
+  // PHASE 4: FINALIZE
+  // ============================================================================
+
+  if (requireFinalApproval) {
+    const finalApproval = await ctx.breakpoint({
+      question: [
+        `**Final PRD review.** PRD at \`${draftResult.prdPath}\`.`,
+        '',
+        `Verification findings processed: ${allFindings.length}.`,
+        '',
+        'Approve to finalize and emit the follow-up prompt, or reject to revise.'
+      ].join('\n'),
+      title: 'Final PRD Approval',
+      context: { runId: ctx.runId }
+    });
+    if (!finalApproval.approved) {
+      return {
+        success: false,
+        reason: 'User rejected at final approval gate',
+        prdPath: draftResult.prdPath,
+        decisionLog
+      };
+    }
+  }
+
+  let trackerUpdate = null;
+  if (trackerHint && sourceLoad.sourceType === 'tracker') {
+    trackerUpdate = await ctx.task(updateTrackerTask, {
+      input,
+      prdPath: draftResult.prdPath,
+      trackerHint
+    });
+  }
+
+  const followup = await ctx.task(generateFollowupPromptTask, {
+    prdPath: draftResult.prdPath,
+    contextDoc
+  });
+
+  return {
+    success: true,
+    prdPath: draftResult.prdPath,
+    decisionLog: decisionLog.entries || [],
+    followupPrompt: followup.prompt,
+    summary: `PRD generated at ${draftResult.prdPath}. Follow-up prompt emitted.`,
+    artifacts: [
+      { type: 'prd', path: draftResult.prdPath },
+      { type: 'decision-log', entries: decisionLog.entries || [] }
+    ],
+    trackerUpdate,
+    metadata: {
+      processId: 'product-management/task-to-prd',
+      timestamp: ctx.now(),
+      featureBranch
+    }
+  };
+}
+
+// ============================================================================
+// TASK DEFINITIONS
+// ============================================================================
+
+export const loadSourceTask = defineTask('load-source', (args, taskCtx) => ({
+  kind: 'agent',
+  title: 'Load task source (tracker / file / inline text)',
+  agent: {
+    name: 'general-purpose',
+    prompt: {
+      role: 'Task-intake analyst detecting and loading the raw source',
+      task: `Detect the input type and load the raw task content. Input: "${args.input}"`,
+      context: { input: args.input, contextDoc: args.contextDoc, archiveDir: args.archiveDir, trackerHint: args.trackerHint },
+      instructions: [
+        'Detect input type: tracker ticket ID (alphanumeric prefix + dash + number), file path (contains / or \\), or inline text (everything else)',
+        args.trackerHint
+          ? `Tracker hint: "${args.trackerHint}". If input matches a tracker ticket pattern, fetch summary + description + comments via the matching tracker integration. Examples: Jira (/jira skill or acli), Linear (linear-cli or MCP), GitHub Issues (gh issue view). Do NOT create new tickets.`
+          : 'No tracker hint configured. If input looks like a tracker ticket ID, treat it as inline text and ask the user to paste content.',
+        'For file paths: read the file',
+        'For inline text: use as-is',
+        `Read the project context document (${args.contextDoc}) for conventions`,
+        args.archiveDir
+          ? `Scan ${args.archiveDir} for previous PRD examples — style inspiration only`
+          : 'Skip archive inspection — none configured'
+      ],
+      outputFormat: 'JSON with keys: sourceType (string: tracker|file|text), rawTask (string), summary (string), projectContext (string)'
+    },
+    outputSchema: {
+      type: 'object',
+      required: ['sourceType', 'rawTask'],
+      properties: {
+        sourceType: { type: 'string' },
+        rawTask: { type: 'string' },
+        summary: { type: 'string' },
+        projectContext: { type: 'string' }
+      }
+    }
+  },
+  io: { inputJsonPath: `tasks/${taskCtx.effectId}/input.json`, outputJsonPath: `tasks/${taskCtx.effectId}/result.json` },
+  labels: ['agent', 'phase-1', 'load-source']
+}));
+
+export const fiveWhysTask = defineTask('five-whys', (args, taskCtx) => ({
+  kind: 'agent',
+  title: 'Five Whys — root-cause analysis',
+  agent: {
+    name: 'general-purpose',
+    prompt: {
+      role: 'Root-cause analyst running a Five Whys pass',
+      task: 'Perform Five Whys on the raw task to dig past the surface request before any solution.',
+      context: { rawTask: args.rawTask },
+      instructions: [
+        'Why is this a problem?',
+        'Why does it happen?',
+        'Why was it not caught earlier?',
+        'Why does the current design allow it?',
+        'Why is the proposed solution the right one (if one was proposed)?',
+        'Identify gaps that need user clarification — these become the question queue for Phase 1 Q&A'
+      ],
+      outputFormat: 'JSON with keys: analysis (markdown), openQuestions (array of strings)'
+    },
+    outputSchema: {
+      type: 'object',
+      required: ['analysis', 'openQuestions'],
+      properties: {
+        analysis: { type: 'string' },
+        openQuestions: { type: 'array', items: { type: 'string' } }
+      }
+    }
+  },
+  io: { inputJsonPath: `tasks/${taskCtx.effectId}/input.json`, outputJsonPath: `tasks/${taskCtx.effectId}/result.json` },
+  labels: ['agent', 'phase-1', 'five-whys']
+}));
+
+export const clarificationLoopTask = defineTask('clarification-loop', (args, taskCtx) => ({
+  kind: 'agent',
+  title: 'Interactive clarification loop (driven by task-to-prd skill)',
+  agent: {
+    name: 'general-purpose',
+    prompt: {
+      role: 'Clarification-loop driver invoking the task-to-prd skill',
+      task: 'Run the interactive clarification loop. Ask one question at a time, in English, with explanation + recommendation + 2-4 options. Track every Q&A in a Decision Log with attribution.',
+      context: { rawTask: args.rawTask, fiveWhys: args.fiveWhys, contextDoc: args.contextDoc },
+      instructions: [
+        'Invoke the task-to-prd skill (via the Skill tool) to drive the clarification loop — Phase 1 of the skill',
+        'Use the harness Q&A mechanism (e.g., AskUserQuestion) for each question',
+        'User may answer directly OR say "I will ask <stakeholder>" — wait for them to paste back the answer',
+        'Continue until all open questions from the Five Whys are resolved (or the user explicitly closes them as out-of-scope)',
+        'Detect scope: which layers are affected (data-pipeline, backend, frontend, infra, docs)',
+        'Maintain a running Decision Log: each entry has question, answer, attribution (user / <stakeholder name>)'
+      ],
+      outputFormat: 'JSON with keys: problemSummary (string), scope (array of strings), constraints (array of strings), entries (array of {question, answer, attribution}), openQuestions (array of strings)'
+    },
+    outputSchema: {
+      type: 'object',
+      required: ['problemSummary', 'scope', 'entries'],
+      properties: {
+        problemSummary: { type: 'string' },
+        scope: { type: 'array', items: { type: 'string' } },
+        constraints: { type: 'array', items: { type: 'string' } },
+        entries: { type: 'array', items: { type: 'object' } },
+        openQuestions: { type: 'array', items: { type: 'string' } }
+      }
+    }
+  },
+  io: { inputJsonPath: `tasks/${taskCtx.effectId}/input.json`, outputJsonPath: `tasks/${taskCtx.effectId}/result.json` },
+  labels: ['agent', 'phase-1', 'clarification', 'invokes-skill']
+}));
+
+export const codebaseScanTask = defineTask('codebase-scan', (args, taskCtx) => ({
+  kind: 'agent',
+  title: 'Parallel codebase scan over locked scope',
+  agent: {
+    name: 'general-purpose',
+    prompt: {
+      role: 'Codebase scanner enumerating affected files for a locked scope',
+      task: 'Launch one subagent per affected layer to scan files in scope. Report exact file paths and line numbers for everything relevant.',
+      context: { scope: args.scope, contextDoc: args.contextDoc },
+      instructions: [
+        `Layers in scope: ${(args.scope || []).join(', ')}`,
+        'For each layer, scan the relevant files: data-pipeline (transforms, configs, schemas), backend (services, schemas, queues), frontend (components, types, API calls), infra (IaC, deployment configs), docs (relevant pages)',
+        'Report exact file paths and line numbers',
+        'Do NOT modify anything'
+      ],
+      outputFormat: 'JSON with keys: filesByLayer (object of layer -> array of {path, lines, summary}), integrationPoints (array)'
+    },
+    outputSchema: {
+      type: 'object',
+      required: ['filesByLayer'],
+      properties: {
+        filesByLayer: { type: 'object' },
+        integrationPoints: { type: 'array' }
+      }
+    }
+  },
+  io: { inputJsonPath: `tasks/${taskCtx.effectId}/input.json`, outputJsonPath: `tasks/${taskCtx.effectId}/result.json` },
+  labels: ['agent', 'phase-2', 'codebase-scan']
+}));
+
+export const draftPrdTask = defineTask('draft-prd', (args, taskCtx) => ({
+  kind: 'agent',
+  title: 'Draft PRD via task-to-prd skill',
+  agent: {
+    name: 'general-purpose',
+    prompt: {
+      role: 'PRD drafter wrapping the task-to-prd Claude Code skill',
+      task: 'Invoke the task-to-prd skill (via the Skill tool) to draft the PRD file using clarification + scope-lock results. Return the absolute PRD file path.',
+      context: {
+        input: args.input,
+        featureBranch: args.featureBranch,
+        contextDoc: args.contextDoc,
+        archiveDir: args.archiveDir,
+        decisionLog: args.decisionLog,
+        fiveWhys: args.fiveWhys
+      },
+      instructions: [
+        'Invoke the task-to-prd skill — Phase 2 (PRD Draft)',
+        `Output path: <tasks-dir>/${args.featureBranch}-PRD.md (the skill resolves the tasks-dir from project conventions)`,
+        'PRD sections must include: Background (with Five Whys), Root Cause, Agreed Solution, Scope (exhaustive file list), Edge Cases, Technical Constraints, Data Flow (if applicable), Decision Log (with attribution), Definition of Done, Open Questions',
+        'PRD must be proportional to the task size',
+        'Do NOT create a SPEC — only a PRD'
+      ],
+      outputFormat: 'JSON with keys: prdPath (string), generatedSections (array of strings)'
+    },
+    outputSchema: {
+      type: 'object',
+      required: ['prdPath'],
+      properties: {
+        prdPath: { type: 'string' },
+        generatedSections: { type: 'array', items: { type: 'string' } }
+      }
+    }
+  },
+  io: { inputJsonPath: `tasks/${taskCtx.effectId}/input.json`, outputJsonPath: `tasks/${taskCtx.effectId}/result.json` },
+  labels: ['agent', 'phase-2', 'draft-prd', 'invokes-skill']
+}));
+
+export const whatCouldGoWrongTask = defineTask('what-could-go-wrong', (args, taskCtx) => ({
+  kind: 'agent',
+  title: 'What-could-go-wrong analysis',
+  agent: {
+    name: 'general-purpose',
+    prompt: {
+      role: 'Risk analyst identifying ways the proposed solution can fail',
+      task: `Read the PRD at ${args.prdPath} and identify what could go wrong with the proposed solution.`,
+      context: { prdPath: args.prdPath },
+      instructions: [
+        'Identify downstream consumers affected',
+        'Find hidden dependencies',
+        'List edge cases not covered in the PRD',
+        'Assess rollback complexity',
+        'For each finding: severity (critical|high|medium|low), suggested PRD change'
+      ],
+      outputFormat: 'JSON with keys: findings (array of {severity, message, suggestedChange})'
+    },
+    outputSchema: { type: 'object', required: ['findings'], properties: { findings: { type: 'array', items: { type: 'object' } } } }
+  },
+  io: { inputJsonPath: `tasks/${taskCtx.effectId}/input.json`, outputJsonPath: `tasks/${taskCtx.effectId}/result.json` },
+  labels: ['agent', 'phase-3', 'verification', 'risk-analysis']
+}));
+
+export const codebaseConsistencyTask = defineTask('codebase-consistency', (args, taskCtx) => ({
+  kind: 'agent',
+  title: 'Codebase consistency check',
+  agent: {
+    name: 'general-purpose',
+    prompt: {
+      role: 'Verification agent comparing PRD claims to actual code',
+      task: `Verify every PRD claim against actual code (file paths, line numbers, identifiers, signatures). PRD: ${args.prdPath}.`,
+      context: { prdPath: args.prdPath, scanResult: args.scanResult },
+      instructions: [
+        'For each file/line reference in the PRD, verify it exists in the code',
+        'For each function/class/CTE/column name, verify correctness',
+        'Cross-check against the codebase scan results',
+        'Each discrepancy is a finding requiring user approval before applying any PRD change'
+      ],
+      outputFormat: 'JSON with keys: findings (array of {severity, message, suggestedChange})'
+    },
+    outputSchema: { type: 'object', required: ['findings'], properties: { findings: { type: 'array', items: { type: 'object' } } } }
+  },
+  io: { inputJsonPath: `tasks/${taskCtx.effectId}/input.json`, outputJsonPath: `tasks/${taskCtx.effectId}/result.json` },
+  labels: ['agent', 'phase-3', 'verification', 'consistency']
+}));
+
+export const conventionsCheckTask = defineTask('conventions-check', (args, taskCtx) => ({
+  kind: 'agent',
+  title: 'Project conventions check',
+  agent: {
+    name: 'general-purpose',
+    prompt: {
+      role: 'Conventions reviewer comparing the PRD against the project guide',
+      task: `Verify the PRD aligns with project conventions. PRD: ${args.prdPath}, conventions doc: ${args.contextDoc}.`,
+      context: { prdPath: args.prdPath, contextDoc: args.contextDoc },
+      instructions: [
+        `Read ${args.contextDoc} (e.g., CLAUDE.md, AGENTS.md, CONTRIBUTING.md, project style guide)`,
+        'Check that the proposed solution follows the project\'s naming, structure, and style rules',
+        'Flag any convention violations'
+      ],
+      outputFormat: 'JSON with keys: findings (array of {severity, message, suggestedChange})'
+    },
+    outputSchema: { type: 'object', required: ['findings'], properties: { findings: { type: 'array', items: { type: 'object' } } } }
+  },
+  io: { inputJsonPath: `tasks/${taskCtx.effectId}/input.json`, outputJsonPath: `tasks/${taskCtx.effectId}/result.json` },
+  labels: ['agent', 'phase-3', 'verification', 'conventions']
+}));
+
+export const adversarialReviewTask = defineTask('adversarial-review', (args, taskCtx) => ({
+  kind: 'agent',
+  title: 'Adversarial review (attacker + defender)',
+  agent: {
+    name: 'general-purpose',
+    prompt: {
+      role: 'Adversarial reviewer running an attacker/defender loop on the PRD',
+      task: `One reviewer attacks the PRD; another defends. Iterate until no new issues.  PRD: ${args.prdPath}.`,
+      context: { prdPath: args.prdPath },
+      instructions: [
+        'Attacker: look for flaws, missed edge cases, performance issues, security issues, data integrity issues',
+        'Defender: justify or refine the PRD',
+        'Iterate until the attacker has no new findings',
+        'Report converged findings — each one with severity and suggested PRD change'
+      ],
+      outputFormat: 'JSON with keys: findings (array of {severity, message, suggestedChange})'
+    },
+    outputSchema: { type: 'object', required: ['findings'], properties: { findings: { type: 'array', items: { type: 'object' } } } }
+  },
+  io: { inputJsonPath: `tasks/${taskCtx.effectId}/input.json`, outputJsonPath: `tasks/${taskCtx.effectId}/result.json` },
+  labels: ['agent', 'phase-3', 'verification', 'adversarial']
+}));
+
+export const qualityChecklistTask = defineTask('quality-checklist', (args, taskCtx) => ({
+  kind: 'agent',
+  title: 'Quality checklist auto-generation + validation',
+  agent: {
+    name: 'general-purpose',
+    prompt: {
+      role: 'Quality reviewer auto-generating and validating a PRD-specific checklist',
+      task: `Auto-generate a quality checklist tailored to this PRD type and validate against it. PRD: ${args.prdPath}.`,
+      context: { prdPath: args.prdPath },
+      instructions: [
+        'Dimensions: completeness, clarity, testability, consistency',
+        'Generate checklist items specific to this PRD type and scope',
+        'Validate the PRD against each item',
+        'Report failures as findings with suggested fixes'
+      ],
+      outputFormat: 'JSON with keys: checklist (array of {item, passed}), findings (array of {severity, message, suggestedChange})'
+    },
+    outputSchema: { type: 'object', required: ['findings'], properties: { checklist: { type: 'array' }, findings: { type: 'array', items: { type: 'object' } } } }
+  },
+  io: { inputJsonPath: `tasks/${taskCtx.effectId}/input.json`, outputJsonPath: `tasks/${taskCtx.effectId}/result.json` },
+  labels: ['agent', 'phase-3', 'verification', 'quality-checklist']
+}));
+
+export const secondaryReviewerTask = defineTask('secondary-review', (args, taskCtx) => ({
+  kind: 'agent',
+  title: 'Secondary review (optional, configurable reviewer)',
+  agent: {
+    name: 'general-purpose',
+    prompt: {
+      role: 'Independent reviewer running a configurable secondary review of the PRD',
+      task: `Run the secondary reviewer "${args.reviewerHint}" against the PRD at ${args.prdPath}.`,
+      context: { prdPath: args.prdPath, reviewerHint: args.reviewerHint },
+      instructions: [
+        `Reviewer hint: "${args.reviewerHint}". Map this to an available reviewer in your environment.`,
+        'Examples: "codex" → Codex CLI review, "gemini" → Gemini review, "deep-verify-plan" → /deep-verify-plan, "peer" → notify a teammate and wait for response',
+        'If the named reviewer is not available, set unavailable: true and skip — do not silently substitute',
+        'Surface CRITICAL/HIGH findings clearly'
+      ],
+      outputFormat: 'JSON with keys: summary (string), findings (array of {severity, message, suggestedChange}), unavailable (boolean)'
+    },
+    outputSchema: {
+      type: 'object',
+      required: ['summary'],
+      properties: { summary: { type: 'string' }, findings: { type: 'array', items: { type: 'object' } }, unavailable: { type: 'boolean' } }
+    }
+  },
+  io: { inputJsonPath: `tasks/${taskCtx.effectId}/input.json`, outputJsonPath: `tasks/${taskCtx.effectId}/result.json` },
+  labels: ['agent', 'phase-3', 'secondary-review', 'optional']
+}));
+
+export const applyFindingsTask = defineTask('apply-findings', (args, taskCtx) => ({
+  kind: 'agent',
+  title: 'Apply approved findings to the PRD (per-finding gated)',
+  agent: {
+    name: 'general-purpose',
+    prompt: {
+      role: 'PRD editor applying user-approved changes from verification findings',
+      task: `Walk the user through each finding for ${args.prdPath} one at a time. For each: present finding + current PRD text + proposed change + recommendation. Apply only approved changes.`,
+      context: { prdPath: args.prdPath, findings: args.findings },
+      instructions: [
+        'For each finding: present (severity, message, currentPrdText, suggestedChange, recommendation)',
+        'Decision options per finding: approve / reject / modify',
+        'Apply only approved changes',
+        'After every batch of changes, re-verify the PRD passes the original quality checklist'
+      ],
+      outputFormat: 'JSON with keys: appliedCount (number), rejectedCount (number), modifiedCount (number)'
+    },
+    outputSchema: { type: 'object', required: ['appliedCount'], properties: { appliedCount: { type: 'number' }, rejectedCount: { type: 'number' }, modifiedCount: { type: 'number' } } }
+  },
+  io: { inputJsonPath: `tasks/${taskCtx.effectId}/input.json`, outputJsonPath: `tasks/${taskCtx.effectId}/result.json` },
+  labels: ['agent', 'phase-3', 'apply-findings']
+}));
+
+export const updateTrackerTask = defineTask('update-tracker', (args, taskCtx) => ({
+  kind: 'agent',
+  title: 'Update tracker ticket with PRD reference',
+  agent: {
+    name: 'general-purpose',
+    prompt: {
+      role: 'Tracker integration agent updating the source ticket',
+      task: `Update the source tracker ticket "${args.input}" with a reference to the PRD at ${args.prdPath}.`,
+      context: { input: args.input, prdPath: args.prdPath, trackerHint: args.trackerHint },
+      instructions: [
+        `Tracker hint: "${args.trackerHint}". Examples: Jira (/jira skill or acli jira workitem update), Linear (linear-cli or MCP), GitHub Issues (gh issue edit).`,
+        'Append a reference to the PRD path or PR link, depending on the tracker',
+        'Do NOT change the ticket status unless the user explicitly approves it',
+        'If the tracker integration is unavailable, report unavailable: true and skip'
+      ],
+      outputFormat: 'JSON with keys: updated (boolean), unavailable (boolean), summary (string)'
+    },
+    outputSchema: { type: 'object', required: ['updated'], properties: { updated: { type: 'boolean' }, unavailable: { type: 'boolean' }, summary: { type: 'string' } } }
+  },
+  io: { inputJsonPath: `tasks/${taskCtx.effectId}/input.json`, outputJsonPath: `tasks/${taskCtx.effectId}/result.json` },
+  labels: ['agent', 'phase-4', 'tracker-update', 'optional']
+}));
+
+export const generateFollowupPromptTask = defineTask('generate-followup-prompt', (args, taskCtx) => ({
+  kind: 'agent',
+  title: 'Generate /prd-to-spec follow-up prompt',
+  agent: {
+    name: 'general-purpose',
+    prompt: {
+      role: 'Prompt generator emitting the next-step follow-up',
+      task: 'Output a 2-line follow-up prompt suitable for direct chat output (NOT a file).',
+      context: { prdPath: args.prdPath, contextDoc: args.contextDoc },
+      instructions: [
+        `Prompt template: "Read ${args.contextDoc} for context. Then run /prd-to-spec ${args.prdPath}"`,
+        'Output as plain text — no formatting, no file write'
+      ],
+      outputFormat: 'JSON with keys: prompt (string)'
+    },
+    outputSchema: { type: 'object', required: ['prompt'], properties: { prompt: { type: 'string' } } }
+  },
+  io: { inputJsonPath: `tasks/${taskCtx.effectId}/input.json`, outputJsonPath: `tasks/${taskCtx.effectId}/result.json` },
+  labels: ['agent', 'phase-4', 'followup-prompt']
+}));


### PR DESCRIPTION
## Library Contribution

**Type:** process (×2, paired)
**Names:** \`prd-to-spec\`, \`task-to-prd\`
**Specialization:** product-management
**Location:** \`library/specializations/product-management/{prd-to-spec,task-to-prd}.js\`
**Companion to:** PR #154 (the skills these processes orchestrate)

## What's included

Two paired babysitter processes that orchestrate the corresponding skills end-to-end with structured phases, parallel verification, and breakpoint-gated user approvals.

### \`prd-to-spec.js\` (324 lines, 5 tasks)

| Phase | Task | Kind |
|-------|------|------|
| 1. Discovery | \`discoveryTask\` | agent |
| 2. SPEC Generation | \`generateSpecTask\` (invokes the skill) | agent |
| 3. Self-Verification | \`selfReviewTask\` | agent |
| 3b. Secondary Review (optional) | \`secondaryReviewTask\` | agent |
| 4. Execution Prompt | \`executionPromptTask\` | agent |

User-approval breakpoint between Phase 3 and Phase 4.

### \`task-to-prd.js\` (618 lines, 12 tasks)

| Phase | Task | Kind |
|-------|------|------|
| 1. Load + Five Whys | \`loadSourceTask\`, \`fiveWhysTask\` | agent |
| 1b. Interactive Clarification | \`clarificationLoopTask\` (invokes the skill) | agent |
| 2. Draft (parallel) | \`codebaseScanTask\`, \`draftPrdTask\` (invokes the skill) | agent |
| 3. Verification (5 parallel checks) | \`whatCouldGoWrongTask\`, \`codebaseConsistencyTask\`, \`conventionsCheckTask\`, \`adversarialReviewTask\`, \`qualityChecklistTask\` | agent |
| 3b. Secondary Review (optional) | \`secondaryReviewerTask\` | agent |
| 3c. Apply approved findings | \`applyFindingsTask\` | agent |
| 4. Tracker Update (optional) | \`updateTrackerTask\` | agent |
| 4b. Follow-up Prompt | \`generateFollowupPromptTask\` | agent |

Three breakpoints: clarification-start, scope-lock, final approval. Per-finding micro-gate inside Phase 3.

## Stack-agnostic

Every external integration is wired through \`inputs\`, not hardcoded:

| Input | Purpose | Examples |
|-------|---------|----------|
| \`trackerHint\` | Tracker integration | \`jira\`, \`linear\`, \`gh-issues\` |
| \`secondaryReviewer\` | Optional independent reviewer | \`codex\`, \`gemini\`, \`deep-verify-plan\`, \`peer\` |
| \`contextDoc\` | Project conventions doc | \`CLAUDE.md\`, \`AGENTS.md\`, \`README.md\` |
| \`archiveDir\` | Past PRDs/SPECs for style ref | any directory or empty |
| \`failureLogPath\` | Cross-run lessons | path or empty |
| \`baseBranch\` | Default integration branch | \`main\`, \`develop\`, \`dev\` |

Both processes work end-to-end without any optional hooks configured.

## Pattern compliance

- Modern imperative pattern: \`async function process(inputs, ctx)\`
- \`ctx.task()\`, \`ctx.breakpoint()\`, \`ctx.parallel.all()\`, \`ctx.log()\`
- All tasks use \`kind: 'agent'\` with \`general-purpose\` agent
- Each task has \`outputSchema\`, \`io\` paths via \`taskCtx.effectId\`, and labels
- JSDoc \`@process\`, \`@description\`, \`@skill\`, \`@inputs\`, \`@outputs\` annotations

## Validation Results

- ✅ kebab-case filenames
- ✅ JSDoc annotations present
- ✅ Self-review pass: no project-specific leakage, no personal info
- ✅ Stack-agnostic — all integrations parameterized
- ✅ Companion skills already merged (PR #154 → staging)

## Files Added

- \`library/specializations/product-management/prd-to-spec.js\` (324 lines)
- \`library/specializations/product-management/task-to-prd.js\` (618 lines)

Companion PR (skills): #154 (already merged to staging on 2026-04-29).

Also published to a community fork in parallel: deedeeharris/claude-skills#4. Happy to adjust to fit conventions better — second contribution to this library.