### PR TITLE
Set Pi session env for babysitter binding

### DIFF
--- a/packages/agent-plugins-mux/src/__tests__/e2e.test.ts
+++ b/packages/agent-plugins-mux/src/__tests__/e2e.test.ts
@@ -259,6 +259,10 @@ describe('e2e: sample plugin compilation', () => {
         path.join(result.outputDir, 'extensions/index.ts'), 'utf-8'
       );
       expect(ext).toContain('@mariozechner/pi-coding-agent');
+      expect(ext).toContain('ExtensionContext');
+      expect(ext).toContain('process.env.PI_SESSION_ID = sessionId');
+      expect(ext).toContain('const forwardBabysit = async (args: unknown, ctx?: ExtensionContext)');
+      expect(ext).toContain('runProxiedHook("babysitter-proxied-session-start.js", sessionStartInput(ctx))');
       expect(ext).toContain('"help"');
       expect(ext).toContain('"status"');
       expect(result.emittedFiles).toContain('AGENTS.md');

--- a/plugins/babysitter-unified/per-harness/pi/extensions-index.ts
+++ b/plugins/babysitter-unified/per-harness/pi/extensions-index.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { execSync } from "child_process";
 import * as path from "path";
 
@@ -24,6 +24,26 @@ const COMMANDS = [
 
 function toSkillPrompt(name: string, args: string): string {
   return `/skill:${name}${args ? ` ${args}` : ""}`;
+}
+
+function syncSessionEnvironment(ctx?: ExtensionContext): string | undefined {
+  const sessionId = ctx?.sessionManager.getSessionId();
+  if (sessionId) {
+    process.env.PI_SESSION_ID = sessionId;
+    process.env.BABYSITTER_SESSION_ID = sessionId;
+  }
+
+  process.env.PI_PLUGIN_ROOT = PLUGIN_ROOT;
+  return sessionId;
+}
+
+function sessionStartInput(ctx?: ExtensionContext): Record<string, unknown> {
+  const sessionId = syncSessionEnvironment(ctx);
+  return {
+    event: "session_start",
+    cwd: ctx?.cwd ?? process.cwd(),
+    ...(sessionId ? { session_id: sessionId } : {}),
+  };
 }
 
 /**
@@ -53,18 +73,21 @@ function runProxiedHook(
 }
 
 export default function activate(pi: ExtensionAPI): void {
-  // ---------------------------------------------------------------------------
-  // Trigger session-start hook on activation
-  // ---------------------------------------------------------------------------
-  runProxiedHook("babysitter-proxied-session-start.js", {
-    event: "session_start",
-    cwd: process.cwd(),
+  pi.on("session_start", async (_event, ctx) => {
+    runProxiedHook("babysitter-proxied-session-start.js", sessionStartInput(ctx));
   });
+
+  // ---------------------------------------------------------------------------
+  // Ensure package root is visible even before Pi emits session_start.
+  // The concrete session id is refreshed from session_start and command contexts.
+  // ---------------------------------------------------------------------------
+  syncSessionEnvironment();
 
   // ---------------------------------------------------------------------------
   // Register slash commands (unchanged from legacy)
   // ---------------------------------------------------------------------------
-  const forwardBabysit = async (args: unknown) => {
+  const forwardBabysit = async (args: unknown, ctx?: ExtensionContext) => {
+    syncSessionEnvironment(ctx);
     pi.sendUserMessage(toSkillPrompt("babysit", String(args ?? "").trim()));
   };
 
@@ -79,7 +102,8 @@ export default function activate(pi: ExtensionAPI): void {
   });
 
   for (const name of COMMANDS) {
-    const forward = async (args: unknown) => {
+    const forward = async (args: unknown, ctx?: ExtensionContext) => {
+      syncSessionEnvironment(ctx);
       pi.sendUserMessage(toSkillPrompt(name, String(args ?? "").trim()));
     };
 


### PR DESCRIPTION
## Summary

- Export the active Pi session ID as `PI_SESSION_ID` and `BABYSITTER_SESSION_ID` during the Babysitter Pi extension `session_start` event.
- Export `PI_PLUGIN_ROOT` from the installed extension location.
- Add an integration test assertion so the Pi package keeps exposing the session-binding env names required by `run:create --harness pi`.

## Why

Without these env vars, `babysitter run:create --harness pi` creates a run but reports `Pi should provide PI_SESSION_ID when the Babysitter package is active`, so session binding is not established from Pi.

## Validation

- `cd plugins/babysitter-pi && npm test`