### PR TITLE
specializations/qa-testing-automation: add diagnostic-first-phase process snippet

### DIFF
--- a/library/specializations/qa-testing-automation/diagnostic-first-phase.js
+++ b/library/specializations/qa-testing-automation/diagnostic-first-phase.js
@@ -1,0 +1,149 @@
+/**
+ * @process specializations/qa-testing-automation/diagnostic-first-phase
+ * @description Reusable defineTask snippet for the diagnostic-first phase in
+ *   "the fix shipped but the bug recurs" patterns. Connects to a live
+ *   production DB read-only via service-role key, dumps raw evidence
+ *   (JSON + markdown summary) BEFORE any code changes.
+ *
+ * Use this as Phase A of any run that fits the recurring-bug pattern. Real
+ * example from the cookbook project: three successive theory-driven fix
+ * attempts (sentinel rows → router.refresh → set-based completeness check)
+ * each passed all mock-DB unit tests and never moved the user-visible badge.
+ * The fourth attempt led with a phase like this one and identified the
+ * actual root cause on the first artifact (PostgREST's 1000-row response
+ * cap silently truncating `.in('recipe_id', ...)` queries — a failure mode
+ * pglite-based unit tests systematically cannot reproduce).
+ *
+ * @inputs {
+ *   projectDir?: string      // defaults to process.cwd()
+ *   envFile?: string         // defaults to '.env.production.local'
+ *   outputDir?: string       // where to write diagnose.{mjs,json,md} artifacts
+ *   queries?: Array<{ name: string, description?: string, code: string }>
+ *   hypotheses?: string[]    // optional priors the LLM should evaluate
+ * }
+ * @outputs { artifacts, queries, topHypothesis, examples, recommendation }
+ *
+ * @example
+ *   import { diagnosticFirstPhaseTask } from
+ *     'specializations/qa-testing-automation/diagnostic-first-phase';
+ *   const diagnostic = await ctx.task(diagnosticFirstPhaseTask, {
+ *     envFile: '.env.production.local',
+ *     outputDir: `.a5c/runs/${ctx.runId}/artifacts`,
+ *     queries: [
+ *       { name: 'incompleteRecipes',
+ *         description: 'Recipes the badge marks pending',
+ *         code: "client.from('recipe').select('id,title').is('deleted_at',null)" },
+ *     ],
+ *     hypotheses: [
+ *       'PostgREST 1000-row cap silently truncating .in() on the join table',
+ *       'Stale framework Server Component cache after the mutation',
+ *     ],
+ *   });
+ *
+ * Contract:
+ *   - The diagnostic instantiates a service-role Supabase client from the
+ *     project's env file and runs ONLY the queries provided in `args.queries`.
+ *   - Read-only by construction: the prompt forbids UPDATE / DELETE / INSERT /
+ *     UPSERT / mutating RPCs, and the generated script must be safe to run
+ *     unattended (YOLO).
+ *   - Dumps the raw query results to `<outputDir>/diagnose.json` and an
+ *     analyst-readable Markdown summary to `<outputDir>/diagnose-summary.md`,
+ *     including a top hypothesis + one-paragraph fix recommendation.
+ *   - No code under src/, tests/, or supabase/ may be modified by Phase A.
+ */
+
+import { defineTask } from '@a5c-ai/babysitter-sdk';
+
+export const diagnosticFirstPhaseTask = defineTask('diagnostic-first-phase', (args, taskCtx) => {
+  const projectDir = args.projectDir || process.cwd();
+  const envFile = args.envFile || '.env.production.local';
+  const outputDir = args.outputDir || `.a5c/runs/${taskCtx.runId || 'unknown'}/artifacts`;
+  const queries = Array.isArray(args.queries) ? args.queries : [];
+  const hypotheses = Array.isArray(args.hypotheses) ? args.hypotheses : [];
+  const queryFragment =
+    queries.length > 0
+      ? queries
+          .map(
+            (q, i) =>
+              `  ${i + 1}. ${q.name || `query-${i + 1}`} — ${q.description || '(no description)'}\n     code: ${q.code || '(none)'}`,
+          )
+          .join('\n')
+      : '  (none provided — derive the smallest read-only queries that reproduce the user-visible discrepancy)';
+  const hypothesisFragment =
+    hypotheses.length > 0
+      ? hypotheses.map((h, i) => `  H${i + 1}. ${h}`).join('\n')
+      : '  (no priors provided — form your own from the queried data)';
+
+  return {
+    kind: 'agent',
+    title: 'Diagnostic-first Phase A: dump live production state, no code changes',
+    execution: { model: 'claude-opus-4-6' },
+    agent: {
+      name: 'general-purpose',
+      prompt: {
+        role: 'Site-reliability engineer triaging a recurring production bug from live data — read-only',
+        task: 'Instantiate a service-role Supabase client from the project env file, run the requested read-only queries, dump JSON + a markdown summary with a top hypothesis and fix recommendation. DO NOT write any production code in this phase.',
+        context: args,
+        instructions: [
+          `PROJECT DIR: ${projectDir}.`,
+          `ENV FILE: ${envFile} — must contain NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY (or the equivalent for your provider).`,
+          `OUTPUT DIR: ${outputDir} (mkdir -p if absent).`,
+          '',
+          'WHAT THIS PHASE IS FOR:',
+          '  Any "the fix shipped but the bug recurs" pattern. When test suites',
+          '  with mocked DBs/clients can\'t reproduce the production failure mode,',
+          '  the unit-test feedback loop becomes actively misleading. Trust the',
+          '  data, not the model in your head — query the live system first.',
+          '',
+          'STEP 1 — Write a one-shot Node script at ' + outputDir + '/diagnose.mjs that:',
+          '  - Loads env from ' + envFile + ' (use `node --env-file` if supported, otherwise inline-parse).',
+          '  - Imports @supabase/supabase-js and creates a service-role client (bypasses RLS).',
+          '  - Runs the queries listed under QUERIES below, each labeled by its `name`.',
+          '  - Aggregates the results into a single JSON object keyed by query name.',
+          '',
+          'QUERIES:',
+          queryFragment,
+          '',
+          'STEP 2 — Run the script and capture stdout/stderr:',
+          `  cd ${projectDir} && node ${outputDir}/diagnose.mjs > ${outputDir}/diagnose-stdout.txt 2>&1`,
+          `  Save the structured result as ${outputDir}/diagnose.json.`,
+          '',
+          'STEP 3 — Analyse and form a HYPOTHESIS. Candidate hypotheses to evaluate (from caller):',
+          hypothesisFragment,
+          '  Reject any hypothesis the data contradicts. Name the one the data supports.',
+          '',
+          'STEP 4 — Write ' + outputDir + '/diagnose-summary.md with these sections:',
+          '  - "## Counts" — totals from each query',
+          '  - "## Evidence" — up to 3 representative rows per query (JSON-formatted)',
+          '  - "## Top hypothesis" — one paragraph naming the most-likely cause and citing the rows that support it',
+          '  - "## Recommendation" — one paragraph the Phase B implementer can act on (file paths, the specific data shape to fix, the contract the fix must restore)',
+          '',
+          'CONSTRAINTS — STRICT, YOLO-SAFE:',
+          '  - READ-ONLY. The diagnose.mjs script MUST NOT contain any of: `.update(`, `.delete(`, `.insert(`, `.upsert(`, `.rpc(` with a mutating function, or any raw SQL matching `UPDATE|DELETE|INSERT|TRUNCATE|ALTER|DROP|CREATE`. Refuse to write the script if a requested query contains a write.',
+          '  - DO NOT touch src/, tests/, supabase/, scripts/, or any framework-config file.',
+          '  - DO NOT commit credentials. Service-role key stays in env.',
+          '  - If the script can\'t reach the DB (network/credentials issue), report the failure clearly and exit with `topHypothesis: "diagnostic unreachable — see notes"` rather than guessing.',
+          '',
+          'OUTPUT (return ONLY this JSON — no markdown fences, no prose):',
+          '  {',
+          `    "artifacts": ["${outputDir}/diagnose.mjs", "${outputDir}/diagnose.json", "${outputDir}/diagnose-summary.md", "${outputDir}/diagnose-stdout.txt"],`,
+          '    "queries": [<echo of the queries you ran, by name>],',
+          '    "topHypothesis": "<one-sentence root-cause hypothesis grounded in the query results>",',
+          '    "examples": [<up to 3 representative rows that motivate the hypothesis>],',
+          '    "recommendation": "<one-paragraph fix recommendation for the Phase B implementer>"',
+          '  }',
+        ],
+        outputFormat: 'JSON',
+      },
+      outputSchema: {
+        type: 'object',
+        required: ['artifacts', 'topHypothesis', 'recommendation'],
+      },
+    },
+    io: {
+      inputJsonPath: `tasks/${taskCtx.effectId}/input.json`,
+      outputJsonPath: `tasks/${taskCtx.effectId}/result.json`,
+    },
+    labels: ['diagnostic-first', 'phase-a'],
+  };
+});

--- a/library/specializations/qa-testing-automation/diagnostic-first-phase.md
+++ b/library/specializations/qa-testing-automation/diagnostic-first-phase.md
@@ -1,0 +1,93 @@
+# Diagnostic-first phase
+
+A reusable `defineTask` snippet for the recurring-bug anti-pattern, where each
+new fix attempt is informed by a hypothesis instead of by live data.
+
+## When to use it
+
+Use it as **Phase A** of any run whose prompt fits the shape
+*"we shipped a fix and the bug recurred."* Don't use it for greenfield work
+or first-attempt bug fixes — it's specifically tuned for the failure mode
+where the unit-test feedback loop has become actively misleading because the
+mock can't reproduce the production behaviour (response caps, rate limits,
+RLS, framework caches, etc.).
+
+## Anti-pattern this targets
+
+A real example: a project's test suite used an in-memory Postgres
+(pglite) for data-layer tests. The first three attempts at fixing a stuck
+"Annotate all (N)" badge each chose a plausible hypothesis (sentinel rows,
+client-side cache refresh, set-based completeness check), shipped a fix that
+passed every test gate, and never moved the user-visible count. The
+fourth attempt led with a phase like this one — querying the live
+production DB via the service-role key — and the very first artifact
+identified the actual cause: PostgREST's default 1000-row response cap was
+silently truncating `.in('recipe_id', ...)` queries. The mock DB couldn't
+reproduce it because the cap is a server-side framework default, not a
+schema constraint.
+
+## Contract
+
+- Instantiates a service-role Supabase client from the project's env file.
+- Runs **only** the queries supplied via `args.queries` (the prompt rejects
+  the script if any query contains a mutation keyword).
+- Writes three artifacts:
+  - `<outputDir>/diagnose.mjs` — the one-shot Node script (auditable).
+  - `<outputDir>/diagnose.json` — structured query results.
+  - `<outputDir>/diagnose-summary.md` — counts, evidence, hypothesis,
+    one-paragraph fix recommendation for the Phase B implementer.
+- **Read-only by construction.** Forbids `UPDATE`/`DELETE`/`INSERT`/
+  `UPSERT`/mutating `RPC` in both the generated script and the model's
+  output.
+- **Source-tree-safe.** Does not modify `src/`, `tests/`, `supabase/`,
+  `scripts/`, or framework-config files.
+
+## Usage
+
+```js
+import { diagnosticFirstPhaseTask } from
+  'specializations/qa-testing-automation/diagnostic-first-phase';
+
+export async function process(inputs, ctx) {
+  const diagnostic = await ctx.task(diagnosticFirstPhaseTask, {
+    envFile: '.env.production.local',
+    outputDir: `.a5c/runs/${ctx.runId}/artifacts`,
+    queries: [
+      {
+        name: 'incompleteRecipes',
+        description: 'Recipes the badge marks pending',
+        code: "client.from('recipe').select('id,title').is('deleted_at', null)",
+      },
+    ],
+    hypotheses: [
+      'PostgREST 1000-row response cap silently truncating .in() on the join table',
+      'Stale framework Server Component cache after the mutation',
+    ],
+  });
+
+  // diagnostic.topHypothesis + diagnostic.recommendation feed the Phase B impl.
+  // ...
+}
+```
+
+## Why upstream
+
+The "fix-and-recur" pattern is universal across web/data projects. Mock-DB
+unit tests systematically can't reproduce production response caps, rate
+limits, or framework caches. Naming the diagnostic-first phase as a
+first-class library primitive makes "start with the data" the default for
+this class of bug instead of the exception.
+
+## Adjacent reading
+
+- The `@productionContract` JSDoc convention (sibling contribution) — name
+  the user-visible assertion the run must satisfy in the process file's
+  header, so completion is gated on user-visible state, not just on test
+  pass-rate.
+
+## Provenance
+
+Discovered in the wild during a real-world Next.js + Supabase project. The
+canonical example run is on file at the contributing project under the
+process id `cookbook-annotate-pending-evidence-may-13`; this contribution
+is the generalized version of that run's `diagnoseProductionTask`.


### PR DESCRIPTION
## Summary

A reusable `defineTask` snippet for the diagnostic-first phase in **"the fix shipped but the bug recurs"** patterns. Connects to a live production DB read-only via service-role key and dumps raw evidence (JSON + markdown summary) **before** any code changes.

## Motivation

Mock-DB unit tests systematically can't reproduce production failure modes like PostgREST response caps, rate limits, or framework caches. When a fix passes every test gate yet never moves user-visible state, the unit-test feedback loop is actively misleading.

This snippet flips the order: query the live system first, form a hypothesis from data, then code.

## Real-world provenance

Discovered in the wild during a Next.js + Supabase project (`cookbook`) where three successive theory-driven fix attempts shipped clean:

1. Sentinel rows for skipped steps — passed all tests, badge still stuck
2. `router.refresh()` + actionable failures UX — passed all tests, badge still stuck
3. Set-based completeness check + orphan cleanup — passed all tests, badge still stuck

The fourth attempt led with a phase like this one and the very first artifact identified the actual cause: PostgREST's silent 1000-row `.in()` truncation, a failure mode pglite-based tests cannot reproduce.

## Contract

- **Read-only by construction.** Forbids `UPDATE` / `DELETE` / `INSERT` / `UPSERT` / mutating `RPC` in both the generated script and the model's output.
- **Source-tree-safe.** Does not modify `src/`, `tests/`, `supabase/`, `scripts/`, or framework-config files.
- Writes 3 artifacts: `diagnose.mjs` (auditable script), `diagnose.json` (structured results), `diagnose-summary.md` (counts + evidence + top hypothesis + Phase B recommendation).

## Test plan

- [ ] Maintainer review of the JSDoc contract (especially the read-only constraints)
- [ ] Optional: try the snippet in a debug run on the maintainer's own project
- [ ] CI lint on the contrib branch (no SDK dep changes; same import pattern as sibling `api-testing.js` / `accessibility-testing.js`)

## Files added

- `library/specializations/qa-testing-automation/diagnostic-first-phase.js` (~ 140 lines, exports `diagnosticFirstPhaseTask`)
- `library/specializations/qa-testing-automation/diagnostic-first-phase.md` (~ 100 lines, companion docs with usage example + provenance)

## Adjacent contribution

I'm planning to send a sibling PR for the `@productionContract` JSDoc convention (gates run completion on the user-visible assertion rather than test pass-rate). Happy to bundle them if reviewers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)