### PR TITLE
refactor(product-management): skill dispatches to process via /babysitter:call|yolo

### DIFF
--- a/library/specializations/product-management/prd-to-spec.js
+++ b/library/specializations/product-management/prd-to-spec.js
@@ -1,13 +1,12 @@
 /**
  * @process product-management/prd-to-spec
- * @description Orchestrate conversion of an approved PRD into a phase-gated implementation SPEC. Stack-agnostic. Wraps the prd-to-spec skill with verification, self-review, and an execution-prompt output.
- * @skill prd-to-spec library/specializations/product-management/skills/prd-to-spec/SKILL.md
+ * @description Orchestrate conversion of an approved PRD into a phase-gated implementation SPEC. Stack-agnostic. Self-contained — the prd-to-spec skill dispatches here via /babysitter:call or /babysitter:yolo.
  * @inputs { prdPath: string, featureBranch: string, baseBranch?: string, contextDoc?: string, archiveDir?: string, failureLogPath?: string, secondaryReviewer?: string, requireApproval?: boolean }
  * @outputs { success: boolean, specPath: string, executionPrompt: string, summary: string }
  *
  * Phases:
  * 1. Discovery & Verification Ledger - read PRD + project context, scan affected layers, build ledger
- * 2. SPEC Generation - invoke the prd-to-spec skill to produce the SPEC file
+ * 2. SPEC Generation - generate the phase-gated SPEC file inline (full structure embedded in agent prompt)
  * 3. Self-Verification - internal review + optional secondary reviewer + user approval breakpoint
  * 4. Execution Prompt - emit the short prompt that drives downstream execution
  */
@@ -194,12 +193,12 @@ export const discoveryTask = defineTask('discovery', (args, taskCtx) => ({
 
 export const generateSpecTask = defineTask('generate-spec', (args, taskCtx) => ({
   kind: 'agent',
-  title: 'Generate SPEC by invoking the prd-to-spec skill',
+  title: 'Generate phase-gated SPEC file',
   agent: {
     name: 'general-purpose',
     prompt: {
-      role: 'SPEC generator wrapping the prd-to-spec Claude Code skill',
-      task: 'Invoke the prd-to-spec skill (via the Skill tool) to produce a phase-gated SPEC file from the PRD and discovery results. Return the SPEC file path.',
+      role: 'SPEC author writing a production-ready, phase-gated implementation SPEC',
+      task: `Generate a phase-gated SPEC file at <tasks-dir>/${args.featureBranch}-SPEC.md based on the PRD at "${args.prdPath}" and the discovery results from Phase 1. Return the absolute SPEC path.`,
       context: {
         prdPath: args.prdPath,
         featureBranch: args.featureBranch,
@@ -208,12 +207,25 @@ export const generateSpecTask = defineTask('generate-spec', (args, taskCtx) => (
         discovery: args.discovery
       },
       instructions: [
-        `Invoke the prd-to-spec skill with input: ${args.prdPath}`,
-        'The skill follows its own internal phases: Pre-Check, Execute (TDD), Pipeline/UI Verification, Conventions Fix, Completeness, Code Review, Deliver',
-        `Pass through: featureBranch=${args.featureBranch}, baseBranch=${args.baseBranch}, contextDoc=${args.contextDoc}`,
-        'Pass through the discovery results (Verification Ledger, scope, blocking PRs, prior failures) as Phase 1 inputs',
-        'After the skill produces the SPEC, return the absolute path to the SPEC file',
-        'If the skill encounters a hard error, report it back; do not silently continue'
+        'The SPEC must contain these top-level sections in order:',
+        '  1. **Header** — Title, Source PRD path, Tracker Task link (if applicable), Branch, Quality Gate (each phase >= 0.85)',
+        '  2. **Prerequisites** — files to read before execution; MUST include the project-local failure-log.md if configured',
+        '  3. **Known Divergences** (if applicable) — intentional differences between related files',
+        '  4. **Verification Ledger** — table of PRD claims vs. actual code findings (use the table from discovery verbatim)',
+        '  5. **Phase 1: Pre-Check** — first numbered step is to read failure-log.md and internalize patterns; branch from base-branch; verify dependencies merged; read project conventions',
+        '  6. **Phase 2: Execute (TDD)** — for every sub-task: failing test FIRST (RED) → minimal implementation (GREEN) → refactor (IMPROVE); list sub-tasks with exact file paths, line numbers, current code, target code; include edge case matrix',
+        '  7. **Phase 3: Local Pipeline Verification & Data Quality** — run project test suite; if data-pipeline/backend changed → Pipeline Verification BREAKPOINT (materialize/run, data-quality spot-check, downstream consumers); if UI changed → UI Verification BREAKPOINT (start dev server, seed test data, present URL+credentials, wait); if neither applies → skip',
+        '  8. **Phase 4: Conventions Fix** — project conventions check; project linter+formatter+type-checker on changed files only',
+        '  9. **Phase 5: Completeness (Hard Gate)** — verify every Definition-of-Done item with file:line evidence; YES/NO gate questions',
+        '  10. **Phase 6: Code Review** — primary review (mandatory); 1-2 independent secondary reviews (optional); re-run tests after fixes',
+        '  11. **Phase 7: Deliver** — BREAKPOINT for user approval; Pre-Push Personal Docs Check (mandatory gate); commit, push, open PR; tracker update (optional); rollback plan; post-deploy monitoring',
+        '  12. **Execution Constraints** — scope boundary, exhaustive file list, what does NOT change',
+        'Apply Smart Scope Detection from discovery: skip Phase 3 sub-sections that target irrelevant layers',
+        'Every phase MUST have a Quality Gate checklist (target score >= 0.85)',
+        'The SPEC must be proportional to the task — concise for small changes, detailed for multi-layer refactors',
+        'Use the Verification Ledger from discovery verbatim; do NOT regenerate it',
+        `Resolve the tasks-dir from project conventions (read ${args.contextDoc}); fall back to docs/active/ if unspecified`,
+        'Return the absolute SPEC file path; if there is a hard error, report it without silent continuation'
       ],
       outputFormat: 'JSON with keys: specPath (string), generatedSections (array of strings)'
     },
@@ -227,7 +239,7 @@ export const generateSpecTask = defineTask('generate-spec', (args, taskCtx) => (
     }
   },
   io: { inputJsonPath: `tasks/${taskCtx.effectId}/input.json`, outputJsonPath: `tasks/${taskCtx.effectId}/result.json` },
-  labels: ['agent', 'phase-2', 'spec-generation', 'invokes-skill']
+  labels: ['agent', 'phase-2', 'spec-generation']
 }));
 
 export const selfReviewTask = defineTask('self-review', (args, taskCtx) => ({

--- a/library/specializations/product-management/skills-agents-backlog.md
+++ b/library/specializations/product-management/skills-agents-backlog.md
@@ -18,7 +18,7 @@ This document identifies specialized skills and agents (subagents) that could en
 ## Overview
 
 ### Current State
-All 17 implemented processes in this specialization currently use the `general-purpose` agent for task execution. While functional, this approach lacks domain-specific optimizations that specialized skills and agents could provide.
+All 19 implemented processes in this specialization currently use the `general-purpose` agent for task execution. While functional, this approach lacks domain-specific optimizations that specialized skills and agents could provide.
 
 ### Implemented Processes
 1. `quarterly-roadmap.js` - Strategic roadmap planning
@@ -38,6 +38,8 @@ All 17 implemented processes in this specialization currently use the `general-p
 15. `stakeholder-alignment.js` - Stakeholder communication
 16. `customer-advisory-board.js` - CAB management
 17. `product-council-review.js` - Product review processes
+18. `prd-to-spec.js` - Orchestrate PRD-to-SPEC pipeline (discovery, SPEC generation, self-review, execution prompt) — dispatched from the `prd-to-spec` skill via `/babysitter:call` or `/babysitter:yolo`
+19. `task-to-prd.js` - Orchestrate task-to-PRD pipeline (Five Whys, interactive clarification, parallel verification, finalize) — dispatched from the `task-to-prd` skill via `/babysitter:call` or `/babysitter:yolo`
 
 ### Goals
 - Provide deep expertise in product management frameworks and methodologies

--- a/library/specializations/product-management/skills/prd-to-spec/SKILL.md
+++ b/library/specializations/product-management/skills/prd-to-spec/SKILL.md
@@ -1,250 +1,110 @@
 ---
 name: prd-to-spec
-description: "Convert an approved PRD into a phase-gated implementation SPEC with verification ledger, TDD breakpoints, and quality gates. Stack-agnostic with optional integration hooks."
+description: "Convert an approved PRD into a phase-gated implementation SPEC. User-facing entry point that dispatches to the prd-to-spec babysitter process via /babysitter:call (interactive) or /babysitter:yolo (auto). Stack-agnostic."
 author: Yehuda Yungstein
 ---
 
 # PRD to SPEC Generator
 
-Convert a PRD into a production-ready, phase-gated SPEC file that an engineer
-(or an orchestrator agent) can execute task-by-task.
+User-facing entry point for the PRD → SPEC pipeline. The user runs
+`/prd-to-spec` and this skill dispatches to the companion babysitter
+process via `/babysitter:call` (interactive, with breakpoints) or
+`/babysitter:yolo` (non-interactive, auto-approve).
 
-This skill is **stack-agnostic**. Every step that integrates with a specific
-tool, tracker, or pipeline framework is wrapped as an **Optional Hook** —
-documented with examples but never required for the skill to function.
+## Usage
 
-## Input
-
-The user provides either:
-
-- A path to a PRD file: `/prd-to-spec <your-tasks-dir>/<task-id>-PRD.md`
-- Inline text describing the task: `/prd-to-spec "description..."`
-
-## Optional Hook Pattern
-
-Throughout this skill, every external-tool integration uses this template:
-
-> **<Capability> (optional):** <one-line description of what this step achieves>.
-> *Examples:* <2-4 concrete examples mixing ecosystems>.
-> *Skip if:* <when this step doesn't apply>.
-
-The skill works end-to-end without any of the optional hooks installed.
-
-## Execution
-
-### Phase 1: Discovery & Verification Ledger
-
-1. Read the PRD (file or inline text).
-2. Read your project's primary context document (e.g., `CLAUDE.md`, `AGENTS.md`,
-   or top-level README) for conventions and onboarding info.
-3. **Smart scope detection** — determine which layers the PRD affects
-   (data-pipeline, backend, frontend, infra, docs). Phases that target
-   irrelevant layers will be skipped in Phase 3.
-4. **Parallel codebase scan** — launch one subagent per affected layer.
-   Each one reads the files mentioned in the PRD and the surrounding code.
-   Examples of layer splits: data-pipeline (SQL/transforms), backend (services,
-   schemas, queues), frontend (components, types, API calls), infra (IaC,
-   deployment configs), docs.
-5. Build a **Verification Ledger** — for every claim in the PRD, verify
-   against actual code with `file:line` references. Note any discrepancies.
-6. **Auto-detect blocking PRs** — check `git log origin/<base-branch>` and
-   `gh pr list` for open PRs touching the same files. If found, note them
-   as dependencies. (`<base-branch>` = your repo's default integration
-   branch — typically `dev`, `develop`, or `main`.)
-7. Inspect your archive of previous SPECs (if you maintain one) for style
-   inspiration only — never as a rigid template. Each task is different.
-8. **Read the project-local `failure-log.md`** — see § Optional: Failure Log
-   Mechanism below. If the file doesn't exist, note "no prior failures
-   recorded" and continue.
-
-### Phase 2: SPEC Generation
-
-Create the SPEC file at `<your-tasks-dir>/<feature-branch>-SPEC.md` with
-these sections:
-
-**Header**
-
-```text
-# SPEC: <Title>
-Source PRD: <path>
-Tracker Task: <link, if applicable>
-Branch: <feature-branch> (from latest <base-branch>)
-Quality Gate: Each phase must reach quality score >= 0.85 before proceeding
+```
+/prd-to-spec <PRD-path-or-inline-text>
 ```
 
-**Prerequisites:** files to read before execution. **MUST include** the
-project-local `failure-log.md` (see § Optional: Failure Log Mechanism) with
-the note "every pattern there is a binding constraint from prior failures".
+Examples:
+- `/prd-to-spec docs/active/feature-X-PRD.md`
+- `/prd-to-spec "Build a notification dashboard with real-time alerts"`
 
-**Known Divergences** *(if applicable)* — document intentional differences
-between related files or components.
+## Companion process
 
-**Verification Ledger** — table of PRD claims vs. actual code findings.
+- Library path: `library/specializations/product-management/prd-to-spec.js`
+- Locally installed: `~/.a5c/processes/prd-to-spec.js`
 
-**Phase 1: Pre-Check**
-- **First step MUST be:** read the project-local `failure-log.md` and
-  internalize all patterns as binding constraints (not suggestions).
-  Add this as the literal first numbered step AND as the first Quality
-  Gate checkbox.
-- Branch from `<base-branch>`; verify any blocking PRs are merged.
-- Read project conventions document.
-- **Ticket-tracker integration (optional):** mark the task as in-progress
-  in your tracker.
-  *Examples:* Jira (`/jira` skill or `acli jira workitem update`), Linear
-  (`linear-cli` or MCP), GitHub Issues (`gh issue edit ... --add-label
-  in-progress`).
-  *Skip if:* you don't track tasks in an external system.
-- Quality Gate checklist (first item: "failure-log.md read and patterns
-  internalized").
+The process file is the source of truth for the pipeline. This skill
+intentionally stays thin so users only need to remember `/prd-to-spec`.
 
-**Phase 2: Execute (TDD)**
-- For EVERY sub-task: write the failing test FIRST (RED) → implement
-  minimally (GREEN) → refactor (IMPROVE).
-- Sub-tasks list: exact file paths, line numbers, current code, target code.
-- Edge case matrix with expected results.
-- Quality Gate checklist.
+## What this skill does when invoked
 
-**Phase 3: Local Pipeline Verification & Data Quality**
-- Run the project's full test suite.
-  *Examples:* `pytest tests/ -v` (Python), `npm test` / `vitest` / `jest`
-  (JS/TS), `go test ./...` (Go), `cargo test` (Rust).
-- **If a data pipeline / backend layer changed — Pipeline Verification
-  BREAKPOINT (skip if not applicable):**
-  - Materialize / run affected pipeline assets locally; verify no errors.
-  - Run data-quality spot-check queries on materialized results.
-  - Verify downstream consumers (snapshots, write-backs, exports) succeed.
-  - If anything fails or hangs: guide the user step by step through
-    diagnosis. Do NOT silently skip or assume it works.
-  - **WAIT for user confirmation** that pipeline results look correct
-    before proceeding.
-  - *Examples:* `dagster asset materialize ...` (Dagster),
-    `airflow tasks test ...` (Airflow), `dbt run --select ...` (dbt),
-    `prefect deployment run ...` (Prefect),
-    `kubectl apply --dry-run=server ...` (K8s previews).
-- **If a UI layer changed — UI Verification BREAKPOINT (skip if not
-  applicable):**
-  - Start the project's dev server(s).
-    *Examples:* `npm run dev`, Vite (`vite`), Next (`next dev`),
-    Storybook (`storybook dev`).
-  - Seed test data if needed (DB fixtures, mock APIs, recorded responses).
-  - Present to user: URL, login credentials (if any), navigation steps,
-    what to look for.
-  - **WAIT for user confirmation** before proceeding.
-- **If neither applies:** skip to Phase 4.
-- Quality Gate checklist (includes "User confirmed pipeline results"
-  and/or "User confirmed UI" as applicable).
+1. **Parse input** — resolve the PRD path or capture the inline text.
+2. **Infer `featureBranch`** — read the current git branch via
+   `git branch --show-current`. If it is `main` / `develop` / `dev`,
+   ask the user for a feature-branch name.
+3. **Detect optional inputs** from the project context:
+   - `contextDoc` — project conventions doc (default `CLAUDE.md`)
+   - `archiveDir` — past SPEC archive directory (default empty)
+   - `failureLogPath` — project-local `failure-log.md` (default empty)
+   - `secondaryReviewer` — hint like `codex`, `gemini`, `peer` (default empty)
+4. **Ask the user to pick the run mode:**
 
-**Phase 4: Conventions Fix**
-- **Project conventions check (optional):** run a project-specific
-  conventions check.
-  *Examples:* a custom `/conventions-check` skill, project-specific lint
-  rules, a pre-commit hook config.
-  *Skip if:* your project has no extra conventions beyond standard
-  linters/formatters.
-- Run the project's linter, formatter, and type checker — on changed
-  files only.
-  *Examples:*
-  - TypeScript: `eslint`, `prettier`, `tsc-files --noEmit`
-  - Python: `ruff`, `black`, `mypy`
-  - Go: `golangci-lint`, `gofmt`, `go vet`
-  - Ruby: `rubocop`, `standardrb`
-- Quality Gate checklist.
+   > Run mode for the babysitter `prd-to-spec` process:
+   >
+   > 1. **Interactive (`/babysitter:call`)** — recommended. Pauses at
+   >    every breakpoint (discovery review, SPEC approval, etc.) for
+   >    explicit user confirmation.
+   > 2. **Auto / yolo (`/babysitter:yolo`)** — non-interactive. Skips
+   >    all breakpoints; auto-approves every gate. Use only when the
+   >    pipeline is well-tested and the inputs are trusted.
 
-**Phase 5: Completeness (Hard Gate)**
-- Verify every Definition-of-Done item with `file:line` evidence.
-- YES/NO gate questions — any NO blocks delivery.
-- **DoD verification (optional):** run a structured Definition-of-Done
-  verification step.
-  *Examples:* a `/verification-before-completion` skill, a manual
-  checklist walkthrough, a pre-merge bot.
-- Quality Gate checklist.
+   Default to option 1 if the user does not respond.
 
-**Phase 6: Code Review**
-- **Step 1 — Primary code review (mandatory):** run a thorough
-  quality + correctness review on the diff. Fix CRITICAL and HIGH
-  findings before continuing.
-- **Step 2 — Independent secondary review (optional but recommended):**
-  at least one reviewer that doesn't share context with Step 1.
-  *Examples:* Codex CLI (`/codex:review --wait` or equivalent), Gemini
-  (`/gemini-review`), GitHub Copilot review, peer review from a teammate.
-- **Step 3 — Project-conventions review (optional):** check the diff
-  against project-specific conventions.
-  *Examples:* a `/requesting-code-review` skill, a CODEOWNERS reviewer,
-  a custom convention bot.
-- Re-run tests after every fix.
-- Quality Gate checklist.
+5. **Dispatch** by invoking the chosen babysitter command via the Skill tool:
 
-**Phase 7: Deliver**
-- **BREAKPOINT** — present summary, WAIT for user approval.
-- **Pre-Push Personal Docs Check (mandatory gate before any push)** —
-  see § Pre-Push Personal Docs Check below for the full procedure.
-  Quality Gate must include "Pre-Push Personal Docs Check executed and
-  resolved with explicit per-file decisions".
-- **Update project status (optional):** update your status / changelog
-  file if you maintain one.
-- Commit, push, open PR against `<base-branch>`.
-- **Ticket-tracker update (optional):** mark the task as in-review and
-  add the PR link.
-  *Examples:* Jira (`/jira` skill or `acli`), Linear (CLI / MCP),
-  GitHub Issues (`gh issue edit`).
-- Do NOT move the PRD/SPEC to an archive folder until the PR is merged.
-- Rollback plan and post-deploy monitoring notes.
-- Quality Gate checklist.
+   For interactive:
+   ```
+   Skill('babysitter:call', 'Run the product-management/prd-to-spec process with inputs: prdPath=<resolved>, featureBranch=<resolved>, contextDoc=<resolved>, archiveDir=<resolved>, failureLogPath=<resolved>, secondaryReviewer=<resolved>')
+   ```
 
-**Execution Constraints:** scope boundary, exhaustive file list,
-what does NOT change.
+   For auto / yolo:
+   ```
+   Skill('babysitter:yolo', '<same instruction as above>')
+   ```
 
-### Phase 3 (Outer): Self-Verification
+6. **Return** the SPEC path and the execution prompt produced by the
+   process to the user.
 
-After generating the SPEC:
+## Fallback (no babysitter runtime)
 
-1. Self-review: check for internal contradictions, missing edge cases,
-   wrong line numbers, unfilled placeholders.
-2. **Plan-quality verifier (optional):** run an external/independent
-   verifier on the SPEC.
-   *Examples:* a `deep-verify-plan` skill, a `verify-plan` skill,
-   `/codex:review` on the SPEC file, a peer SPEC review.
-3. Fix any issues found.
-4. **BREAKPOINT** — present the SPEC to user for approval.
+If neither `/babysitter:call` nor `/babysitter:yolo` is available:
 
-### Phase 4 (Outer): Generate Execution Prompt
+1. Read the process source at the location above.
+2. Execute each task's agent prompt manually, in phase order.
+3. Pause at every `ctx.breakpoint(...)` for explicit user approval
+   (interactive equivalent) or skip every breakpoint (yolo equivalent),
+   matching the mode the user picked in step 4.
+4. Return the same outputs the process would have returned.
 
-After user approves the SPEC, output a short execution prompt in chat
-(NOT a file):
+## Optional Integration Hooks
 
-```text
-Read <project-context-doc> for context. Then execute the SPEC at
-<path-to-SPEC>. Execute phase-by-phase, ensuring each phase reaches
-quality score >= 0.85 before proceeding.
-```
+All flow through the process inputs (none required):
 
-The execution can be manual (engineer reads the SPEC and works through
-phases) or via an orchestrator agent.
+- **Tracker integration** — `trackerHint` input. Examples: `jira`
+  (`/jira` or `acli jira workitem update`), `linear` (CLI / MCP),
+  `gh-issues` (`gh issue edit`).
+- **Secondary reviewer** — `secondaryReviewer` input. Examples: `codex`
+  (`/codex:review`), `gemini` (`/gemini-review`), `deep-verify-plan`
+  (`/deep-verify-plan`), `peer` (notify a teammate).
+- **Pipeline framework** for Phase 3 verification — examples: Dagster,
+  Airflow, dbt, Prefect, K8s preview.
+- **UI framework** for Phase 3 verification — examples: Vite, Next,
+  Storybook.
 
-> **Orchestrator (optional):** automate phase-by-phase execution with
-> a runtime that respects breakpoints and quality gates.
-> *Examples:* a babysitter run, a claude-flow workflow, an autoclaude
-> session, a custom shell loop.
-> *Skip if:* you prefer manual execution.
+The process works end-to-end without any of them.
 
-## Optional: Failure Log Mechanism
+## Failure Log Mechanism
 
-The SPEC requires reading a project-local `failure-log.md` before each run.
-This file accumulates lessons learned from prior failed runs of the SPEC
-pipeline, so each new execution inherits patterns to avoid.
+The process reads a project-local `failure-log.md` in Phase 1 to
+internalize lessons from prior failed runs. Setup:
 
-### Setup (one-time)
+- Cross-project lessons: `~/.claude/skills/<your-namespace>/failure-log.md`
+- Project-specific lessons: `<repo-root>/.claude/failure-log.md`
 
-Create the file in either:
-
-- `~/.claude/skills/<your-namespace>/failure-log.md` — for cross-project
-  lessons that follow you everywhere.
-- `<repo-root>/.claude/failure-log.md` — for project-specific lessons that
-  travel with the repo.
-
-### Format
-
-A single markdown file. Each entry follows this template:
+Each entry follows:
 
 ```markdown
 ### [YYYY-MM-DD] <short-pattern-name>
@@ -254,58 +114,29 @@ A single markdown file. Each entry follows this template:
 **Constraint going forward:** <the binding rule for future runs>
 ```
 
-### When to write to it
-
-After any phase failure, code-review escalation, or production rollback —
-add an entry. The next SPEC run will read it as part of Phase 1 and treat
-each pattern as a binding constraint, not a suggestion.
-
-### When to read it
-
-Phase 1 of every SPEC execution. The first numbered step in Phase 1 must be:
-"Read `failure-log.md` and internalize all patterns as binding constraints."
-If the file doesn't exist yet, that's fine — skip and note "no prior
-failures recorded."
+If the file doesn't exist, the process notes "no prior failures recorded"
+and continues.
 
 ## Pre-Push Personal Docs Check
 
-Personal/working documents often slip into commits — this gate catches them.
+The process executes this gate as part of Phase 7 (Deliver) of the
+generated SPEC. Procedure:
 
-**Procedure:**
-
-1. **List candidates** — run `git diff --name-only origin/<base-branch>...HEAD`
-   to see every file changing in the push.
-
-2. **Classify each file** as one of:
-   - `legitimate` — real product change, ship it.
-   - `personal-doc` — working note, scratch file, AI-generated planning
-     artifact.
-   - `ambiguous` — unclear, requires human judgment.
-
-3. **Common personal-doc patterns** (block by default):
-   - `SPEC*.md`, `PRD*.md`, `HANDOFF*.md`, `SUMMARY*.md`, `*-NOTES.md`
-   - Anything under `docs/plans/`, `ai_docs/`, `.claude/scratch/`, `tmp/`
-   - Files named like `investigation-*`, `analysis-*`, `playbook-*`
-   - AI-generated plans/specs not explicitly approved for shipping
-
-4. **Block-and-ask gate** — present blocked files to the user. For each
-   one, require an explicit decision:
-   - `unstage` — remove from this push (`git reset HEAD <file>`).
-   - `keep` — yes, intentionally part of the change.
-   - `gitignore` — add to `.gitignore` and unstage.
-
-   Do NOT skip this step even if the user is in a hurry. The cost of one
-   leaked working doc is much higher than the 30 seconds of friction.
-
-5. After all blocked files are resolved, proceed with the push.
+1. List candidates: `git diff --name-only origin/<base-branch>...HEAD`
+2. Classify each file: `legitimate` / `personal-doc` / `ambiguous`
+3. Block by default for: `SPEC*.md`, `PRD*.md`, `HANDOFF*.md`,
+   `SUMMARY*.md`, `*-NOTES.md`, anything under `docs/plans/`, `ai_docs/`,
+   `.claude/scratch/`, `tmp/`, `investigation-*`, `analysis-*`,
+   `playbook-*`, AI-generated plans/specs not explicitly approved.
+4. Block-and-ask gate: per-file decision of `unstage` / `keep` /
+   `gitignore`. Do NOT skip even if rushed.
+5. Proceed with push only after all blocked files are resolved.
 
 ## Rules
 
-- The SPEC must be proportional to the task. A 1-line change gets a concise
-  SPEC. A multi-layer refactor gets a detailed one.
-- Every phase MUST have a Quality Gate checklist.
-- Previous SPECs are inspiration, not templates. Adapt to the task.
-- All clarification questions to the user follow this format: short
-  explanation of what's unclear + why it matters + recommendation +
-  2-4 options.
-- Do NOT implement anything. This skill only produces the SPEC file.
+- The skill itself does not produce the SPEC. It only sets up inputs
+  and dispatches to the process via `/babysitter:call` or `/babysitter:yolo`.
+- Default to `/babysitter:call` (interactive) when in doubt.
+- Never bypass user-approval breakpoints in interactive mode — they
+  are first-class in the process.
+- The SPEC must be proportional to the task (the process honors this).

--- a/library/specializations/product-management/skills/task-to-prd/SKILL.md
+++ b/library/specializations/product-management/skills/task-to-prd/SKILL.md
@@ -1,178 +1,129 @@
 ---
 name: task-to-prd
-description: "Convert a raw task (tracker ticket, email, or text) into a fully characterized PRD via Five Whys + interactive clarification + adversarial review. Stack-agnostic with optional integration hooks."
+description: "Convert a raw task (tracker ticket, email, or text) into a fully characterized PRD. User-facing entry point that dispatches to the task-to-prd babysitter process via /babysitter:call (interactive) or /babysitter:yolo (auto). Stack-agnostic."
 author: Yehuda Yungstein
 ---
 
 # Task to PRD Generator
 
-Convert an unrefined task into a production-ready PRD through interactive
-clarification, automated codebase verification, and user-gated refinement.
+User-facing entry point for the task → PRD pipeline. The user runs
+`/task-to-prd` and this skill dispatches to the companion babysitter
+process via `/babysitter:call` (interactive — Five Whys, clarification
+loop, scope-lock, per-finding gates, final approval) or
+`/babysitter:yolo` (non-interactive, auto-approve every gate).
 
-This skill is **stack-agnostic**. Tracker integrations, code-review tools,
-and external verifiers are all wrapped as **Optional Hooks** — the skill
-works end-to-end without any of them.
+## Usage
 
-The output is a PRD file ready to be consumed by `/prd-to-spec`.
+```
+/task-to-prd <tracker-id | file-path | inline-text>
+```
 
-## Input Sources
+Examples:
+- `/task-to-prd JIRA-1234`
+- `/task-to-prd path/to/email.txt`
+- `/task-to-prd "Eden asked to change the donut to show lessons"` (inline)
 
-Accept one of:
+## Companion process
 
-- **Tracker ticket ID:** `/task-to-prd <ticket-id>` — fetched via your
-  tracker integration (see Optional Hook in Phase 1).
-  *Examples:* `JIRA-1234`, `LIN-456`, `gh-issue-789`.
-- **Text description:** `/task-to-prd "Change the dashboard donut to show
-  lessons instead of points"`
-- **File path:** `/task-to-prd path/to/email.txt`
+- Library path: `library/specializations/product-management/task-to-prd.js`
+- Locally installed: `~/.a5c/processes/task-to-prd.js`
 
-## Optional Hook Pattern
+The process file is the source of truth for the pipeline. This skill
+intentionally stays thin so users only need to remember `/task-to-prd`.
 
-Every external-tool integration follows this template:
+## What this skill does when invoked
 
-> **<Capability> (optional):** <one-line description of what this step achieves>.
-> *Examples:* <2-4 concrete examples mixing ecosystems>.
-> *Skip if:* <when this step doesn't apply>.
+1. **Parse input** — detect whether it's a tracker ticket ID, a file
+   path, or inline text.
+2. **Infer `featureBranch`** — read the current git branch via
+   `git branch --show-current`. If unsuitable (e.g., `main`), ask the
+   user to provide a feature-branch name.
+3. **Detect optional inputs** from the project context:
+   - `contextDoc` — project conventions doc (default `CLAUDE.md`)
+   - `archiveDir` — past PRD archive directory (default empty)
+   - `trackerHint` — hint like `jira`, `linear`, `gh-issues` (default empty)
+   - `secondaryReviewer` — hint like `codex`, `gemini`, `peer` (default empty)
+4. **Ask the user to pick the run mode:**
 
-## Execution
+   > Run mode for the babysitter `task-to-prd` process:
+   >
+   > 1. **Interactive (`/babysitter:call`)** — recommended. The Five
+   >    Whys + clarification loop is intrinsically interactive — every
+   >    question goes through the user. Verification findings each get
+   >    a per-finding approval gate.
+   > 2. **Auto / yolo (`/babysitter:yolo`)** — non-interactive. Skips
+   >    the clarification loop (uses defaults from Five Whys), auto-
+   >    approves every gate, applies all proposed PRD changes
+   >    automatically. Use only when the input is already well-defined
+   >    and you want a fast first draft.
 
-### Phase 1: Clarification (Interactive)
+   Default to option 1 if the user does not respond.
 
-1. **Load source:**
-   - If input is a tracker ticket ID → fetch summary, description, and
-     comments via your tracker integration (see Optional Hook below).
-   - If input is a file path → read the file.
-   - If input is inline text → use as-is.
+5. **Dispatch** by invoking the chosen babysitter command via the Skill tool:
 
-   > **Tracker fetch (optional):** retrieve the ticket's full content
-   > (summary, description, comments, linked issues) without creating
-   > a new ticket.
-   > *Examples:* Jira via a `/jira` skill or `acli jira workitem view`,
-   > Linear via `linear-cli` or MCP, GitHub Issues via `gh issue view`.
-   > *Skip if:* input is plain text or a local file.
-
-2. **Read project context:**
-   - Your project's primary context document (e.g., `CLAUDE.md`,
-     `AGENTS.md`, top-level README).
-   - Your archive of previous PRDs (if maintained) for style inspiration —
-     never as a rigid template.
-
-3. **Five Whys** — dig into the root cause before jumping to a solution:
-   - Why is this a problem?
-   - Why does it happen?
-   - Why was it not caught earlier?
-   - Why does the current design allow it?
-   - Why is the proposed solution the right one (if one was proposed)?
-
-4. **Interactive clarification** — ask questions one at a time using your
-   harness's interactive Q&A mechanism (e.g., `AskUserQuestion`):
-   - Each question follows this format: short explanation of what's
-     unclear + why it matters + recommendation + 2-4 options.
-   - The user may answer directly OR say "I'll ask <stakeholder>" — then
-     wait; the user will paste the answer back.
-   - Track every Q&A in a running **Decision Log** with attribution.
-
-5. **Scope detection** — identify which layers the task affects
-   (data-pipeline, backend, frontend, infra, docs).
-
-6. **BREAKPOINT — Scope Lock:** before writing anything, present:
-   - Summary of the problem.
-   - Proposed scope (files, layers).
-   - Known constraints.
-   - Decision Log so far.
-
-   **Wait for explicit user approval** before proceeding to Phase 2.
-
-### Phase 2: PRD Draft (Automatic)
-
-1. **Parallel codebase scan** — launch one subagent per affected layer.
-   Each one reads the files relevant to the locked scope and reports back.
-   *Example layer splits:* data-pipeline, backend, frontend, infra.
-
-2. **Draft PRD** at `<your-tasks-dir>/<feature-branch>-PRD.md` with
-   these sections:
-   - Background (including Five Whys findings)
-   - Root Cause
-   - Agreed Solution
-   - Scope (exhaustive file list by layer)
-   - Edge Cases
-   - Technical Constraints
-   - Data Flow (if applicable)
-   - **Decision Log** — every Q&A from Phase 1 with attribution
-     (user / `<stakeholder name>` such as product owner, tech lead,
-     designer)
-   - Definition of Done
-   - Open Questions (if any remain)
-
-### Phase 3: Automated Verification (with User Gates)
-
-Run these checks in order. **ANY proposed change to the PRD requires a
-BREAKPOINT** with user approval showing: old text, new text, reason,
-recommendation.
-
-1. **"What could go wrong" analysis** — examine:
-   - Downstream consumers affected.
-   - Hidden dependencies.
-   - Edge cases not covered.
-   - Rollback complexity.
-
-2. **Codebase consistency check** — verify PRD claims against actual code
-   (file paths, line numbers, identifiers, signatures, etc.).
-
-3. **Conventions check** — verify against your project's conventions
-   document (e.g., `CLAUDE.md`, `CONTRIBUTING.md`, project style guide).
-
-4. **Adversarial review** — one subagent tries to find flaws in the
-   proposed solution; another defends or refines.
-
-5. **Quality checklist** — auto-generate a quality checklist for the PRD
-   (completeness, clarity, testability, consistency) and validate.
-
-6. **Independent external PRD reviewer (optional):** run an external
-   reviewer that hasn't seen the drafting context.
-   *Examples:* Codex CLI (`/codex:review --wait` or equivalent), Gemini
-   (`/gemini-review`), peer review from a teammate.
-   *Skip if:* you don't have a secondary reviewer available.
-
-7. For EVERY finding that suggests a change:
-   - **BREAKPOINT** showing: finding, current PRD text, proposed change,
-     recommendation.
-   - Wait for user approval (approve / reject / modify).
-   - Apply only approved changes.
-
-### Phase 4: Finalize
-
-1. **BREAKPOINT — Final PRD Review:** present the complete PRD to the
-   user for final approval.
-
-2. After approval:
-   - **Tracker update (optional):** if input was a tracker ticket,
-     update its description with a reference to the PRD file path.
-     If input was text/file and no ticket exists, ask whether to create
-     one.
-     *Examples:* Jira (`/jira` or `acli`), Linear (CLI / MCP),
-     GitHub Issues (`gh issue edit` / `gh issue create`).
-     *Skip if:* you don't track tasks in an external system.
-   - **Project status update (optional):** append a "PRD created" entry
-     to your status / changelog file if you maintain one.
-
-3. **Output in chat** (NOT a file) — a short follow-up prompt to convert
-   the PRD into a SPEC:
-
-   ```text
-   Read <project-context-doc> for context. Then run /prd-to-spec <path-to-PRD>
+   For interactive:
    ```
+   Skill('babysitter:call', 'Run the product-management/task-to-prd process with inputs: input=<resolved>, featureBranch=<resolved>, contextDoc=<resolved>, archiveDir=<resolved>, trackerHint=<resolved>, secondaryReviewer=<resolved>')
+   ```
+
+   For auto / yolo:
+   ```
+   Skill('babysitter:yolo', '<same instruction as above>')
+   ```
+
+6. **Return** the PRD path, the Decision Log, and the follow-up
+   `/prd-to-spec` prompt produced by the process to the user.
+
+## Fallback (no babysitter runtime)
+
+If neither `/babysitter:call` nor `/babysitter:yolo` is available:
+
+1. Read the process source at the location above.
+2. Execute each task's agent prompt manually, in phase order.
+3. Pause at every `ctx.breakpoint(...)` for explicit user approval
+   (interactive equivalent) or skip every breakpoint (yolo equivalent),
+   matching the mode the user picked in step 4.
+4. Return the same outputs the process would have returned.
+
+## Optional Integration Hooks
+
+All flow through the process inputs (none required):
+
+- **Tracker integration** — `trackerHint` input. Examples: Jira
+  (`/jira` skill or `acli jira workitem view`), Linear (CLI / MCP),
+  GitHub Issues (`gh issue view`).
+- **Secondary reviewer** — `secondaryReviewer` input. Examples: Codex
+  (`/codex:review`), Gemini (`/gemini-review`), `deep-verify-plan`
+  (`/deep-verify-plan`), `peer` (notify a teammate).
+- **Stakeholder attribution** — the Decision Log records each Q&A with
+  attribution to `user` or a named stakeholder (e.g., product owner,
+  tech lead, designer).
+
+The process works end-to-end without any of them.
+
+## Pipeline shape (executed by the process)
+
+| Phase | What happens | Interactive in `/babysitter:call`? |
+|-------|--------------|-----------------------------------|
+| 1a. Load source | Detect tracker / file / inline | no |
+| 1b. Five Whys | Root-cause analysis | no |
+| 1c. Clarification loop | Q&A one at a time | YES |
+| 1d. Scope Lock | Approve scope before drafting | YES |
+| 2. Draft (parallel) | Codebase scan + draft PRD via embedded skill instructions | no |
+| 3a. Verification (5 parallel) | what-could-go-wrong + consistency + conventions + adversarial + quality checklist | no |
+| 3b. Per-finding gate | Approve each proposed PRD change | YES |
+| 4a. Final review | Approve final PRD | YES |
+| 4b. Tracker update | Push reference to tracker (if applicable) | no |
+| 4c. Follow-up prompt | Output `/prd-to-spec <path>` | no |
+
+In `/babysitter:yolo` mode, every gate marked YES is auto-approved.
 
 ## Rules
 
-- Phase 1 and Phase 4 are 100% under user control (interactive).
-- Phase 2 is fully automatic (no questions).
-- Phase 3 is automatic BUT pauses on every proposed change.
-- All clarification questions follow the format: short explanation +
-  why it matters + recommendation + 2-4 options.
-- Never modify the PRD silently — every change needs user approval.
-- Do NOT create a SPEC. That's `/prd-to-spec`.
-- Do NOT move the PRD to an archive folder until the PR for it is merged.
-- The PRD must be proportional to the task. A 1-line fix gets a concise
-  PRD; a multi-layer feature gets a detailed one.
-- Previous PRDs are inspiration, not templates.
+- The skill itself does not produce the PRD. It only sets up inputs
+  and dispatches to the process via `/babysitter:call` or `/babysitter:yolo`.
+- Default to `/babysitter:call` (interactive) when in doubt.
+- Phase 1 (clarification) is the most user-intensive — yolo mode
+  effectively turns it into a shallow first-draft using only Five-Whys
+  defaults. Recommend interactive mode for any non-trivial task.
+- The PRD must be proportional to the task size (the process honors this).

--- a/library/specializations/product-management/task-to-prd.js
+++ b/library/specializations/product-management/task-to-prd.js
@@ -1,13 +1,12 @@
 /**
  * @process product-management/task-to-prd
- * @description Orchestrate conversion of a raw task (tracker ticket / file / inline text) into a fully characterized PRD via interactive clarification, automated verification, and user-gated refinement. Stack-agnostic. Wraps the task-to-prd skill.
- * @skill task-to-prd library/specializations/product-management/skills/task-to-prd/SKILL.md
+ * @description Orchestrate conversion of a raw task (tracker ticket / file / inline text) into a fully characterized PRD via interactive clarification, automated verification, and user-gated refinement. Stack-agnostic. Self-contained — the task-to-prd skill dispatches here via /babysitter:call or /babysitter:yolo.
  * @inputs { input: string, featureBranch: string, contextDoc?: string, archiveDir?: string, trackerHint?: string, secondaryReviewer?: string, requireFinalApproval?: boolean }
  * @outputs { success: boolean, prdPath: string, decisionLog: array, followupPrompt: string, summary: string }
  *
  * Phases:
  * 1. Clarification (interactive) - load source, Five Whys, interactive Q&A, scope-lock breakpoint
- * 2. Draft (automatic) - parallel codebase scan + draft PRD via the task-to-prd skill
+ * 2. Draft (automatic) - parallel codebase scan + draft PRD inline (full instructions embedded in agent prompt)
  * 3. Verification (with user gates) - what-could-go-wrong, consistency, conventions, adversarial, quality checklist, optional secondary reviewer; every proposed change goes through a per-finding breakpoint
  * 4. Finalize - final review breakpoint, optional tracker update, emit follow-up prompt
  */
@@ -53,7 +52,7 @@ export async function process(inputs, ctx) {
     rawTask: sourceLoad.rawTask
   });
 
-  // Interactive clarification — handed to the user; the task-to-prd skill drives the Q&A loop
+  // Interactive clarification — handed to the user via the harness Q&A mechanism
   const clarification = await ctx.breakpoint({
     question: [
       'Interactive Clarification phase begins now.',
@@ -61,7 +60,7 @@ export async function process(inputs, ctx) {
       `**Task summary:** ${sourceLoad.summary || sourceLoad.rawTask?.slice(0, 200)}`,
       `**Five Whys gaps:** ${(fiveWhys.openQuestions || []).length} open question(s)`,
       '',
-      'The task-to-prd skill will ask one question at a time (explanation + recommendation + 2-4 options). You may answer directly or say "I will ask <stakeholder>" — paste their answer back when ready.',
+      'The clarification loop will ask one question at a time (explanation + recommendation + 2-4 options). You may answer directly or say "I will ask <stakeholder>" — paste their answer back when ready.',
       '',
       'Approve to start the clarification loop, or reject to cancel.'
     ].join('\n'),
@@ -101,7 +100,7 @@ export async function process(inputs, ctx) {
   // PHASE 2: DRAFT (AUTOMATIC)
   // ============================================================================
 
-  ctx.log('info', 'Phase 2: Drafting PRD via task-to-prd skill');
+  ctx.log('info', 'Phase 2: Drafting PRD');
 
   const [scanResult, draftResult] = await ctx.parallel.all([
     () => ctx.task(codebaseScanTask, { scope: decisionLog.scope, contextDoc }),
@@ -307,20 +306,21 @@ export const fiveWhysTask = defineTask('five-whys', (args, taskCtx) => ({
 
 export const clarificationLoopTask = defineTask('clarification-loop', (args, taskCtx) => ({
   kind: 'agent',
-  title: 'Interactive clarification loop (driven by task-to-prd skill)',
+  title: 'Interactive clarification loop',
   agent: {
     name: 'general-purpose',
     prompt: {
-      role: 'Clarification-loop driver invoking the task-to-prd skill',
+      role: 'Clarification-loop driver running an interactive Q&A pass',
       task: 'Run the interactive clarification loop. Ask one question at a time, in English, with explanation + recommendation + 2-4 options. Track every Q&A in a Decision Log with attribution.',
       context: { rawTask: args.rawTask, fiveWhys: args.fiveWhys, contextDoc: args.contextDoc },
       instructions: [
-        'Invoke the task-to-prd skill (via the Skill tool) to drive the clarification loop — Phase 1 of the skill',
-        'Use the harness Q&A mechanism (e.g., AskUserQuestion) for each question',
-        'User may answer directly OR say "I will ask <stakeholder>" — wait for them to paste back the answer',
-        'Continue until all open questions from the Five Whys are resolved (or the user explicitly closes them as out-of-scope)',
-        'Detect scope: which layers are affected (data-pipeline, backend, frontend, infra, docs)',
-        'Maintain a running Decision Log: each entry has question, answer, attribution (user / <stakeholder name>)'
+        'Use the harness interactive Q&A mechanism (e.g., AskUserQuestion). Ask one question at a time.',
+        'Each question MUST include: short explanation of what is unclear + why it matters + recommendation + 2-4 options. Language: English.',
+        'Iterate over the open questions from the Five Whys analysis until all are resolved or explicitly marked out-of-scope by the user',
+        'User may answer directly OR say "I will ask <stakeholder>" — wait for them to paste back the answer; tag the entry with that stakeholder in the Decision Log',
+        'Detect scope as a side-effect: which layers are affected (data-pipeline, backend, frontend, infra, docs)',
+        'Maintain a running Decision Log: each entry has question, answer, attribution (user / <stakeholder name>)',
+        'When all questions are resolved, summarize: problem summary, scope, constraints, decision-log entries, any remaining open questions'
       ],
       outputFormat: 'JSON with keys: problemSummary (string), scope (array of strings), constraints (array of strings), entries (array of {question, answer, attribution}), openQuestions (array of strings)'
     },
@@ -337,7 +337,7 @@ export const clarificationLoopTask = defineTask('clarification-loop', (args, tas
     }
   },
   io: { inputJsonPath: `tasks/${taskCtx.effectId}/input.json`, outputJsonPath: `tasks/${taskCtx.effectId}/result.json` },
-  labels: ['agent', 'phase-1', 'clarification', 'invokes-skill']
+  labels: ['agent', 'phase-1', 'clarification']
 }));
 
 export const codebaseScanTask = defineTask('codebase-scan', (args, taskCtx) => ({
@@ -372,12 +372,12 @@ export const codebaseScanTask = defineTask('codebase-scan', (args, taskCtx) => (
 
 export const draftPrdTask = defineTask('draft-prd', (args, taskCtx) => ({
   kind: 'agent',
-  title: 'Draft PRD via task-to-prd skill',
+  title: 'Draft PRD file',
   agent: {
     name: 'general-purpose',
     prompt: {
-      role: 'PRD drafter wrapping the task-to-prd Claude Code skill',
-      task: 'Invoke the task-to-prd skill (via the Skill tool) to draft the PRD file using clarification + scope-lock results. Return the absolute PRD file path.',
+      role: 'PRD author writing a production-ready PRD from clarification and scope-lock results',
+      task: `Generate a PRD file at <tasks-dir>/${args.featureBranch}-PRD.md using the Decision Log, Five Whys analysis, and codebase context. Return the absolute PRD path.`,
       context: {
         input: args.input,
         featureBranch: args.featureBranch,
@@ -387,11 +387,24 @@ export const draftPrdTask = defineTask('draft-prd', (args, taskCtx) => ({
         fiveWhys: args.fiveWhys
       },
       instructions: [
-        'Invoke the task-to-prd skill — Phase 2 (PRD Draft)',
-        `Output path: <tasks-dir>/${args.featureBranch}-PRD.md (the skill resolves the tasks-dir from project conventions)`,
-        'PRD sections must include: Background (with Five Whys), Root Cause, Agreed Solution, Scope (exhaustive file list), Edge Cases, Technical Constraints, Data Flow (if applicable), Decision Log (with attribution), Definition of Done, Open Questions',
-        'PRD must be proportional to the task size',
-        'Do NOT create a SPEC — only a PRD'
+        'The PRD must contain these top-level sections in order:',
+        '  1. **Background** — include the Five Whys findings verbatim',
+        '  2. **Root Cause** — distilled from the Five Whys',
+        '  3. **Agreed Solution** — the locked scope from the Decision Log',
+        '  4. **Scope** — exhaustive file list by layer (data-pipeline / backend / frontend / infra / docs as applicable)',
+        '  5. **Edge Cases** — every edge case raised during clarification or risk analysis',
+        '  6. **Technical Constraints** — performance, security, compatibility, integration',
+        '  7. **Data Flow** (if applicable) — diagram or step-by-step description',
+        '  8. **Decision Log** — every Q&A from the clarification loop with attribution (user / <stakeholder name>)',
+        '  9. **Definition of Done** — testable, exhaustive checklist',
+        '  10. **Open Questions** — any clarifications that remain unresolved',
+        'The PRD must be proportional to the task size — concise for a 1-line fix, detailed for a multi-layer feature',
+        `Resolve the tasks-dir from project conventions (read ${args.contextDoc}); fall back to docs/active/ if unspecified`,
+        args.archiveDir
+          ? `Reference style from previous PRDs in ${args.archiveDir} for inspiration only — never as a rigid template`
+          : 'No PRD archive configured — write fresh',
+        'Do NOT create a SPEC — only a PRD. The /prd-to-spec skill is the next step.',
+        'Return the absolute PRD file path; if there is a hard error, report it without silent continuation'
       ],
       outputFormat: 'JSON with keys: prdPath (string), generatedSections (array of strings)'
     },
@@ -405,7 +418,7 @@ export const draftPrdTask = defineTask('draft-prd', (args, taskCtx) => ({
     }
   },
   io: { inputJsonPath: `tasks/${taskCtx.effectId}/input.json`, outputJsonPath: `tasks/${taskCtx.effectId}/result.json` },
-  labels: ['agent', 'phase-2', 'draft-prd', 'invokes-skill']
+  labels: ['agent', 'phase-2', 'draft-prd']
 }));
 
 export const whatCouldGoWrongTask = defineTask('what-could-go-wrong', (args, taskCtx) => ({


### PR DESCRIPTION
## Why

Restructures the prd-to-spec / task-to-prd architecture so the **skill is the user-facing entry point** and the **babysitter process holds the implementation**. Previously the process orchestrated phases that themselves invoked the skill (circular). Now the flow is one-way:

\`\`\`
user types /prd-to-spec
  → skill (thin wrapper) parses inputs and asks "interactive or yolo?"
  → skill dispatches via Skill('babysitter:call', ...) or Skill('babysitter:yolo', ...)
  → process drives all phases with breakpoints
  → user gets the SPEC + execution prompt
\`\`\`

## Files modified

- \`library/specializations/product-management/skills/prd-to-spec/SKILL.md\` — replaced with thin dispatch (~140 lines)
- \`library/specializations/product-management/skills/task-to-prd/SKILL.md\` — replaced with thin dispatch (~130 lines)
- \`library/specializations/product-management/prd-to-spec.js\` — \`generateSpecTask\` now embeds full SPEC structure in its agent prompt instead of delegating back to the skill
- \`library/specializations/product-management/task-to-prd.js\` — \`clarificationLoopTask\` and \`draftPrdTask\` now embed full instructions instead of delegating back to the skill

Net diff: 4 files, +273/-466 lines (skills shrink, processes slightly grow due to inlined instructions).

## Two run modes

The skill prompts the user to choose:

1. **\`/babysitter:call\`** (interactive) — recommended. Pauses at every breakpoint (clarification loop, scope-lock, per-finding gate, final approval).
2. **\`/babysitter:yolo\`** (auto-approve) — non-interactive. Use only when input is well-defined and you want a fast first draft.

## Companion

Same refactor going to deedeeharris/claude-skills#5 (community fork) so both distribution paths stay aligned. Companion to the merged PRs #154 (skills) and #155 (processes).

## Test plan

- [ ] Pull this branch and run \`/prd-to-spec docs/some-PRD.md\` — verify the skill asks for call/yolo and dispatches
- [ ] Run \`/babysitter:call\` directly with the same args — verify it produces the same result (skill is just a UX layer)
- [ ] Run \`/task-to-prd "test task"\` — verify Five Whys + clarification breakpoint sequence in call mode
- [ ] Verify yolo mode skips all breakpoints and produces a viable first draft
- [ ] Verify the fallback procedure in the SKILL.md works in environments without the babysitter runtime