### PR TITLE
Localize Babysitter doctor command label (i18n)

### DIFF
--- a/plugins/babysitter-unified/per-harness/omp/extensions-i18n.ts
+++ b/plugins/babysitter-unified/per-harness/omp/extensions-i18n.ts
@@ -1,0 +1,45 @@
+type Locale = "en" | "es" | "fr" | "pt-BR";
+type Params = Record<string, string | number>;
+
+const translations: Record<Exclude<Locale, "en">, Record<string, string>> = {
+  es: {
+    "command.doctor.description": "Abrir el diagnóstico de Babysitter",
+    "command.doctor.aliasDescription": "Alias de /doctor",
+  },
+  fr: {
+    "command.doctor.description": "Ouvrir le diagnostic Babysitter",
+    "command.doctor.aliasDescription": "Alias de /doctor",
+  },
+  "pt-BR": {
+    "command.doctor.description": "Abrir o diagnóstico do Babysitter",
+    "command.doctor.aliasDescription": "Alias para /doctor",
+  },
+};
+
+let currentLocale: Locale = "en";
+
+export function initI18n(pi: { events?: { emit?: (event: string, payload: unknown) => void } }): void {
+  pi.events?.emit?.("pi-core/i18n/registerBundle", {
+    namespace: "babysitter-pi",
+    defaultLocale: "en",
+    locales: translations,
+  });
+  pi.events?.emit?.("pi-core/i18n/requestApi", {
+    onReady: (api: { getLocale?: () => string; onLocaleChange?: (cb: (locale: string) => void) => void }) => {
+      const locale = api.getLocale?.();
+      if (isLocale(locale)) currentLocale = locale;
+      api.onLocaleChange?.((next) => {
+        if (isLocale(next)) currentLocale = next;
+      });
+    },
+  });
+}
+
+export function t(key: string, fallback: string, params: Params = {}): string {
+  const template = currentLocale === "en" ? fallback : translations[currentLocale]?.[key] ?? fallback;
+  return template.replace(/\{(\w+)\}/g, (_, name) => String(params[name] ?? `{${name}}`));
+}
+
+function isLocale(locale: string | undefined): locale is Locale {
+  return locale === "en" || locale === "es" || locale === "fr" || locale === "pt-BR";
+}

--- a/plugins/babysitter-unified/per-harness/omp/extensions-index.ts
+++ b/plugins/babysitter-unified/per-harness/omp/extensions-index.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent";
 import { execSync } from "child_process";
 import * as path from "path";
+import { initI18n, t } from "./extensions-i18n.js";
 
 const PLUGIN_ROOT = path.resolve(__dirname, "..");
 
@@ -53,6 +54,8 @@ function runProxiedHook(
 }
 
 export default function activate(pi: ExtensionAPI): void {
+  initI18n(pi);
+
   // ---------------------------------------------------------------------------
   // Trigger session-start hook on activation
   // ---------------------------------------------------------------------------
@@ -84,12 +87,16 @@ export default function activate(pi: ExtensionAPI): void {
     };
 
     pi.registerCommand(name, {
-      description: `Open the Babysitter ${name} skill`,
+      description: name === "doctor"
+        ? t("command.doctor.description", "Open the Babysitter doctor skill")
+        : `Open the Babysitter ${name} skill`,
       handler: forward,
     });
 
     pi.registerCommand(`babysitter:${name}`, {
-      description: `Alias for /${name}`,
+      description: name === "doctor"
+        ? t("command.doctor.aliasDescription", "Alias for /doctor")
+        : `Alias for /${name}`,
       handler: forward,
     });
   }

--- a/plugins/babysitter-unified/per-harness/pi/extensions-i18n.ts
+++ b/plugins/babysitter-unified/per-harness/pi/extensions-i18n.ts
@@ -1,0 +1,45 @@
+type Locale = "en" | "es" | "fr" | "pt-BR";
+type Params = Record<string, string | number>;
+
+const translations: Record<Exclude<Locale, "en">, Record<string, string>> = {
+  es: {
+    "command.doctor.description": "Abrir el diagnóstico de Babysitter",
+    "command.doctor.aliasDescription": "Alias de /doctor",
+  },
+  fr: {
+    "command.doctor.description": "Ouvrir le diagnostic Babysitter",
+    "command.doctor.aliasDescription": "Alias de /doctor",
+  },
+  "pt-BR": {
+    "command.doctor.description": "Abrir o diagnóstico do Babysitter",
+    "command.doctor.aliasDescription": "Alias para /doctor",
+  },
+};
+
+let currentLocale: Locale = "en";
+
+export function initI18n(pi: { events?: { emit?: (event: string, payload: unknown) => void } }): void {
+  pi.events?.emit?.("pi-core/i18n/registerBundle", {
+    namespace: "babysitter-pi",
+    defaultLocale: "en",
+    locales: translations,
+  });
+  pi.events?.emit?.("pi-core/i18n/requestApi", {
+    onReady: (api: { getLocale?: () => string; onLocaleChange?: (cb: (locale: string) => void) => void }) => {
+      const locale = api.getLocale?.();
+      if (isLocale(locale)) currentLocale = locale;
+      api.onLocaleChange?.((next) => {
+        if (isLocale(next)) currentLocale = next;
+      });
+    },
+  });
+}
+
+export function t(key: string, fallback: string, params: Params = {}): string {
+  const template = currentLocale === "en" ? fallback : translations[currentLocale]?.[key] ?? fallback;
+  return template.replace(/\{(\w+)\}/g, (_, name) => String(params[name] ?? `{${name}}`));
+}
+
+function isLocale(locale: string | undefined): locale is Locale {
+  return locale === "en" || locale === "es" || locale === "fr" || locale === "pt-BR";
+}

--- a/plugins/babysitter-unified/per-harness/pi/extensions-index.ts
+++ b/plugins/babysitter-unified/per-harness/pi/extensions-index.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { execSync } from "child_process";
 import * as path from "path";
+import { initI18n, t } from "./extensions-i18n.js";
 
 const PLUGIN_ROOT = path.resolve(__dirname, "..");
 
@@ -73,6 +74,8 @@ function runProxiedHook(
 }
 
 export default function activate(pi: ExtensionAPI): void {
+  initI18n(pi);
+
   pi.on("session_start", async (_event, ctx) => {
     runProxiedHook("babysitter-proxied-session-start.js", sessionStartInput(ctx));
   });
@@ -108,12 +111,16 @@ export default function activate(pi: ExtensionAPI): void {
     };
 
     pi.registerCommand(name, {
-      description: `Open the Babysitter ${name} skill`,
+      description: name === "doctor"
+        ? t("command.doctor.description", "Open the Babysitter doctor skill")
+        : `Open the Babysitter ${name} skill`,
       handler: forward,
     });
 
     pi.registerCommand(`babysitter:${name}`, {
-      description: `Alias for /${name}`,
+      description: name === "doctor"
+        ? t("command.doctor.aliasDescription", "Alias for /doctor")
+        : `Alias for /${name}`,
       handler: forward,
     });
   }

--- a/plugins/babysitter-unified/plugin.json
+++ b/plugins/babysitter-unified/plugin.json
@@ -65,7 +65,8 @@
       "AGENTS.md": "file:per-harness/{{targetDir}}/AGENTS.md"
     },
     "pi-extension": {
-      "extensions/index.ts": "file:per-harness/{{targetDir}}/extensions-index.ts"
+      "extensions/index.ts": "file:per-harness/{{targetDir}}/extensions-index.ts",
+      "extensions/i18n.ts": "file:per-harness/{{targetDir}}/extensions-i18n.ts"
     },
     "codex-branding": {
       "assets/icon.svg": "file:per-harness/{{targetDir}}/assets/icon.svg",


### PR DESCRIPTION
## Summary
- Adds i18n module for Pi/OMP extensions with translations for the doctor command (es, fr, pt-BR)
- Applied to `babysitter-unified` per-harness sources (Pi + OMP) and plugin.json sharedSets mapping
- Rebased from original PR #163 by @jerryfan onto current repo structure — thank you Jerry for the contribution!

Supersedes #163 (fork PR couldn't be updated after repo restructuring).

## Changes
- `plugins/babysitter-unified/per-harness/pi/extensions-i18n.ts` — i18n translation module
- `plugins/babysitter-unified/per-harness/pi/extensions-index.ts` — use i18n for doctor command
- `plugins/babysitter-unified/per-harness/omp/extensions-i18n.ts` — same for OMP
- `plugins/babysitter-unified/per-harness/omp/extensions-index.ts` — same for OMP
- `plugins/babysitter-unified/plugin.json` — map i18n.ts in pi-extension shared set

Generated with [Claude Code](https://claude.com/claude-code)