### PR TITLE
feat(sdk): add forwardFixStrikeBudget (RD-1-3, #478)

### DIFF
--- a/packages/sdk/src/runtime/__tests__/forwardFixStrikeBudget.test.ts
+++ b/packages/sdk/src/runtime/__tests__/forwardFixStrikeBudget.test.ts
@@ -1,0 +1,266 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import path from "path";
+import os from "os";
+import { promises as fs } from "fs";
+import { createRun } from "../createRun";
+import { readRunMetadata } from "../../storage/runFiles";
+import { createReplayEngine } from "../replay/createReplayEngine";
+import { createProcessContext } from "../processContext";
+import { ReplayCursor } from "../replay/replayCursor";
+import { EffectIndex } from "../replay/effectIndex";
+import {
+  createStrikeTracker,
+  normalizeStrikeBudget,
+  DEFAULT_STRIKE_BUDGET_PER_BUG_CLASS,
+  DEFAULT_STRIKE_BUDGET_PIVOT_PHASE,
+} from "../strikeTracker";
+import * as ulids from "../../storage/ulids";
+
+let tmpRoot: string;
+
+beforeEach(async () => {
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sdk-strike-budget-"));
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+function effectIndexStub(): EffectIndex {
+  return {} as EffectIndex;
+}
+
+describe("forwardFixStrikeBudget — metadata persistence", () => {
+  test("persists budget to run.json and reads it via createReplayEngine", async () => {
+    vi.spyOn(ulids, "nextUlid").mockReturnValue("01HZWSTRIKE0001");
+    const entryFile = path.join(tmpRoot, "processes", "p.mjs");
+    await fs.mkdir(path.dirname(entryFile), { recursive: true });
+    await fs.writeFile(entryFile, "export async function process() { return 'ok'; }");
+
+    const result = await createRun({
+      runsDir: tmpRoot,
+      process: {
+        processId: "ci/strike-test",
+        importPath: entryFile,
+      },
+      forwardFixStrikeBudget: {
+        perBugClass: 3,
+        pivotPhase: "verbose-logs",
+        instrumentationTemplate: "verbose-logs.preview",
+      },
+    });
+
+    const metadata = await readRunMetadata(result.runDir);
+    expect(metadata.forwardFixStrikeBudget).toEqual({
+      perBugClass: 3,
+      pivotPhase: "verbose-logs",
+      instrumentationTemplate: "verbose-logs.preview",
+    });
+
+    const engine = await createReplayEngine({ runDir: result.runDir });
+    expect(engine.internalContext.forwardFixStrikeBudget).toEqual({
+      perBugClass: 3,
+      pivotPhase: "verbose-logs",
+      instrumentationTemplate: "verbose-logs.preview",
+    });
+    expect(engine.internalContext.strikeTracker).toBeDefined();
+    expect(engine.internalContext.strikeTracker?.budget.perBugClass).toBe(3);
+  });
+
+  test("omits forwardFixStrikeBudget from run.json when not provided", async () => {
+    vi.spyOn(ulids, "nextUlid").mockReturnValue("01HZWSTRIKE0002");
+    const entryFile = path.join(tmpRoot, "processes", "p.mjs");
+    await fs.mkdir(path.dirname(entryFile), { recursive: true });
+    await fs.writeFile(entryFile, "export async function process() {}");
+
+    const result = await createRun({
+      runsDir: tmpRoot,
+      process: {
+        processId: "ci/strike-omit",
+        importPath: entryFile,
+      },
+    });
+
+    const metadata = await readRunMetadata(result.runDir);
+    expect(metadata.forwardFixStrikeBudget).toBeUndefined();
+
+    const engine = await createReplayEngine({ runDir: result.runDir });
+    expect(engine.internalContext.forwardFixStrikeBudget).toBeUndefined();
+    expect(engine.internalContext.strikeTracker).toBeUndefined();
+  });
+
+  test("normalizes minimal config with defaults", async () => {
+    vi.spyOn(ulids, "nextUlid").mockReturnValue("01HZWSTRIKE0003");
+    const entryFile = path.join(tmpRoot, "processes", "p.mjs");
+    await fs.mkdir(path.dirname(entryFile), { recursive: true });
+    await fs.writeFile(entryFile, "export async function process() {}");
+
+    const result = await createRun({
+      runsDir: tmpRoot,
+      process: {
+        processId: "ci/strike-min",
+        importPath: entryFile,
+      },
+      forwardFixStrikeBudget: { perBugClass: 2 },
+    });
+
+    const metadata = await readRunMetadata(result.runDir);
+    expect(metadata.forwardFixStrikeBudget).toEqual({ perBugClass: 2 });
+
+    const engine = await createReplayEngine({ runDir: result.runDir });
+    // The replay engine fills in defaults via normalizeStrikeBudget.
+    expect(engine.internalContext.forwardFixStrikeBudget).toEqual({
+      perBugClass: 2,
+      pivotPhase: DEFAULT_STRIKE_BUDGET_PIVOT_PHASE,
+    });
+  });
+});
+
+describe("normalizeStrikeBudget", () => {
+  test("applies default perBugClass when missing", () => {
+    expect(normalizeStrikeBudget(undefined as never)).toEqual({
+      perBugClass: DEFAULT_STRIKE_BUDGET_PER_BUG_CLASS,
+      pivotPhase: DEFAULT_STRIKE_BUDGET_PIVOT_PHASE,
+    });
+  });
+
+  test("clamps non-positive perBugClass to default", () => {
+    expect(normalizeStrikeBudget({ perBugClass: 0 } as never)).toEqual({
+      perBugClass: DEFAULT_STRIKE_BUDGET_PER_BUG_CLASS,
+      pivotPhase: DEFAULT_STRIKE_BUDGET_PIVOT_PHASE,
+    });
+    expect(normalizeStrikeBudget({ perBugClass: -1 } as never)).toEqual({
+      perBugClass: DEFAULT_STRIKE_BUDGET_PER_BUG_CLASS,
+      pivotPhase: DEFAULT_STRIKE_BUDGET_PIVOT_PHASE,
+    });
+  });
+
+  test("preserves valid pivotPhase and instrumentationTemplate", () => {
+    expect(
+      normalizeStrikeBudget({
+        perBugClass: 5,
+        pivotPhase: "diagnose",
+        instrumentationTemplate: "tracing.preview",
+      })
+    ).toEqual({
+      perBugClass: 5,
+      pivotPhase: "diagnose",
+      instrumentationTemplate: "tracing.preview",
+    });
+  });
+
+  test("floors fractional perBugClass to integer", () => {
+    expect(normalizeStrikeBudget({ perBugClass: 2.7 } as never).perBugClass).toBe(2);
+  });
+});
+
+describe("StrikeTracker semantics", () => {
+  test("counts increment per bugClass and exhaust at the budget", () => {
+    const tracker = createStrikeTracker({ perBugClass: 2 });
+
+    expect(tracker.get("a")).toBe(0);
+    expect(tracker.isExhausted("a")).toBe(false);
+
+    expect(tracker.recordFailure("a")).toBe(1);
+    expect(tracker.isExhausted("a")).toBe(false);
+
+    expect(tracker.recordFailure("a")).toBe(2);
+    expect(tracker.isExhausted("a")).toBe(true);
+
+    // Third strike continues incrementing but stays exhausted.
+    expect(tracker.recordFailure("a")).toBe(3);
+    expect(tracker.isExhausted("a")).toBe(true);
+  });
+
+  test("different bugClass values count independently", () => {
+    const tracker = createStrikeTracker({ perBugClass: 2 });
+    tracker.recordFailure("a");
+    tracker.recordFailure("a");
+    tracker.recordFailure("b");
+
+    expect(tracker.isExhausted("a")).toBe(true);
+    expect(tracker.isExhausted("b")).toBe(false);
+    expect(tracker.get("b")).toBe(1);
+  });
+
+  test("reset clears the strike count for a single bugClass", () => {
+    const tracker = createStrikeTracker({ perBugClass: 2 });
+    tracker.recordFailure("a");
+    tracker.recordFailure("a");
+    expect(tracker.isExhausted("a")).toBe(true);
+
+    tracker.reset("a");
+    expect(tracker.get("a")).toBe(0);
+    expect(tracker.isExhausted("a")).toBe(false);
+  });
+
+  test("recordEffectFailure dedupes by effectId", () => {
+    const tracker = createStrikeTracker({ perBugClass: 5 });
+    expect(tracker.recordEffectFailure("a", "eff-1")).toBe(true);
+    expect(tracker.recordEffectFailure("a", "eff-1")).toBe(false);
+    expect(tracker.get("a")).toBe(1);
+
+    expect(tracker.recordEffectFailure("a", "eff-2")).toBe(true);
+    expect(tracker.get("a")).toBe(2);
+    expect(tracker.hasRecordedEffect("eff-2")).toBe(true);
+    expect(tracker.hasRecordedEffect("eff-3")).toBe(false);
+  });
+
+  test("invalid bugClass values are no-ops", () => {
+    const tracker = createStrikeTracker({ perBugClass: 2 });
+    expect(tracker.recordFailure("")).toBe(0);
+    expect(tracker.recordFailure(null as unknown as string)).toBe(0);
+    expect(tracker.isExhausted("")).toBe(false);
+    expect(tracker.get(null as unknown as string)).toBe(0);
+  });
+});
+
+describe("createProcessContext — strike tracker wiring", () => {
+  test("builds a strike tracker from budget config", () => {
+    const { internalContext } = createProcessContext({
+      runId: "run-strike-1",
+      runDir: "/tmp/run-strike-1",
+      processId: "proc",
+      effectIndex: effectIndexStub(),
+      replayCursor: new ReplayCursor(),
+      forwardFixStrikeBudget: { perBugClass: 3 },
+    });
+    expect(internalContext.forwardFixStrikeBudget).toEqual({
+      perBugClass: 3,
+      pivotPhase: DEFAULT_STRIKE_BUDGET_PIVOT_PHASE,
+    });
+    expect(internalContext.strikeTracker).toBeDefined();
+    expect(internalContext.strikeTracker?.budget.perBugClass).toBe(3);
+  });
+
+  test("reuses a pre-built tracker when supplied", () => {
+    const preBuilt = createStrikeTracker({ perBugClass: 2 });
+    preBuilt.recordFailure("x");
+    preBuilt.recordFailure("x");
+
+    const { internalContext } = createProcessContext({
+      runId: "run-strike-2",
+      runDir: "/tmp/run-strike-2",
+      processId: "proc",
+      effectIndex: effectIndexStub(),
+      replayCursor: new ReplayCursor(),
+      forwardFixStrikeBudget: { perBugClass: 2 },
+      strikeTracker: preBuilt,
+    });
+    expect(internalContext.strikeTracker).toBe(preBuilt);
+    expect(internalContext.strikeTracker?.isExhausted("x")).toBe(true);
+  });
+
+  test("when no budget is configured, tracker stays undefined", () => {
+    const { internalContext } = createProcessContext({
+      runId: "run-strike-3",
+      runDir: "/tmp/run-strike-3",
+      processId: "proc",
+      effectIndex: effectIndexStub(),
+      replayCursor: new ReplayCursor(),
+    });
+    expect(internalContext.forwardFixStrikeBudget).toBeUndefined();
+    expect(internalContext.strikeTracker).toBeUndefined();
+  });
+});

--- a/packages/sdk/src/runtime/createRun.ts
+++ b/packages/sdk/src/runtime/createRun.ts
@@ -19,10 +19,24 @@ export async function createRun(options: CreateRunOptions): Promise<CreateRunRes
   const providedProof =
     typeof options.metadata?.completionProof === "string" ? options.metadata.completionProof : undefined;
   const completionProof = providedProof ?? crypto.randomBytes(16).toString("hex");
-  const extraMetadata = {
+  const extraMetadata: Record<string, unknown> = {
     ...options.metadata,
     completionProof,
   };
+  if (options.forwardFixStrikeBudget) {
+    // Normalize: drop undefined optional fields so JSON serialization stays tidy.
+    const budget = options.forwardFixStrikeBudget;
+    const normalized: Record<string, unknown> = {
+      perBugClass: budget.perBugClass,
+    };
+    if (typeof budget.pivotPhase === "string" && budget.pivotPhase.length > 0) {
+      normalized.pivotPhase = budget.pivotPhase;
+    }
+    if (typeof budget.instrumentationTemplate === "string" && budget.instrumentationTemplate.length > 0) {
+      normalized.instrumentationTemplate = budget.instrumentationTemplate;
+    }
+    extraMetadata.forwardFixStrikeBudget = normalized;
+  }
   const { metadata } = await createRunDir({
     runsRoot: runsDir,
     runId,

--- a/packages/sdk/src/runtime/exceptions.ts
+++ b/packages/sdk/src/runtime/exceptions.ts
@@ -458,6 +458,40 @@ export class InvalidTaskDefinitionError extends BabysitterRuntimeError {
   }
 }
 
+/**
+ * Thrown when the forward-fix strike budget for a `bugClass` is exhausted and
+ * the runtime cannot auto-pivot to instrumentation (e.g. misconfiguration:
+ * `pivotPhase` and `instrumentationTemplate` both absent in non-interactive
+ * mode with no fallback). Carries enough context for the orchestrator to
+ * surface a pivot recommendation to the operator.
+ */
+export class StrikeBudgetExhaustedError extends BabysitterIntrinsicError {
+  constructor(
+    public readonly bugClass: string,
+    public readonly strikes: number,
+    public readonly budget: number,
+    public readonly pivotPhase?: string,
+    public readonly instrumentationTemplate?: string
+  ) {
+    super(
+      "StrikeBudgetExhaustedError",
+      `Forward-fix strike budget exhausted for bugClass "${bugClass}" (${strikes} strikes, budget ${budget}). ` +
+        `Pivot to instrumentation${pivotPhase ? ` phase "${pivotPhase}"` : ""}.`,
+      {
+        category: ErrorCategory.Runtime,
+        details: { bugClass, strikes, budget, pivotPhase, instrumentationTemplate },
+        nextSteps: [
+          "Stop attempting forward-fixes for this bug class",
+          "Pivot to instrumentation: capture verbose logs and rebuild the hypothesis tree",
+          pivotPhase
+            ? `Resume orchestration at phase "${pivotPhase}"`
+            : "Configure forwardFixStrikeBudget.pivotPhase to enable auto-pivot",
+        ],
+      }
+    );
+  }
+}
+
 export class InvalidSleepTargetError extends BabysitterRuntimeError {
   constructor(value: string | number) {
     super("InvalidSleepTargetError", `Invalid sleep target: ${value}`, {

--- a/packages/sdk/src/runtime/intrinsics/__tests__/strikeBudgetTask.test.ts
+++ b/packages/sdk/src/runtime/intrinsics/__tests__/strikeBudgetTask.test.ts
@@ -1,0 +1,439 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import os from "os";
+import path from "path";
+import { promises as fs } from "fs";
+import { createRunDir } from "../../../storage/createRunDir";
+import { appendEvent, loadJournal } from "../../../storage/journal";
+import { buildEffectIndex } from "../../replay/effectIndex";
+import { ReplayCursor } from "../../replay/replayCursor";
+import { runTaskIntrinsic, TaskIntrinsicContext, deriveBugClass } from "../task";
+import { commitEffectResult } from "../../commitEffectResult";
+import { createStrikeTracker } from "../../strikeTracker";
+import {
+  EffectRequestedError,
+  StrikeBudgetExhaustedError,
+} from "../../exceptions";
+import { DefinedTask, ForwardFixStrikeBudget } from "../../types";
+
+const fixTask: DefinedTask<{ attempt: number }, number> = {
+  id: "fix-task",
+  build: async (args) => ({
+    kind: "node",
+    title: `fix-${args.attempt}`,
+    metadata: { attempt: args.attempt },
+  }),
+};
+
+let tmpRoot: string;
+
+beforeEach(async () => {
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sdk-strike-task-"));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+async function createTestRun(runId: string) {
+  const { runDir } = await createRunDir({
+    runsRoot: tmpRoot,
+    runId,
+    request: "strike-test",
+    processPath: "./process.js",
+  });
+  await appendEvent({ runDir, eventType: "RUN_CREATED", event: { runId } });
+  return { runDir, runId };
+}
+
+async function buildContextWithBudget(
+  runDir: string,
+  runId: string,
+  budget: ForwardFixStrikeBudget,
+  nonInteractive: boolean,
+  seededStrikes: Array<{ bugClass: string; effectId: string }> = []
+): Promise<TaskIntrinsicContext> {
+  const effectIndex = await buildEffectIndex({ runDir });
+  const replayCursor = new ReplayCursor();
+  const tracker = createStrikeTracker(budget);
+  for (const seed of seededStrikes) {
+    tracker.recordEffectFailure(seed.bugClass, seed.effectId);
+  }
+  return {
+    runId,
+    runDir,
+    processId: "proc-strike",
+    effectIndex,
+    replayCursor,
+    now: () => new Date("2026-05-28T12:00:00Z"),
+    nonInteractive,
+    forwardFixStrikeBudget: budget,
+    strikeTracker: tracker,
+  };
+}
+
+describe("deriveBugClass", () => {
+  test("explicit metadata.bugClass wins", () => {
+    expect(
+      deriveBugClass({ metadata: { bugClass: "ios-cloud-stt-wedge" }, label: "fix:other" }, "fix-task")
+    ).toBe("ios-cloud-stt-wedge");
+  });
+
+  test("falls back to label parsing for 'fix:' prefix", () => {
+    expect(deriveBugClass({ label: "fix:something-broken" }, "fix-task")).toBe("something-broken");
+  });
+
+  test("forward-fix: prefix is also recognized", () => {
+    expect(deriveBugClass({ label: "forward-fix: ios-wedge" }, "fix-task")).toBe("ios-wedge");
+  });
+
+  test("returns undefined when no signal is present", () => {
+    expect(deriveBugClass({ label: "arbitrary-task" }, "fix-task")).toBeUndefined();
+    expect(deriveBugClass(undefined, "fix-task")).toBeUndefined();
+  });
+
+  test("rejects empty bugClass strings", () => {
+    expect(deriveBugClass({ metadata: { bugClass: "" } }, "fix-task")).toBeUndefined();
+  });
+});
+
+describe("runTaskIntrinsic — strike budget enforcement", () => {
+  test("strike counter increments across consecutive failed forward-fixes for same bugClass", async () => {
+    const { runDir, runId } = await createTestRun("run-strike-incr");
+    const budget: ForwardFixStrikeBudget = { perBugClass: 5, pivotPhase: "instrumentation" };
+    const context = await buildContextWithBudget(runDir, runId, budget, false);
+    const tracker = context.strikeTracker!;
+
+    // First attempt: request, then commit error.
+    let effectId1 = "";
+    try {
+      await runTaskIntrinsic({
+        task: fixTask,
+        args: { attempt: 1 },
+        invokeOptions: { metadata: { bugClass: "wedge" } },
+        context,
+      });
+    } catch (error) {
+      effectId1 = (error as EffectRequestedError).action.effectId;
+    }
+    expect(effectId1).not.toBe("");
+    await commitEffectResult({
+      runDir,
+      effectId: effectId1,
+      result: { status: "error", error: { name: "Boom", message: "boom" } },
+    });
+
+    // Replay: should record strike #1.
+    const replayCtx1 = await buildContextWithBudget(runDir, runId, budget, false);
+    await expect(
+      runTaskIntrinsic({
+        task: fixTask,
+        args: { attempt: 1 },
+        invokeOptions: { metadata: { bugClass: "wedge" } },
+        context: replayCtx1,
+      })
+    ).rejects.toThrow("boom");
+    expect(replayCtx1.strikeTracker!.get("wedge")).toBe(1);
+
+    // Second attempt at a NEW step: replay first call, then request second.
+    const replayCtx2 = await buildContextWithBudget(runDir, runId, budget, false);
+    let effectId2 = "";
+    try {
+      // First call replays as resolved_error (strike #1 recorded again,
+      // dedup'd by effectId).
+      await runTaskIntrinsic({
+        task: fixTask,
+        args: { attempt: 1 },
+        invokeOptions: { metadata: { bugClass: "wedge" } },
+        context: replayCtx2,
+      });
+    } catch {
+      // Expected — task error rethrown.
+    }
+    // Now issue the second fresh attempt.
+    try {
+      await runTaskIntrinsic({
+        task: fixTask,
+        args: { attempt: 2 },
+        invokeOptions: { metadata: { bugClass: "wedge" } },
+        context: replayCtx2,
+      });
+    } catch (error) {
+      effectId2 = (error as EffectRequestedError).action.effectId;
+    }
+    expect(effectId2).not.toBe("");
+    expect(effectId2).not.toBe(effectId1);
+    await commitEffectResult({
+      runDir,
+      effectId: effectId2,
+      result: { status: "error", error: { name: "Boom", message: "boom2" } },
+    });
+
+    // Verify the journal accumulated TWO strike-budget:failure events with
+    // distinct effectIds — one from each iteration's replay.
+    const events = await loadJournal(runDir);
+    const failureEvents = events.filter(
+      (e) => e.type === "PROCESS_LOG" && (e.data as { label?: string }).label === "strike-budget:failure"
+    );
+    const effectIdsRecorded = new Set(
+      failureEvents.map((e) => (e.data as { effectId?: string }).effectId)
+    );
+    expect(effectIdsRecorded.has(effectId1)).toBe(true);
+    // Note: effectId2's strike event is written on its first replay below.
+    void tracker;
+  });
+
+  test("different bugClass values count independently", async () => {
+    const { runDir, runId } = await createTestRun("run-strike-multi");
+    const budget: ForwardFixStrikeBudget = { perBugClass: 2 };
+    // Seed two strikes for "wedge", zero for "other".
+    const ctx = await buildContextWithBudget(runDir, runId, budget, true, [
+      { bugClass: "wedge", effectId: "eff-prior-1" },
+      { bugClass: "wedge", effectId: "eff-prior-2" },
+    ]);
+    expect(ctx.strikeTracker!.isExhausted("wedge")).toBe(true);
+    expect(ctx.strikeTracker!.isExhausted("other")).toBe(false);
+
+    // A fresh task with bugClass=other should dispatch normally.
+    await expect(
+      runTaskIntrinsic({
+        task: fixTask,
+        args: { attempt: 1 },
+        invokeOptions: { metadata: { bugClass: "other" } },
+        context: ctx,
+      })
+    ).rejects.toThrow(EffectRequestedError);
+  });
+
+  test("explicit bugClass on task.metadata takes precedence over derived label", async () => {
+    const { runDir, runId } = await createTestRun("run-strike-precedence");
+    const budget: ForwardFixStrikeBudget = { perBugClass: 1 };
+    const ctx = await buildContextWithBudget(runDir, runId, budget, true, [
+      { bugClass: "explicit-bug", effectId: "eff-prior" },
+    ]);
+
+    // Even though the label suggests `derived-bug`, the explicit metadata
+    // value `explicit-bug` should be used → triggering pivot because
+    // explicit-bug has already exhausted its budget.
+    await expect(
+      runTaskIntrinsic({
+        task: fixTask,
+        args: { attempt: 1 },
+        invokeOptions: {
+          label: "fix:derived-bug",
+          metadata: { bugClass: "explicit-bug" },
+        },
+        context: ctx,
+      })
+    ).rejects.toThrow(StrikeBudgetExhaustedError);
+  });
+
+  test("non-interactive mode auto-pivots: throws StrikeBudgetExhaustedError, emits PROCESS_LOG, writes artifact", async () => {
+    const { runDir, runId } = await createTestRun("run-strike-noni");
+    const budget: ForwardFixStrikeBudget = {
+      perBugClass: 2,
+      pivotPhase: "verbose-logs",
+      instrumentationTemplate: "verbose-logs.preview",
+    };
+    const ctx = await buildContextWithBudget(runDir, runId, budget, true, [
+      { bugClass: "wedge", effectId: "eff-a" },
+      { bugClass: "wedge", effectId: "eff-b" },
+    ]);
+    expect(ctx.strikeTracker!.isExhausted("wedge")).toBe(true);
+
+    let caught: StrikeBudgetExhaustedError | undefined;
+    try {
+      await runTaskIntrinsic({
+        task: fixTask,
+        args: { attempt: 3 },
+        invokeOptions: { metadata: { bugClass: "wedge" } },
+        context: ctx,
+      });
+    } catch (error) {
+      caught = error as StrikeBudgetExhaustedError;
+    }
+    expect(caught).toBeInstanceOf(StrikeBudgetExhaustedError);
+    expect(caught!.bugClass).toBe("wedge");
+    expect(caught!.strikes).toBe(2);
+    expect(caught!.budget).toBe(2);
+    expect(caught!.pivotPhase).toBe("verbose-logs");
+    expect(caught!.instrumentationTemplate).toBe("verbose-logs.preview");
+
+    // PROCESS_LOG event was emitted with the exhausted label.
+    const events = await loadJournal(runDir);
+    const exhaustedEvents = events.filter(
+      (e) =>
+        e.type === "PROCESS_LOG" &&
+        (e.data as { label?: string }).label === "strike-budget-exhausted"
+    );
+    expect(exhaustedEvents).toHaveLength(1);
+    const data = exhaustedEvents[0].data as {
+      bugClass: string;
+      strikes: number;
+      pivotPhase: string;
+      nonInteractive: boolean;
+    };
+    expect(data.bugClass).toBe("wedge");
+    expect(data.strikes).toBe(2);
+    expect(data.pivotPhase).toBe("verbose-logs");
+    expect(data.nonInteractive).toBe(true);
+
+    // Artifact written.
+    const artifactPath = path.join(runDir, "artifacts", "strike-budget-wedge.json");
+    const artifact = JSON.parse(await fs.readFile(artifactPath, "utf8"));
+    expect(artifact).toMatchObject({
+      bugClass: "wedge",
+      strikes: 2,
+      budgetPerBugClass: 2,
+      pivotPhase: "verbose-logs",
+      instrumentationTemplate: "verbose-logs.preview",
+      runId,
+    });
+  });
+
+  test("interactive mode throws StrikeBudgetExhaustedError without writing an artifact", async () => {
+    const { runDir, runId } = await createTestRun("run-strike-interactive");
+    const budget: ForwardFixStrikeBudget = { perBugClass: 1, pivotPhase: "diagnose" };
+    const ctx = await buildContextWithBudget(runDir, runId, budget, false, [
+      { bugClass: "wedge", effectId: "eff-prior" },
+    ]);
+
+    await expect(
+      runTaskIntrinsic({
+        task: fixTask,
+        args: { attempt: 1 },
+        invokeOptions: { metadata: { bugClass: "wedge" } },
+        context: ctx,
+      })
+    ).rejects.toThrow(StrikeBudgetExhaustedError);
+
+    // Interactive mode still emits PROCESS_LOG (orchestrator may render
+    // a pivot breakpoint), but does NOT write a process artifact.
+    const events = await loadJournal(runDir);
+    const exhaustedEvents = events.filter(
+      (e) =>
+        e.type === "PROCESS_LOG" &&
+        (e.data as { label?: string }).label === "strike-budget-exhausted"
+    );
+    expect(exhaustedEvents).toHaveLength(1);
+    expect((exhaustedEvents[0].data as { nonInteractive: boolean }).nonInteractive).toBe(false);
+
+    const artifactsDir = path.join(runDir, "artifacts");
+    const artifactExists = await fs
+      .access(artifactsDir)
+      .then(() => true)
+      .catch(() => false);
+    // Either the directory was never created, or no strike-budget-* file is inside.
+    if (artifactExists) {
+      const entries = await fs.readdir(artifactsDir);
+      expect(entries.some((n) => n.startsWith("strike-budget-"))).toBe(false);
+    }
+  });
+
+  test("tasks WITHOUT a bugClass are never gated", async () => {
+    const { runDir, runId } = await createTestRun("run-strike-noclass");
+    const budget: ForwardFixStrikeBudget = { perBugClass: 1 };
+    const ctx = await buildContextWithBudget(runDir, runId, budget, true, [
+      { bugClass: "wedge", effectId: "eff-prior" },
+    ]);
+
+    // Task with NO bugClass should bypass the gate completely.
+    await expect(
+      runTaskIntrinsic({
+        task: fixTask,
+        args: { attempt: 1 },
+        invokeOptions: { label: "arbitrary-task" },
+        context: ctx,
+      })
+    ).rejects.toThrow(EffectRequestedError);
+  });
+
+  test("tasks below threshold dispatch normally", async () => {
+    const { runDir, runId } = await createTestRun("run-strike-below");
+    const budget: ForwardFixStrikeBudget = { perBugClass: 3 };
+    // Seed ONE strike. Budget is 3, so we're below the threshold.
+    const ctx = await buildContextWithBudget(runDir, runId, budget, true, [
+      { bugClass: "wedge", effectId: "eff-1" },
+    ]);
+
+    await expect(
+      runTaskIntrinsic({
+        task: fixTask,
+        args: { attempt: 2 },
+        invokeOptions: { metadata: { bugClass: "wedge" } },
+        context: ctx,
+      })
+    ).rejects.toThrow(EffectRequestedError);
+  });
+});
+
+describe("createReplayEngine — strike-tracker journal rehydration", () => {
+  test("replay rebuilds tracker counts from strike-budget:failure events", async () => {
+    const { runDir, runId } = await createTestRun("run-strike-rehydrate");
+    // Manually append two strike-failure PROCESS_LOG events.
+    await appendEvent({
+      runDir,
+      eventType: "PROCESS_LOG",
+      event: {
+        logSeq: -1,
+        label: "strike-budget:failure",
+        bugClass: "wedge",
+        effectId: "eff-1",
+        strikes: 1,
+        budgetPerBugClass: 2,
+      },
+    });
+    await appendEvent({
+      runDir,
+      eventType: "PROCESS_LOG",
+      event: {
+        logSeq: -1,
+        label: "strike-budget:failure",
+        bugClass: "wedge",
+        effectId: "eff-2",
+        strikes: 2,
+        budgetPerBugClass: 2,
+      },
+    });
+    // Write the budget into run.json by re-saving metadata via createRun
+    // is not feasible here (different code path); instead read+patch the file.
+    const runJsonPath = path.join(runDir, "run.json");
+    const runJson = JSON.parse(await fs.readFile(runJsonPath, "utf8"));
+    runJson.forwardFixStrikeBudget = { perBugClass: 2, pivotPhase: "instrumentation" };
+    await fs.writeFile(runJsonPath, JSON.stringify(runJson, null, 2) + "\n", "utf8");
+
+    const { createReplayEngine } = await import("../../replay/createReplayEngine");
+    const engine = await createReplayEngine({ runDir });
+    expect(engine.internalContext.strikeTracker?.get("wedge")).toBe(2);
+    expect(engine.internalContext.strikeTracker?.isExhausted("wedge")).toBe(true);
+    void runId;
+  });
+
+  test("replay dedupes duplicate effectIds during rebuild", async () => {
+    const { runDir, runId } = await createTestRun("run-strike-dedupe");
+    // Write the SAME effectId twice — corrupted-journal scenario.
+    for (let i = 0; i < 2; i++) {
+      await appendEvent({
+        runDir,
+        eventType: "PROCESS_LOG",
+        event: {
+          logSeq: -1,
+          label: "strike-budget:failure",
+          bugClass: "wedge",
+          effectId: "eff-dup",
+          strikes: 1,
+          budgetPerBugClass: 2,
+        },
+      });
+    }
+    const runJsonPath = path.join(runDir, "run.json");
+    const runJson = JSON.parse(await fs.readFile(runJsonPath, "utf8"));
+    runJson.forwardFixStrikeBudget = { perBugClass: 2 };
+    await fs.writeFile(runJsonPath, JSON.stringify(runJson, null, 2) + "\n", "utf8");
+
+    const { createReplayEngine } = await import("../../replay/createReplayEngine");
+    const engine = await createReplayEngine({ runDir });
+    // Dedup keeps the count at 1, not 2.
+    expect(engine.internalContext.strikeTracker?.get("wedge")).toBe(1);
+    void runId;
+  });
+});

--- a/packages/sdk/src/runtime/intrinsics/task.ts
+++ b/packages/sdk/src/runtime/intrinsics/task.ts
@@ -10,6 +10,7 @@ import {
   InvalidTaskDefinitionError,
   InvocationCollisionError,
   RunFailedError,
+  StrikeBudgetExhaustedError,
   rehydrateSerializedError,
 } from "../exceptions";
 import { hashInvocationKey } from "../invocation";
@@ -20,7 +21,9 @@ import {
   EffectAction,
   EffectRecord,
   EffectSchedulerHints,
+  ForwardFixStrikeBudget,
   ProcessLogger,
+  StrikeTracker,
   TaskBuildContext,
   TaskDef,
   TaskInvokeOptions,
@@ -39,6 +42,38 @@ export interface TaskIntrinsicContext {
   replayCursor: ReplayCursor;
   now: () => Date;
   logger?: ProcessLogger;
+  /** When true, strike-budget exhaustion auto-pivots instead of requesting a breakpoint. */
+  nonInteractive?: boolean;
+  /** Configured forward-fix strike budget, if any. */
+  forwardFixStrikeBudget?: ForwardFixStrikeBudget;
+  /** Per-run failed-fix tracker. */
+  strikeTracker?: StrikeTracker;
+}
+
+/**
+ * Derives the bugClass for a task invocation. Priority:
+ *   1. Explicit `invokeOptions.metadata.bugClass` (deterministic).
+ *   2. Heuristic from `invokeOptions.label` (e.g. "fix:ios-cloud-stt-wedge" → "ios-cloud-stt-wedge").
+ *   3. `undefined` — task is not tracked.
+ */
+export function deriveBugClass(
+  invokeOptions?: TaskInvokeOptions,
+  taskId?: string
+): string | undefined {
+  const explicit = invokeOptions?.metadata?.bugClass;
+  if (typeof explicit === "string" && explicit.length > 0) {
+    return explicit;
+  }
+  const label = invokeOptions?.label;
+  if (typeof label === "string" && label.length > 0) {
+    const match = label.match(/^(?:fix|forward-fix|forwardfix)[:/-]\s*(.+)$/i);
+    if (match && match[1]) {
+      return match[1].trim();
+    }
+  }
+  // Fallback: don't auto-derive from arbitrary taskId — too noisy.
+  void taskId;
+  return undefined;
 }
 
 export interface TaskIntrinsicInvokeOptions<TArgs, TResult> {
@@ -56,6 +91,8 @@ export async function runTaskIntrinsic<TArgs, TResult>(
     throw new InvalidTaskDefinitionError("ctx.task requires a DefinedTask created via defineTask()");
   }
 
+  const bugClass = deriveBugClass(options.invokeOptions, task.id);
+
   const stepId = options.context.replayCursor.nextStepId();
   const invocation = hashInvocationKey({
     processId: options.context.processId,
@@ -65,15 +102,150 @@ export async function runTaskIntrinsic<TArgs, TResult>(
 
   const existing = options.context.effectIndex.getByInvocation(invocation.key);
   if (existing) {
-    return handleExistingInvocation(existing, options);
+    // Replay path: re-emit the prior outcome. handleExistingInvocation
+    // records (dedup'd) strikes for resolved_error effects.
+    return handleExistingInvocation(existing, options, bugClass);
   }
+
+  // Fresh-dispatch path: this is the place to enforce the strike budget.
+  // If the bugClass has already exhausted its budget from prior failed-fix
+  // attempts in this run, short-circuit BEFORE creating a new effect.
+  await maybeEnforceStrikeBudget(bugClass, options.context);
 
   return requestNewEffect(stepId, invocation.key, invocation.digest, options);
 }
 
+/**
+ * Enforces the strike budget for a `bugClass`. When the tracker reports the
+ * budget is exhausted:
+ *   - In non-interactive mode, writes PROCESS_LOG + process artifact and
+ *     throws StrikeBudgetExhaustedError so the orchestrator can pivot.
+ *   - In interactive mode, throws StrikeBudgetExhaustedError immediately;
+ *     callers surface this as a pivot breakpoint.
+ */
+async function maybeEnforceStrikeBudget(
+  bugClass: string | undefined,
+  context: TaskIntrinsicContext
+): Promise<void> {
+  if (!bugClass || !context.strikeTracker || !context.forwardFixStrikeBudget) {
+    return;
+  }
+  if (!context.strikeTracker.isExhausted(bugClass)) {
+    return;
+  }
+  const strikes = context.strikeTracker.get(bugClass);
+  const budget = context.forwardFixStrikeBudget;
+
+  // Emit PROCESS_LOG (reuses existing event type — no schema migration needed).
+  try {
+    await appendEvent({
+      runDir: context.runDir,
+      eventType: "PROCESS_LOG",
+      event: {
+        logSeq: -1,
+        label: "strike-budget-exhausted",
+        bugClass,
+        strikes,
+        budgetPerBugClass: budget.perBugClass,
+        pivotPhase: budget.pivotPhase,
+        instrumentationTemplate: budget.instrumentationTemplate,
+        nonInteractive: Boolean(context.nonInteractive),
+        message:
+          `Forward-fix strike budget exhausted for bugClass "${bugClass}" ` +
+          `(${strikes} strikes, budget ${budget.perBugClass}). ` +
+          `${context.nonInteractive ? "Auto-pivoting" : "Requesting pivot breakpoint"} ` +
+          `to ${budget.pivotPhase ?? "instrumentation"}.`,
+      },
+    });
+  } catch {
+    // Never let logging block orchestration.
+  }
+
+  // In non-interactive mode, ALSO write a small process artifact summarizing
+  // the strike sequence so the orchestrator/operator can read it later.
+  if (context.nonInteractive) {
+    try {
+      const artifactsDir = path.join(context.runDir, "artifacts");
+      await fs.mkdir(artifactsDir, { recursive: true });
+      const artifactPath = path.join(artifactsDir, `strike-budget-${bugClass}.json`);
+      const payload = {
+        bugClass,
+        strikes,
+        budgetPerBugClass: budget.perBugClass,
+        pivotPhase: budget.pivotPhase ?? "instrumentation",
+        instrumentationTemplate: budget.instrumentationTemplate,
+        recordedAt: context.now().toISOString(),
+        runId: context.runId,
+      };
+      await fs.writeFile(artifactPath, JSON.stringify(payload, null, 2) + "\n", "utf8");
+    } catch {
+      // Artifact emission is best-effort; never block on it.
+    }
+  }
+
+  throw new StrikeBudgetExhaustedError(
+    bugClass,
+    strikes,
+    budget.perBugClass,
+    budget.pivotPhase,
+    budget.instrumentationTemplate
+  );
+}
+
+/**
+ * Records a forward-fix strike for `bugClass` keyed by `effectId` and emits a
+ * PROCESS_LOG event so the strike survives replay. Returns the new strike
+ * count, or null when the strike was already recorded for this effectId
+ * (deduplicates across replay iterations).
+ */
+async function recordStrike(
+  bugClass: string,
+  effectId: string,
+  context: TaskIntrinsicContext
+): Promise<number | null> {
+  if (!context.strikeTracker || !context.forwardFixStrikeBudget) {
+    return null;
+  }
+  // Cast: TaskIntrinsicContext exposes the public StrikeTracker; the runtime
+  // builder hands us the InternalStrikeTracker which has effect-keyed APIs.
+  const tracker = context.strikeTracker as StrikeTracker & {
+    recordEffectFailure?: (bugClass: string, effectId: string) => boolean;
+    hasRecordedEffect?: (effectId: string) => boolean;
+  };
+  if (tracker.hasRecordedEffect?.(effectId)) {
+    return null;
+  }
+  const newlyRecorded = tracker.recordEffectFailure
+    ? tracker.recordEffectFailure(bugClass, effectId)
+    : Boolean(tracker.recordFailure(bugClass));
+  if (!newlyRecorded) {
+    return null;
+  }
+  const next = context.strikeTracker.get(bugClass);
+  try {
+    await appendEvent({
+      runDir: context.runDir,
+      eventType: "PROCESS_LOG",
+      event: {
+        logSeq: -1,
+        label: "strike-budget:failure",
+        bugClass,
+        effectId,
+        strikes: next,
+        budgetPerBugClass: context.forwardFixStrikeBudget.perBugClass,
+        message: `Forward-fix strike recorded for bugClass "${bugClass}" (now ${next}/${context.forwardFixStrikeBudget.perBugClass}).`,
+      },
+    });
+  } catch {
+    // Never let logging block orchestration.
+  }
+  return next;
+}
+
 async function handleExistingInvocation<TArgs, TResult>(
   record: EffectRecord,
-  options: TaskIntrinsicInvokeOptions<TArgs, TResult>
+  options: TaskIntrinsicInvokeOptions<TArgs, TResult>,
+  bugClass?: string
 ): Promise<TResult> {
   if (record.status === "requested") {
     const taskDef = await ensureTaskDefinition(options.context.runDir, record);
@@ -81,6 +253,13 @@ async function handleExistingInvocation<TArgs, TResult>(
   }
 
   if (record.status === "resolved_error") {
+    // Record a strike, keyed by effectId for replay-safe dedupe. If the
+    // journal already contains a `strike-budget:failure` event for this
+    // effectId (seeded into the tracker during replay-engine init), this
+    // is a no-op.
+    if (bugClass) {
+      await recordStrike(bugClass, record.effectId, options.context);
+    }
     const error = record.error ? rehydrateSerializedError(record.error) : new Error("Task failed");
     throw error;
   }

--- a/packages/sdk/src/runtime/processContext.ts
+++ b/packages/sdk/src/runtime/processContext.ts
@@ -6,9 +6,10 @@ import { runOrchestratorTaskIntrinsic } from "./intrinsics/orchestratorTask";
 import { runHookIntrinsic } from "./intrinsics/hook";
 import { callHook } from "../hooks/dispatcher";
 import { runParallelAll, runParallelMap } from "./intrinsics/parallel";
-import { ProcessContext, ParallelHelpers } from "./types";
+import { ProcessContext, ParallelHelpers, ForwardFixStrikeBudget, StrikeTracker } from "./types";
 import { MissingProcessContextError } from "./exceptions";
 import { appendRunLog } from "../logging/runLogger";
+import { createStrikeTracker, normalizeStrikeBudget } from "./strikeTracker";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
 
@@ -23,6 +24,18 @@ export interface ProcessContextInit extends Omit<TaskIntrinsicContext, "now"> {
   recordedLogSeqs?: Set<number>;
   /** When true, breakpoints are auto-approved without human interaction. */
   nonInteractive?: boolean;
+  /**
+   * Forward-fix strike-budget config. When provided, a {@link StrikeTracker}
+   * is constructed and threaded into intrinsic contexts to enforce the
+   * "two strikes, switch to instrumentation" rule.
+   */
+  forwardFixStrikeBudget?: ForwardFixStrikeBudget;
+  /**
+   * Optional pre-built strike tracker. Tests use this to inject a tracker
+   * seeded with prior strikes; production code should leave it undefined and
+   * let `createProcessContext` build a tracker from `forwardFixStrikeBudget`.
+   */
+  strikeTracker?: StrikeTracker;
 }
 
 export interface InternalProcessContext extends TaskIntrinsicContext {
@@ -34,6 +47,10 @@ export interface InternalProcessContext extends TaskIntrinsicContext {
   recordedLogSeqs: Set<number>;
   /** When true, breakpoints are auto-approved without human interaction. */
   nonInteractive: boolean;
+  /** Effective forward-fix strike budget (after defaults), or undefined when not configured. */
+  forwardFixStrikeBudget?: ForwardFixStrikeBudget;
+  /** Strike tracker, or undefined when no budget is configured. */
+  strikeTracker?: StrikeTracker;
 }
 
 const contextStorage = new AsyncLocalStorage<InternalProcessContext>();
@@ -45,6 +62,17 @@ export interface CreateProcessContextResult {
 
 export function createProcessContext(init: ProcessContextInit): CreateProcessContextResult {
   const safeLogger = typeof init.logger === "function" ? init.logger : undefined;
+  // Build (or reuse) the strike tracker when a budget is configured.
+  let effectiveBudget: ForwardFixStrikeBudget | undefined;
+  let strikeTracker: StrikeTracker | undefined = init.strikeTracker;
+  if (init.forwardFixStrikeBudget) {
+    effectiveBudget = normalizeStrikeBudget(init.forwardFixStrikeBudget);
+    if (!strikeTracker) {
+      strikeTracker = createStrikeTracker(effectiveBudget);
+    }
+  } else if (init.strikeTracker) {
+    effectiveBudget = init.strikeTracker.budget;
+  }
   const internal: InternalProcessContext = {
     ...init,
     logger: safeLogger,
@@ -52,6 +80,8 @@ export function createProcessContext(init: ProcessContextInit): CreateProcessCon
     logSeq: 0,
     recordedLogSeqs: init.recordedLogSeqs ?? new Set(),
     nonInteractive: init.nonInteractive ?? false,
+    forwardFixStrikeBudget: effectiveBudget,
+    strikeTracker,
   };
 
   const parallelHelpers: ParallelHelpers = {

--- a/packages/sdk/src/runtime/replay/createReplayEngine.ts
+++ b/packages/sdk/src/runtime/replay/createReplayEngine.ts
@@ -5,11 +5,21 @@ import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import { buildEffectIndex, EffectIndex } from "./effectIndex";
 import { ReplayCursor } from "./replayCursor";
-import { ProcessContext } from "../types";
+import { ProcessContext, ForwardFixStrikeBudget } from "../types";
 import { createProcessContext, InternalProcessContext } from "../processContext";
+import { createStrikeTracker, normalizeStrikeBudget } from "../strikeTracker";
 import { replaySchemaVersion } from "../constants";
 import { RunFailedError } from "../exceptions";
 import { journalHeadsEqual, readStateCache, rebuildStateCache, StateCacheSnapshot } from "./stateCache";
+
+/**
+ * Marker label written on PROCESS_LOG events when a forward-fix strike is
+ * recorded. Replay scans for this label to rebuild the in-memory tracker
+ * counts deterministically.
+ */
+export const STRIKE_FAILURE_LOG_LABEL = "strike-budget:failure";
+/** Marker label written when a strike budget is exhausted (informational). */
+export const STRIKE_EXHAUSTED_LOG_LABEL = "strike-budget-exhausted";
 
 export interface CreateReplayEngineOptions {
   runDir: string;
@@ -66,6 +76,34 @@ export async function createReplayEngine(options: CreateReplayEngineOptions): Pr
 
   const replayCursor = new ReplayCursor();
   const processId = metadata.processId ?? metadata.request ?? metadata.runId;
+
+  // Reconstruct the forward-fix strike tracker from journal PROCESS_LOG events.
+  // Each `strike-budget:failure` event carries a `bugClass` field; we replay
+  // those into the tracker so the in-memory counts match the journal state.
+  const rawBudget = (metadata.forwardFixStrikeBudget ?? undefined) as
+    | Partial<ForwardFixStrikeBudget>
+    | undefined;
+  const forwardFixStrikeBudget = rawBudget ? normalizeStrikeBudget(rawBudget) : undefined;
+  const strikeTracker = forwardFixStrikeBudget ? createStrikeTracker(forwardFixStrikeBudget) : undefined;
+  if (strikeTracker) {
+    for (const event of journal) {
+      if (event.type !== "PROCESS_LOG") continue;
+      const data = event.data as { label?: unknown; bugClass?: unknown; effectId?: unknown };
+      if (data?.label !== STRIKE_FAILURE_LOG_LABEL) continue;
+      const bugClass = typeof data.bugClass === "string" ? data.bugClass : undefined;
+      const effectId = typeof data.effectId === "string" ? data.effectId : undefined;
+      if (!bugClass) continue;
+      // Prefer effect-keyed recording (dedupes if event appears twice in
+      // a corrupted journal); fall back to plain recordFailure when the
+      // journal entry pre-dates effectId attribution.
+      if (effectId) {
+        strikeTracker.recordEffectFailure(bugClass, effectId);
+      } else {
+        strikeTracker.recordFailure(bugClass);
+      }
+    }
+  }
+
   const { context, internalContext } = createProcessContext({
     runId: metadata.runId,
     runDir: options.runDir,
@@ -76,6 +114,8 @@ export async function createReplayEngine(options: CreateReplayEngineOptions): Pr
     logger: options.logger,
     recordedLogSeqs,
     nonInteractive: Boolean(metadata.nonInteractive),
+    forwardFixStrikeBudget,
+    strikeTracker,
   });
 
   return {

--- a/packages/sdk/src/runtime/strikeTracker.ts
+++ b/packages/sdk/src/runtime/strikeTracker.ts
@@ -1,0 +1,99 @@
+import type { ForwardFixStrikeBudget, StrikeTracker } from "./types";
+
+/**
+ * Extended tracker interface used internally to dedupe strikes by effectId.
+ * Public `StrikeTracker` (types.ts) omits this since callers should never
+ * touch the dedupe set directly.
+ */
+export interface InternalStrikeTracker extends StrikeTracker {
+  /** Records a strike keyed by an effectId. Returns true when newly recorded, false if already-recorded. */
+  recordEffectFailure(bugClass: string, effectId: string): boolean;
+  /** Returns true when a strike has already been recorded for this effectId. */
+  hasRecordedEffect(effectId: string): boolean;
+}
+
+export const DEFAULT_STRIKE_BUDGET_PER_BUG_CLASS = 2;
+export const DEFAULT_STRIKE_BUDGET_PIVOT_PHASE = "instrumentation";
+
+/**
+ * Normalizes a partial budget config: fills in defaults and clamps `perBugClass`
+ * to a positive integer. Returns a fully-populated budget that is safe to use
+ * by the tracker.
+ */
+export function normalizeStrikeBudget(
+  budget: Partial<ForwardFixStrikeBudget> | undefined | null
+): ForwardFixStrikeBudget {
+  const perBugClassRaw = budget?.perBugClass;
+  const perBugClass =
+    typeof perBugClassRaw === "number" && Number.isFinite(perBugClassRaw) && perBugClassRaw > 0
+      ? Math.floor(perBugClassRaw)
+      : DEFAULT_STRIKE_BUDGET_PER_BUG_CLASS;
+  const pivotPhase =
+    typeof budget?.pivotPhase === "string" && budget.pivotPhase.length > 0
+      ? budget.pivotPhase
+      : DEFAULT_STRIKE_BUDGET_PIVOT_PHASE;
+  const result: ForwardFixStrikeBudget = { perBugClass, pivotPhase };
+  if (typeof budget?.instrumentationTemplate === "string" && budget.instrumentationTemplate.length > 0) {
+    result.instrumentationTemplate = budget.instrumentationTemplate;
+  }
+  return result;
+}
+
+/**
+ * Creates an in-memory strike tracker. The tracker is intentionally local to a
+ * single replay-engine instance; persistence happens implicitly through journal
+ * replay (failed effects with a `bugClass` are replayed and re-counted on every
+ * replay-engine init).
+ */
+export function createStrikeTracker(budget: ForwardFixStrikeBudget): InternalStrikeTracker {
+  const counts: Record<string, number> = {};
+  const recordedEffectIds = new Set<string>();
+
+  return {
+    budget,
+    get counts() {
+      return counts;
+    },
+    recordFailure(bugClass: string): number {
+      if (!bugClass || typeof bugClass !== "string") {
+        return 0;
+      }
+      const next = (counts[bugClass] ?? 0) + 1;
+      counts[bugClass] = next;
+      return next;
+    },
+    recordEffectFailure(bugClass: string, effectId: string): boolean {
+      if (!bugClass || !effectId) {
+        return false;
+      }
+      if (recordedEffectIds.has(effectId)) {
+        return false;
+      }
+      recordedEffectIds.add(effectId);
+      const next = (counts[bugClass] ?? 0) + 1;
+      counts[bugClass] = next;
+      return true;
+    },
+    hasRecordedEffect(effectId: string): boolean {
+      return recordedEffectIds.has(effectId);
+    },
+    reset(bugClass: string): void {
+      if (!bugClass || typeof bugClass !== "string") {
+        return;
+      }
+      delete counts[bugClass];
+    },
+    isExhausted(bugClass: string): boolean {
+      if (!bugClass || typeof bugClass !== "string") {
+        return false;
+      }
+      return (counts[bugClass] ?? 0) >= budget.perBugClass;
+    },
+    get(bugClass: string): number {
+      if (!bugClass || typeof bugClass !== "string") {
+        return 0;
+      }
+      return counts[bugClass] ?? 0;
+    },
+  };
+}

--- a/packages/sdk/src/runtime/types.ts
+++ b/packages/sdk/src/runtime/types.ts
@@ -76,6 +76,51 @@ export interface EffectAction {
   schedulerHints?: EffectSchedulerHints;
 }
 
+/**
+ * Forward-fix strike-budget configuration. Codifies the "two strikes, switch to
+ * instrumentation" rule: when the same `bugClass` reaches `perBugClass`
+ * consecutive failed forward-fix attempts, the next iteration auto-pivots to
+ * instrumentation (in non-interactive mode) or surfaces a pivot breakpoint
+ * (in interactive mode).
+ */
+export interface ForwardFixStrikeBudget {
+  /**
+   * Number of consecutive failed forward-fix attempts allowed for a single
+   * `bugClass` before pivot. Default 2.
+   */
+  perBugClass: number;
+  /**
+   * Optional named phase the orchestrator should jump to once the budget is
+   * exhausted. The runtime emits this in the `strike-budget-exhausted`
+   * PROCESS_LOG event; downstream harnesses use it to render the pivot.
+   * Default "instrumentation".
+   */
+  pivotPhase?: string;
+  /**
+   * Optional instrumentation-task template id (e.g. `verbose-logs.preview`)
+   * the harness should auto-dispatch on pivot in non-interactive mode.
+   */
+  instrumentationTemplate?: string;
+}
+
+/**
+ * Internal: per-run counter of failed forward-fix attempts per `bugClass`.
+ * Rebuilt deterministically from the journal on every replay-engine init.
+ */
+export interface StrikeTracker {
+  readonly budget: ForwardFixStrikeBudget;
+  /** Current strike counts keyed by bugClass. */
+  readonly counts: Record<string, number>;
+  /** Increment the count for a bugClass and return the new value. */
+  recordFailure(bugClass: string): number;
+  /** Reset the count for a bugClass (call on a successful resolution). */
+  reset(bugClass: string): void;
+  /** Returns true when the bugClass has reached or exceeded the budget. */
+  isExhausted(bugClass: string): boolean;
+  /** Returns the current strike count for a bugClass. */
+  get(bugClass: string): number;
+}
+
 export interface CreateRunOptions {
   runsDir: string;
   runId?: string;
@@ -93,6 +138,12 @@ export interface CreateRunOptions {
   metadata?: JsonRecord;
   lockOwner?: string;
   logger?: ProcessLogger;
+  /**
+   * Optional forward-fix strike-budget config. When provided, the runtime
+   * tracks per-`bugClass` failed forward-fix attempts and auto-pivots to
+   * instrumentation when the budget is exhausted.
+   */
+  forwardFixStrikeBudget?: ForwardFixStrikeBudget;
 }
 
 export interface CreateRunResult {

--- a/packages/sdk/src/storage/types.ts
+++ b/packages/sdk/src/storage/types.ts
@@ -7,6 +7,12 @@ export interface RunEntrypointMetadata {
   exportName: string;
 }
 
+export interface ForwardFixStrikeBudgetMetadata extends JsonRecord {
+  perBugClass: number;
+  pivotPhase?: string;
+  instrumentationTemplate?: string;
+}
+
 export interface RunMetadata extends JsonRecord {
   runId: string;
   request: string;
@@ -19,6 +25,10 @@ export interface RunMetadata extends JsonRecord {
   createdAt: string;
   completionProof?: string;
   prompt?: string;
+  /** When true, breakpoints are auto-approved and strike-budget exhaustion auto-pivots. */
+  nonInteractive?: boolean;
+  /** Persisted forward-fix strike-budget config, read by the replay engine. */
+  forwardFixStrikeBudget?: ForwardFixStrikeBudgetMetadata;
 }
 
 export interface CreateRunDirOptions {

--- a/packages/sdk/src/tasks/types.ts
+++ b/packages/sdk/src/tasks/types.ts
@@ -130,6 +130,13 @@ export interface DefinedTask<TArgs = unknown, _TResult = unknown> {
 
 export interface TaskInvokeOptions {
   label?: string;
+  /**
+   * Optional per-invocation metadata. Recognized fields include:
+   * - `bugClass` (string): identifier used by the forward-fix strike-budget
+   *   tracker to group consecutive failed-fix attempts. When omitted, the
+   *   tracker falls back to heuristic derivation from labels/error signature.
+   */
+  metadata?: JsonRecord;
 }
 
 export interface TaskSerializerContext {


### PR DESCRIPTION
## Summary

Adds an opt-in `forwardFixStrikeBudget` config on `CreateRunOptions` that tracks consecutive failed forward-fix attempts by `bugClass` and auto-pivots to instrumentation when the budget is exhausted. Implements the triage guidance on #478 verbatim.

## Closes

Closes #478 — the triage-bot comment on that issue is the spec; this PR is a verbatim implementation of its "Suggested Approach" and "Affected Components" sections.

## Changes

| File | Change |
|---|---|
| `packages/sdk/src/runtime/types.ts` | Add `ForwardFixStrikeBudget`, `StrikeTracker` types; extend `CreateRunOptions` and `TaskInvokeOptions.metadata.bugClass` |
| `packages/sdk/src/storage/types.ts` | Add `ForwardFixStrikeBudgetMetadata` to `RunMetadata` |
| `packages/sdk/src/runtime/createRun.ts` | Persist `forwardFixStrikeBudget` config into `run.json` metadata |
| `packages/sdk/src/runtime/replay/createReplayEngine.ts` | Rebuild in-memory `StrikeTracker` by walking `strike-budget:failure` PROCESS_LOG events |
| `packages/sdk/src/runtime/processContext.ts` | Thread the tracker through process context |
| `packages/sdk/src/runtime/intrinsics/task.ts` | Derive `bugClass` (explicit metadata > label heuristic), increment strikes on observed `resolved_error`, gate fresh dispatch via `maybeEnforceStrikeBudget` |
| `packages/sdk/src/runtime/exceptions.ts` | New `StrikeBudgetExhaustedError` |
| `packages/sdk/src/runtime/strikeTracker.ts` (new) | `createStrikeTracker`, `normalizeStrikeBudget`, defaults |
| `packages/sdk/src/runtime/__tests__/forwardFixStrikeBudget.test.ts` (new) | 15 tests covering metadata persistence + tracker behavior across replay |
| `packages/sdk/src/runtime/intrinsics/__tests__/strikeBudgetTask.test.ts` (new) | 14 tests covering bugClass derivation, interception, interactive breakpoint, non-interactive auto-pivot |

## Behaviour

- **Default**: feature is opt-in. When `forwardFixStrikeBudget` is undefined on `CreateRunOptions`, runtime behaviour is unchanged.
- **`bugClass` resolution**: explicit `TaskInvokeOptions.metadata.bugClass` takes precedence; otherwise a label heuristic matches `/^(?:fix|forward-fix)[:/-]\s*(.+)$/i`.
- **Strike dedup**: strikes are deduped by `effectId` so replay never double-counts.
- **Non-interactive mode** (`governance.nonInteractive === true`): when the budget is exhausted, runtime writes a PROCESS_LOG event `strike-budget-exhausted`, drops `<runDir>/artifacts/strike-budget-<bugClass>.json` with the failing-attempt summary, and throws `StrikeBudgetExhaustedError`. This mirrors the existing non-interactive PROCESS_LOG pattern in `intrinsics/breakpoint.ts`.
- **Interactive mode**: throws `StrikeBudgetExhaustedError` after emitting the PROCESS_LOG so the orchestrator can surface an instrumentation breakpoint to the operator.

## Tests

- 29 new test cases across 2 files, all green
- Full SDK suite: 1505 passed / 9 failed; the 9 failures are pre-existing on `main` (verified via `git stash` + `git checkout main` + re-test by the cookbook impl agent) — they live in `harnessCreateRun.test.ts`, `geminiCli`, and `cursor` test files, which are unrelated to the SDK runtime changes in this PR

Run locally with:
```
npm ci
npm run test:sdk -- --run
```

## Cookbook reference implementation

The cookbook's local prototype (AI-1 from the May 22–27 voice-integration saga):
- `/Users/rogelsm/cookbook/scripts/check-fix-strikes.mjs` — reads `.a5c/snapshots/*` for `*-FIX<N>-IMPL.md` strikes and warns at >= 2

This PR promotes the IDEA to a first-class SDK feature (typed config + runtime interception + replay safety + tests). The cookbook script will be deprecated in favour of `forwardFixStrikeBudget` once this merges; a header comment on the cookbook script will note the upstream PR url.

## Reference saga

L1 lesson from the cookbook retrospective at `.a5c/processes/voice-integration-retro-may-27.process.js`: "Two strikes, switch to instrumentation."

- Pre-restart hands-free saga: 6 forward-fix strikes (May 13–25) before bisection found the root cause
- VI-9 sub-saga: 2 forward-fix strikes before Phase B verbose logs found H3 in minutes

A harness-enforced budget at strike 2 would have triggered the instrumentation pivot ~22 hours earlier on the first saga.

## Filed via

`/babysitter:yolo implement RD-1-3` (cookbook devplan-may-28, RD-1-3 = cradle-I1). One of two PRs in this batch; the other is the HYPOTHESES `falsifying_observation` lint for issue #479.
