### PR TITLE
feat(sdk): expose runId, runDir, and artifactsDir on ProcessContext

### DIFF
--- a/packages/sdk/src/runtime/__tests__/processContext.test.ts
+++ b/packages/sdk/src/runtime/__tests__/processContext.test.ts
@@ -61,6 +61,42 @@ function makeAction(id: string): EffectAction {
 
 const delay = (ms = 0) => new Promise((resolve) => setTimeout(resolve, ms));
 
+describe("ProcessContext runtime identity surface", () => {
+  test("public context exposes runId, runDir, and a derived artifactsDir", () => {
+    const { context } = createProcessContext({
+      runId: "01TESTRUNID",
+      runDir: "/tmp/01TESTRUNID",
+      processId: "proc-id-surface",
+      effectIndex: effectIndexStub(),
+      replayCursor: new ReplayCursor(),
+    });
+
+    expect(context.runId).toBe("01TESTRUNID");
+    expect(context.runDir).toBe("/tmp/01TESTRUNID");
+    expect(context.artifactsDir).toBe("/tmp/01TESTRUNID/artifacts");
+  });
+
+  test("artifactsDir is always <runDir>/artifacts regardless of runDir shape", () => {
+    const { context: a } = createProcessContext({
+      runId: "run-a",
+      runDir: "/var/runs/run-a",
+      processId: "p",
+      effectIndex: effectIndexStub(),
+      replayCursor: new ReplayCursor(),
+    });
+    const { context: b } = createProcessContext({
+      runId: "run-b",
+      runDir: "/var/runs/run-b/",
+      processId: "p",
+      effectIndex: effectIndexStub(),
+      replayCursor: new ReplayCursor(),
+    });
+
+    expect(a.artifactsDir).toBe("/var/runs/run-a/artifacts");
+    expect(b.artifactsDir).toBe("/var/runs/run-b/artifacts");
+  });
+});
+
 describe("ProcessContext ambient helpers", () => {
   test("withProcessContext isolates ALS scopes across concurrent runs", async () => {
     const { internalContext: ctxA } = createProcessContext({

--- a/packages/sdk/src/runtime/processContext.ts
+++ b/packages/sdk/src/runtime/processContext.ts
@@ -59,7 +59,20 @@ export function createProcessContext(init: ProcessContextInit): CreateProcessCon
     map: (items, fn) => runParallelMap(items, fn),
   };
 
+  // Per-run artifacts directory — created up-front so processes can write to
+  // ctx.artifactsDir from the first iteration without ENOENT. mkdir is
+  // idempotent (recursive); fire-and-forget so context construction stays
+  // synchronous in surface, and any race with parallel processes resolves to
+  // the same directory.
+  const artifactsDir = path.join(internal.runDir, "artifacts");
+  void fs.mkdir(artifactsDir, { recursive: true }).catch(() => {
+    // Never let bootstrap break orchestration.
+  });
+
   const processContext: ProcessContext = {
+    runId: internal.runId,
+    runDir: internal.runDir,
+    artifactsDir,
     now: () => internal.now(),
     task: (task, args, options) =>
       runTaskIntrinsic({

--- a/packages/sdk/src/runtime/types.ts
+++ b/packages/sdk/src/runtime/types.ts
@@ -107,6 +107,17 @@ export interface ParallelHelpers {
 }
 
 export interface ProcessContext {
+  /** ULID of the current run — same as the run directory name. */
+  runId: string;
+  /** Absolute path to the run directory (e.g. `.a5c/runs/<runId>`). */
+  runDir: string;
+  /**
+   * Absolute path to the per-run artifacts directory (`<runDir>/artifacts`),
+   * created on first context construction. Processes can write reports,
+   * logs, and other generated files here without computing the path
+   * themselves.
+   */
+  artifactsDir: string;
   now(): Date;
   task<TArgs, TResult>(
     task: DefinedTask<TArgs, TResult>,


### PR DESCRIPTION
## Summary

Surface three values that the runtime already knows on the public `ProcessContext` so processes can use them inside `process(inputs, ctx)` without manual workarounds:

- `ctx.runId` — ULID of the current run (same as the run directory name)
- `ctx.runDir` — absolute path to `.a5c/runs/<runId>`
- `ctx.artifactsDir` — absolute path to `<runDir>/artifacts` (created via recursive `mkdir` at context construction)

Today these are present on `InternalProcessContext` (via `TaskIntrinsicContext`) but not exposed on the public type, so processes must derive them from `inputs.artifactsDir` injected after `run:create`. In practice every process that wants to write reports / logs / generated files has to either:

1. Have the orchestrator patch `inputs.json` with `artifactsDir` after `run:create`, OR
2. Carry boilerplate like `const runDir = artifactsDir.replace(/\/artifacts$/, '')`.

This change removes that friction.

## Motivation

Across 14 babysitter runs on a downstream project in May 2026, the same workaround was repeated identically in every process — patching `inputs.json` post-create to inject `artifactsDir`. The runtime already knows the run directory (it's the only way it could write the journal), so the fix is purely a surface-area improvement.

## Changes

- `packages/sdk/src/runtime/types.ts` — add `runId`, `runDir`, `artifactsDir` to the public `ProcessContext` interface with TSDoc.
- `packages/sdk/src/runtime/processContext.ts` — populate the three fields on the public context, derive `artifactsDir = path.join(internal.runDir, 'artifacts')`, fire a recursive \`mkdir\` so writes from the first iteration don't ENOENT. Fire-and-forget so context construction stays synchronous in surface; concurrent context creation is idempotent.
- `packages/sdk/src/runtime/__tests__/processContext.test.ts` — two new test cases in a fresh \`describe('ProcessContext runtime identity surface')\` block:
  - public context exposes \`runId\`, \`runDir\`, and a derived \`artifactsDir\`
  - \`artifactsDir\` is consistently \`<runDir>/artifacts\` regardless of trailing-slash shape

Total: +60 lines, 3 files. No public method signatures changed; only new readable fields added. Non-breaking.

## Test plan

- [x] \`tsc --noEmit\` clean on the two touched source files
- [x] ESLint clean on the touched source files (\`--max-warnings=0\`)
- [x] Two new vitest cases follow the existing pattern in the same file (CI will run them on a fresh install — the cloned workspace had a pre-existing \`vitest@4\` ↔ \`vite@5\` resolution issue unrelated to this PR)
- [ ] Downstream consumer: replace inputs.json patching boilerplate with direct \`ctx.runId\` / \`ctx.artifactsDir\` reads and confirm processes still resolve artifact paths correctly

## Backwards compatibility

Non-breaking — only adds new readable fields. Existing processes that read \`artifactsDir\` from \`inputs\` continue to work; they can incrementally adopt \`ctx.artifactsDir\` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)