### PR TITLE
Localize Babysitter doctor command label

### DIFF
--- a/plugins/babysitter-pi/extensions/i18n.ts
+++ b/plugins/babysitter-pi/extensions/i18n.ts
@@ -1,0 +1,45 @@
+type Locale = "en" | "es" | "fr" | "pt-BR";
+type Params = Record<string, string | number>;
+
+const translations: Record<Exclude<Locale, "en">, Record<string, string>> = {
+  es: {
+    "command.doctor.description": "Abrir el diagnóstico de Babysitter",
+    "command.doctor.aliasDescription": "Alias de /doctor",
+  },
+  fr: {
+    "command.doctor.description": "Ouvrir le diagnostic Babysitter",
+    "command.doctor.aliasDescription": "Alias de /doctor",
+  },
+  "pt-BR": {
+    "command.doctor.description": "Abrir o diagnóstico do Babysitter",
+    "command.doctor.aliasDescription": "Alias para /doctor",
+  },
+};
+
+let currentLocale: Locale = "en";
+
+export function initI18n(pi: { events?: { emit?: (event: string, payload: unknown) => void } }): void {
+  pi.events?.emit?.("pi-core/i18n/registerBundle", {
+    namespace: "babysitter-pi",
+    defaultLocale: "en",
+    locales: translations,
+  });
+  pi.events?.emit?.("pi-core/i18n/requestApi", {
+    onReady: (api: { getLocale?: () => string; onLocaleChange?: (cb: (locale: string) => void) => void }) => {
+      const locale = api.getLocale?.();
+      if (isLocale(locale)) currentLocale = locale;
+      api.onLocaleChange?.((next) => {
+        if (isLocale(next)) currentLocale = next;
+      });
+    },
+  });
+}
+
+export function t(key: string, fallback: string, params: Params = {}): string {
+  const template = currentLocale === "en" ? fallback : translations[currentLocale]?.[key] ?? fallback;
+  return template.replace(/\{(\w+)\}/g, (_, name) => String(params[name] ?? `{${name}}`));
+}
+
+function isLocale(locale: string | undefined): locale is Locale {
+  return locale === "en" || locale === "es" || locale === "fr" || locale === "pt-BR";
+}

--- a/plugins/babysitter-pi/extensions/index.ts
+++ b/plugins/babysitter-pi/extensions/index.ts
@@ -1,4 +1,5 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { initI18n, t } from "./i18n.js";
 
 const COMMANDS = [
   "assimilate",
@@ -23,6 +24,8 @@ function toSkillPrompt(name: string, args: string): string {
 }
 
 export default function activate(pi: ExtensionAPI): void {
+  initI18n(pi);
+
   const forwardBabysit = async (args: unknown) => {
     pi.sendUserMessage(toSkillPrompt("babysit", String(args ?? "").trim()));
   };
@@ -43,12 +46,16 @@ export default function activate(pi: ExtensionAPI): void {
     };
 
     pi.registerCommand(name, {
-      description: `Open the Babysitter ${name} skill`,
+      description: name === "doctor"
+        ? t("command.doctor.description", "Open the Babysitter doctor skill")
+        : `Open the Babysitter ${name} skill`,
       handler: forward,
     });
 
     pi.registerCommand(`babysitter:${name}`, {
-      description: `Alias for /${name}`,
+      description: name === "doctor"
+        ? t("command.doctor.aliasDescription", "Alias for /doctor")
+        : `Alias for /${name}`,
       handler: forward,
     });
   }


### PR DESCRIPTION
This is a smaller follow-up after I retracted the earlier over-broad localization PR. I kept this one limited to the Pi command label for the diagnostic path only.\n\nWhat changed:\n- adds a tiny local i18n helper with English fallback\n- localizes only /doctor and /babysitter:doctor command descriptions\n- registers an optional pi-core i18n bundle when available\n- includes es, fr, and pt-BR strings\n\nWhat did not change:\n- no required dependency\n- English remains the default/fallback\n- skill prompts, command forwarding, docs, and runtime behavior stay untouched\n\nValidation:\n- passed: npm pack --dry-run in plugins/babysitter-pi\n- partial: npm test passed 19/20 checks\n- blocked/existing: npm test reports stale generated skills/babysit/SKILL.md from sync-command-docs; this PR does not touch generated skill docs\n\nIf useful later, I’m happy to handle broader localization in small follow-up PRs using whatever locale set you prefer.