### PR TITLE
Localize Pi command palette strings

### DIFF
--- a/plugins/babysitter-pi/extensions/i18n.ts
+++ b/plugins/babysitter-pi/extensions/i18n.ts
@@ -1,0 +1,60 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+type Params = Record<string, string | number>;
+type Translate = (key: string, fallback: string, params?: Params) => string;
+
+let translate: Translate = (_key, fallback, params) => format(fallback, params);
+
+function format(text: string, params?: Params): string {
+  if (!params) return text;
+  return text.replace(/\{(\w+)\}/g, (_match, key: string) => String(params[key] ?? `{${key}}`));
+}
+
+export function t(key: string, fallback: string, params?: Params): string {
+  return translate(key, fallback, params);
+}
+
+const bundles = [
+  {
+    locale: "ja",
+    namespace: "babysitter-pi",
+    messages: {
+      "cmd.babysit.description": "Babysitter のオーケストレーションスキルを読み込む",
+      "cmd.babysitter.description": "/babysit のエイリアス",
+      "cmd.skill.description": "Babysitter の {name} スキルを開く",
+      "cmd.skill.alias": "/{name} のエイリアス",
+    },
+  },
+  {
+    locale: "zh-CN",
+    namespace: "babysitter-pi",
+    messages: {
+      "cmd.babysit.description": "加载 Babysitter 编排技能",
+      "cmd.babysitter.description": "/babysit 的别名",
+      "cmd.skill.description": "打开 Babysitter {name} 技能",
+      "cmd.skill.alias": "/{name} 的别名",
+    },
+  },
+  {
+    locale: "es",
+    namespace: "babysitter-pi",
+    messages: {
+      "cmd.babysit.description": "Cargar la skill de orquestación de Babysitter",
+      "cmd.babysitter.description": "Alias de /babysit",
+      "cmd.skill.description": "Abrir la skill {name} de Babysitter",
+      "cmd.skill.alias": "Alias de /{name}",
+    },
+  },
+];
+
+export function initI18n(pi: ExtensionAPI): void {
+  const events = pi.events;
+  if (!events) return;
+  for (const bundle of bundles) events.emit("pi-core/i18n/registerBundle", bundle);
+  events.emit("pi-core/i18n/requestApi", {
+    namespace: "babysitter-pi",
+    callback(api: { t?: Translate } | undefined) {
+      if (typeof api?.t === "function") translate = api.t;
+    },
+  });
+}

--- a/plugins/babysitter-pi/extensions/index.ts
+++ b/plugins/babysitter-pi/extensions/index.ts
@@ -1,4 +1,5 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { initI18n, t } from "./i18n.js";
 
 const COMMANDS = [
   "assimilate",
@@ -23,17 +24,18 @@ function toSkillPrompt(name: string, args: string): string {
 }
 
 export default function activate(pi: ExtensionAPI): void {
+  initI18n(pi);
   const forwardBabysit = async (args: unknown) => {
     pi.sendUserMessage(toSkillPrompt("babysit", String(args ?? "").trim()));
   };
 
   pi.registerCommand("babysit", {
-    description: "Load the Babysitter orchestration skill",
+    description: t("cmd.babysit.description", "Load the Babysitter orchestration skill"),
     handler: forwardBabysit,
   });
 
   pi.registerCommand("babysitter", {
-    description: "Alias for /babysit",
+    description: t("cmd.babysitter.description", "Alias for /babysit"),
     handler: forwardBabysit,
   });
 
@@ -43,12 +45,12 @@ export default function activate(pi: ExtensionAPI): void {
     };
 
     pi.registerCommand(name, {
-      description: `Open the Babysitter ${name} skill`,
+      description: t("cmd.skill.description", `Open the Babysitter ${name} skill`, { name }),
       handler: forward,
     });
 
     pi.registerCommand(`babysitter:${name}`, {
-      description: `Alias for /${name}`,
+      description: t("cmd.skill.alias", `Alias for /${name}`, { name }),
       handler: forward,
     });
   }


### PR DESCRIPTION
The Pi package exposes most Babysitter entry points through command-palette descriptions. Those labels are the first decision point for users choosing between babysit/call/plan/resume/yolo/doctor/observe.

This PR makes that small Pi command surface optionally localizable while preserving the existing English fallbacks.

- No new dependency
- No behavior change without an i18n provider
- English remains the default/fallback
- Locales: ja, zh-CN, es
- Pi plugin extension only; skills/command docs are unchanged

Validation:
- npm pack --dry-run from plugins/babysitter-pi

Note: npm test currently fails on the existing command-doc sync check for skills/babysit/SKILL.md being stale; this PR does not touch generated skill docs.