### PR TITLE
feat(scripts,plan): require HYPOTHESES[].falsifying_observation (RD-1-3, #479)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "check:plugin-commands": "node ./scripts/sync-plugin-commands.cjs --check",
     "test:sdk": "npm run test --workspace=@a5c-ai/babysitter-sdk",
     "test:e2e:docker": "vitest run --config e2e-tests/docker/vitest.config.ts",
+    "check:processes": "node ./scripts/check-processes.mjs",
+    "test:check-processes": "node --test ./scripts/__tests__/check-processes.test.mjs",
     "build:sdk": "npm run build --workspace=@a5c-ai/babysitter-sdk",
     "token:eval": "bash scripts/eval-compression.sh",
     "build:observer": "npm run build --workspace=@a5c-ai/babysitter-observer-dashboard",

--- a/plugins/babysitter-codex/skills/plan/SKILL.md
+++ b/plugins/babysitter-codex/skills/plan/SKILL.md
@@ -6,3 +6,28 @@ description: Plan a babysitter run. use this command to plan a complex workflow,
 # plan
 
 Invoke the babysitter:babysit skill (using the Skill tool) and follow its instructions (SKILL.md). focus on creating the best process possible, but without creating and running the actual run.
+
+## HYPOTHESES authoring requirement
+
+When the process file you author exports a top-level `HYPOTHESES` array (for hypothesis-driven debugging or investigation runs), every entry MUST set `falsifying_observation` (or camelCase `falsifyingObservation`) to a non-empty string that names the specific observation that would falsify the hypothesis.
+
+The `check:processes` lint enforces this. Run `npm run check:processes` to verify before creating the run.
+
+### Why this is required
+
+Hypothesis ranking without falsification criteria is noise — an unfalsifiable hypothesis cannot be ranked, deprioritized, or eliminated by observation. The cookbook's VI-9 iOS Safari forensics demoted the actual root cause (H3) to LOW likelihood based on a soft argument; a required `falsifying_observation` field would have surfaced the missing criterion before two wasted forensic cycles.
+
+### Shape
+
+```js
+export const HYPOTHESES = [
+  {
+    id: 'H1',
+    title: 'Web Audio context auto-suspends',
+    prediction: 'cycle 2 wedges if AudioContext.state !== "running"',
+    falsifying_observation: 'cycle 2 wedges even when AudioContext.state === "running" at cycle-2 start',
+    likelihood: 'medium',
+  },
+  // ...
+];
+```

--- a/plugins/babysitter-cursor/skills/plan/SKILL.md
+++ b/plugins/babysitter-cursor/skills/plan/SKILL.md
@@ -6,3 +6,28 @@ description: Plan a babysitter run. use this command to plan a complex workflow,
 # plan
 
 Invoke the babysitter:babysit skill (using the Skill tool) and follow its instructions (SKILL.md). focus on creating the best process possible, but without creating and running the actual run.
+
+## HYPOTHESES authoring requirement
+
+When the process file you author exports a top-level `HYPOTHESES` array (for hypothesis-driven debugging or investigation runs), every entry MUST set `falsifying_observation` (or camelCase `falsifyingObservation`) to a non-empty string that names the specific observation that would falsify the hypothesis.
+
+The `check:processes` lint enforces this. Run `npm run check:processes` to verify before creating the run.
+
+### Why this is required
+
+Hypothesis ranking without falsification criteria is noise — an unfalsifiable hypothesis cannot be ranked, deprioritized, or eliminated by observation. The cookbook's VI-9 iOS Safari forensics demoted the actual root cause (H3) to LOW likelihood based on a soft argument; a required `falsifying_observation` field would have surfaced the missing criterion before two wasted forensic cycles.
+
+### Shape
+
+```js
+export const HYPOTHESES = [
+  {
+    id: 'H1',
+    title: 'Web Audio context auto-suspends',
+    prediction: 'cycle 2 wedges if AudioContext.state !== "running"',
+    falsifying_observation: 'cycle 2 wedges even when AudioContext.state === "running" at cycle-2 start',
+    likelihood: 'medium',
+  },
+  // ...
+];
+```

--- a/plugins/babysitter-github/skills/plan/SKILL.md
+++ b/plugins/babysitter-github/skills/plan/SKILL.md
@@ -6,3 +6,28 @@ description: Plan a babysitter run. use this command to plan a complex workflow,
 # plan
 
 Invoke the babysitter:babysit skill (using the Skill tool) and follow its instructions (SKILL.md). focus on creating the best process possible, but without creating and running the actual run.
+
+## HYPOTHESES authoring requirement
+
+When the process file you author exports a top-level `HYPOTHESES` array (for hypothesis-driven debugging or investigation runs), every entry MUST set `falsifying_observation` (or camelCase `falsifyingObservation`) to a non-empty string that names the specific observation that would falsify the hypothesis.
+
+The `check:processes` lint enforces this. Run `npm run check:processes` to verify before creating the run.
+
+### Why this is required
+
+Hypothesis ranking without falsification criteria is noise — an unfalsifiable hypothesis cannot be ranked, deprioritized, or eliminated by observation. The cookbook's VI-9 iOS Safari forensics demoted the actual root cause (H3) to LOW likelihood based on a soft argument; a required `falsifying_observation` field would have surfaced the missing criterion before two wasted forensic cycles.
+
+### Shape
+
+```js
+export const HYPOTHESES = [
+  {
+    id: 'H1',
+    title: 'Web Audio context auto-suspends',
+    prediction: 'cycle 2 wedges if AudioContext.state !== "running"',
+    falsifying_observation: 'cycle 2 wedges even when AudioContext.state === "running" at cycle-2 start',
+    likelihood: 'medium',
+  },
+  // ...
+];
+```

--- a/plugins/babysitter-omp/skills/plan/SKILL.md
+++ b/plugins/babysitter-omp/skills/plan/SKILL.md
@@ -6,3 +6,28 @@ description: Plan a babysitter run. use this command to plan a complex workflow,
 # plan
 
 Invoke the babysitter:babysit skill (using the Skill tool) and follow its instructions (SKILL.md). focus on creating the best process possible, but without creating and running the actual run.
+
+## HYPOTHESES authoring requirement
+
+When the process file you author exports a top-level `HYPOTHESES` array (for hypothesis-driven debugging or investigation runs), every entry MUST set `falsifying_observation` (or camelCase `falsifyingObservation`) to a non-empty string that names the specific observation that would falsify the hypothesis.
+
+The `check:processes` lint enforces this. Run `npm run check:processes` to verify before creating the run.
+
+### Why this is required
+
+Hypothesis ranking without falsification criteria is noise — an unfalsifiable hypothesis cannot be ranked, deprioritized, or eliminated by observation. The cookbook's VI-9 iOS Safari forensics demoted the actual root cause (H3) to LOW likelihood based on a soft argument; a required `falsifying_observation` field would have surfaced the missing criterion before two wasted forensic cycles.
+
+### Shape
+
+```js
+export const HYPOTHESES = [
+  {
+    id: 'H1',
+    title: 'Web Audio context auto-suspends',
+    prediction: 'cycle 2 wedges if AudioContext.state !== "running"',
+    falsifying_observation: 'cycle 2 wedges even when AudioContext.state === "running" at cycle-2 start',
+    likelihood: 'medium',
+  },
+  // ...
+];
+```

--- a/plugins/babysitter-opencode/skills/plan/SKILL.md
+++ b/plugins/babysitter-opencode/skills/plan/SKILL.md
@@ -6,3 +6,28 @@ description: Plan a babysitter run. use this command to plan a complex workflow,
 # plan
 
 Invoke the babysitter:babysit skill (using the Skill tool) and follow its instructions (SKILL.md). focus on creating the best process possible, but without creating and running the actual run.
+
+## HYPOTHESES authoring requirement
+
+When the process file you author exports a top-level `HYPOTHESES` array (for hypothesis-driven debugging or investigation runs), every entry MUST set `falsifying_observation` (or camelCase `falsifyingObservation`) to a non-empty string that names the specific observation that would falsify the hypothesis.
+
+The `check:processes` lint enforces this. Run `npm run check:processes` to verify before creating the run.
+
+### Why this is required
+
+Hypothesis ranking without falsification criteria is noise — an unfalsifiable hypothesis cannot be ranked, deprioritized, or eliminated by observation. The cookbook's VI-9 iOS Safari forensics demoted the actual root cause (H3) to LOW likelihood based on a soft argument; a required `falsifying_observation` field would have surfaced the missing criterion before two wasted forensic cycles.
+
+### Shape
+
+```js
+export const HYPOTHESES = [
+  {
+    id: 'H1',
+    title: 'Web Audio context auto-suspends',
+    prediction: 'cycle 2 wedges if AudioContext.state !== "running"',
+    falsifying_observation: 'cycle 2 wedges even when AudioContext.state === "running" at cycle-2 start',
+    likelihood: 'medium',
+  },
+  // ...
+];
+```

--- a/plugins/babysitter-pi/skills/plan/SKILL.md
+++ b/plugins/babysitter-pi/skills/plan/SKILL.md
@@ -6,3 +6,28 @@ description: Plan a babysitter run. use this command to plan a complex workflow,
 # plan
 
 Invoke the babysitter:babysit skill (using the Skill tool) and follow its instructions (SKILL.md). focus on creating the best process possible, but without creating and running the actual run.
+
+## HYPOTHESES authoring requirement
+
+When the process file you author exports a top-level `HYPOTHESES` array (for hypothesis-driven debugging or investigation runs), every entry MUST set `falsifying_observation` (or camelCase `falsifyingObservation`) to a non-empty string that names the specific observation that would falsify the hypothesis.
+
+The `check:processes` lint enforces this. Run `npm run check:processes` to verify before creating the run.
+
+### Why this is required
+
+Hypothesis ranking without falsification criteria is noise — an unfalsifiable hypothesis cannot be ranked, deprioritized, or eliminated by observation. The cookbook's VI-9 iOS Safari forensics demoted the actual root cause (H3) to LOW likelihood based on a soft argument; a required `falsifying_observation` field would have surfaced the missing criterion before two wasted forensic cycles.
+
+### Shape
+
+```js
+export const HYPOTHESES = [
+  {
+    id: 'H1',
+    title: 'Web Audio context auto-suspends',
+    prediction: 'cycle 2 wedges if AudioContext.state !== "running"',
+    falsifying_observation: 'cycle 2 wedges even when AudioContext.state === "running" at cycle-2 start',
+    likelihood: 'medium',
+  },
+  // ...
+];
+```

--- a/scripts/__fixtures__/processes/missing-falsifier/missing-falsifier.process.js
+++ b/scripts/__fixtures__/processes/missing-falsifier/missing-falsifier.process.js
@@ -1,0 +1,9 @@
+// Fixture: HYPOTHESES entry with no falsifier — lint should reject.
+export const HYPOTHESES = [
+  {
+    id: 'H1',
+    title: 'Network failure in upload path',
+    prediction: 'POST returns 500 under load',
+    likelihood: 'medium',
+  },
+];

--- a/scripts/__fixtures__/processes/mixed/missing-falsifier.process.js
+++ b/scripts/__fixtures__/processes/mixed/missing-falsifier.process.js
@@ -1,0 +1,9 @@
+// Fixture: HYPOTHESES entry with no falsifier — lint should reject.
+export const HYPOTHESES = [
+  {
+    id: 'H1',
+    title: 'Network failure in upload path',
+    prediction: 'POST returns 500 under load',
+    likelihood: 'medium',
+  },
+];

--- a/scripts/__fixtures__/processes/mixed/no-hypotheses.process.js
+++ b/scripts/__fixtures__/processes/mixed/no-hypotheses.process.js
@@ -1,0 +1,5 @@
+// Fixture: process file with no HYPOTHESES export. Lint should ignore it
+// entirely (backward compatibility with phase-list processes).
+export async function process() {
+  // body intentionally empty for the lint walker
+}

--- a/scripts/__fixtures__/processes/mixed/valid-camel.process.js
+++ b/scripts/__fixtures__/processes/mixed/valid-camel.process.js
@@ -1,0 +1,12 @@
+// Fixture: HYPOTHESES with camelCase `falsifyingObservation`. Lint should
+// accept either alias.
+export const HYPOTHESES = [
+  {
+    id: 'H1',
+    title: 'Migration drift between local and remote',
+    prediction: 'remote schema rejects insert that local accepts',
+    falsifyingObservation:
+      'remote insert succeeds with the same payload local accepts',
+    likelihood: 'low',
+  },
+];

--- a/scripts/__fixtures__/processes/mixed/valid.process.js
+++ b/scripts/__fixtures__/processes/mixed/valid.process.js
@@ -1,0 +1,20 @@
+// Fixture: HYPOTHESES with all required fields including snake_case
+// `falsifying_observation`. Lint should accept.
+export const HYPOTHESES = [
+  {
+    id: 'H1',
+    title: 'Audio context auto-suspends after cycle 1',
+    prediction: 'cycle 2 wedges if AudioContext.state !== "running"',
+    falsifying_observation:
+      'cycle 2 wedges even when AudioContext.state === "running" at cycle-2 start',
+    likelihood: 'medium',
+  },
+  {
+    id: 'H2',
+    title: 'Gesture token consumed by HTMLAudioElement.play()',
+    prediction: 'SpeechRecognition silently wedges after audio.play()',
+    falsifying_observation:
+      'SpeechRecognition emits onresult after audio.play() in the same gesture',
+    likelihood: 'high',
+  },
+];

--- a/scripts/__fixtures__/processes/no-hypotheses/no-hypotheses.process.js
+++ b/scripts/__fixtures__/processes/no-hypotheses/no-hypotheses.process.js
@@ -1,0 +1,5 @@
+// Fixture: process file with no HYPOTHESES export. Lint should ignore it
+// entirely (backward compatibility with phase-list processes).
+export async function process() {
+  // body intentionally empty for the lint walker
+}

--- a/scripts/__fixtures__/processes/valid-camel/valid-camel.process.js
+++ b/scripts/__fixtures__/processes/valid-camel/valid-camel.process.js
@@ -1,0 +1,12 @@
+// Fixture: HYPOTHESES with camelCase `falsifyingObservation`. Lint should
+// accept either alias.
+export const HYPOTHESES = [
+  {
+    id: 'H1',
+    title: 'Migration drift between local and remote',
+    prediction: 'remote schema rejects insert that local accepts',
+    falsifyingObservation:
+      'remote insert succeeds with the same payload local accepts',
+    likelihood: 'low',
+  },
+];

--- a/scripts/__fixtures__/processes/valid/valid.process.js
+++ b/scripts/__fixtures__/processes/valid/valid.process.js
@@ -1,0 +1,20 @@
+// Fixture: HYPOTHESES with all required fields including snake_case
+// `falsifying_observation`. Lint should accept.
+export const HYPOTHESES = [
+  {
+    id: 'H1',
+    title: 'Audio context auto-suspends after cycle 1',
+    prediction: 'cycle 2 wedges if AudioContext.state !== "running"',
+    falsifying_observation:
+      'cycle 2 wedges even when AudioContext.state === "running" at cycle-2 start',
+    likelihood: 'medium',
+  },
+  {
+    id: 'H2',
+    title: 'Gesture token consumed by HTMLAudioElement.play()',
+    prediction: 'SpeechRecognition silently wedges after audio.play()',
+    falsifying_observation:
+      'SpeechRecognition emits onresult after audio.play() in the same gesture',
+    likelihood: 'high',
+  },
+];

--- a/scripts/__tests__/check-processes.test.mjs
+++ b/scripts/__tests__/check-processes.test.mjs
@@ -1,0 +1,80 @@
+// Tests for scripts/check-processes.mjs — the HYPOTHESES falsifier lint.
+//
+// Uses Node's built-in node:test runner so no additional dev-deps are
+// required at the repo root (the existing `vitest` lives inside the
+// SDK workspace; this script is at the repo root and stays plain Node).
+//
+// Run:
+//   node --test scripts/__tests__/check-processes.test.mjs
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..', '..');
+const script = resolve(repoRoot, 'scripts', 'check-processes.mjs');
+const fixtures = resolve(repoRoot, 'scripts', '__fixtures__', 'processes');
+
+function runLint(subdir) {
+  const dir = resolve(fixtures, subdir);
+  return spawnSync('node', [script, '--dir', dir], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+}
+
+test('--self-test exits 0', () => {
+  const result = spawnSync('node', [script, '--self-test'], { encoding: 'utf8' });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /--self-test OK/);
+});
+
+test('valid (snake_case) → exit 0', () => {
+  const result = runLint('valid');
+  assert.equal(result.status, 0, `stderr=${result.stderr} stdout=${result.stdout}`);
+  assert.match(result.stdout, /all have falsifying_observation/);
+});
+
+test('valid (camelCase) → exit 0', () => {
+  const result = runLint('valid-camel');
+  assert.equal(result.status, 0, `stderr=${result.stderr} stdout=${result.stdout}`);
+  assert.match(result.stdout, /all have falsifying_observation/);
+});
+
+test('missing-falsifier → exit 1 with helpful message', () => {
+  const result = runLint('missing-falsifier');
+  assert.equal(result.status, 1, `stderr=${result.stderr} stdout=${result.stdout}`);
+  assert.match(result.stderr, /HYP-FAIL/);
+  assert.match(
+    result.stderr,
+    /falsifying_observation \(or falsifyingObservation\)/,
+  );
+});
+
+test('no-hypotheses → exit 0 (script ignores files without HYPOTHESES)', () => {
+  const result = runLint('no-hypotheses');
+  assert.equal(result.status, 0, `stderr=${result.stderr} stdout=${result.stdout}`);
+  assert.match(result.stdout, /Linted 0 HYPOTHESES array/);
+});
+
+test('mixed dir with one bad fixture → exit 1', () => {
+  const result = runLint('mixed');
+  assert.equal(result.status, 1, `stderr=${result.stderr} stdout=${result.stdout}`);
+  // Other fixtures still report their results — failure does not short-circuit.
+  assert.match(result.stdout, /OK   valid.process.js/);
+  assert.match(result.stdout, /OK   valid-camel.process.js/);
+  assert.match(result.stdout, /OK   no-hypotheses.process.js/);
+  assert.match(result.stderr, /HYP-FAIL missing-falsifier.process.js/);
+});
+
+test('missing directory → exit 0 with friendly note', () => {
+  const result = spawnSync(
+    'node',
+    [script, '--dir', resolve(fixtures, 'does-not-exist')],
+    { encoding: 'utf8' },
+  );
+  assert.equal(result.status, 0, `stderr=${result.stderr}`);
+  assert.match(result.stdout, /no process directory/);
+});

--- a/scripts/check-processes.mjs
+++ b/scripts/check-processes.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+// HYPOTHESES-falsifier lint for babysitter process files.
+//
+// When a process file exports a top-level `HYPOTHESES` array (or
+// `PROCESS.HYPOTHESES`), every entry MUST have non-empty `id`, `title`,
+// `prediction`, and a falsifier under either snake_case
+// (`falsifying_observation`) or camelCase (`falsifyingObservation`).
+//
+// Codifies the cookbook L7 lesson — "hypothesis ranking without
+// falsification criteria is noise" — and the May-27 voice-integration
+// retro AI-7 follow-up. Run before creating a HYPOTHESES-tree run:
+//   npm run check:processes
+//
+// CLI:
+//   node scripts/check-processes.mjs                       # default dir: .a5c/processes
+//   node scripts/check-processes.mjs --dir <path>          # custom directory
+//   node scripts/check-processes.mjs --self-test           # exits 0 immediately
+//
+// Process files without a `HYPOTHESES` export are unaffected (backward
+// compatible with every existing process module).
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+function parseArgs(argv) {
+  const args = { dir: null, selfTest: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--self-test') {
+      args.selfTest = true;
+    } else if (a === '--dir') {
+      args.dir = argv[++i];
+    } else if (a.startsWith('--dir=')) {
+      args.dir = a.slice('--dir='.length);
+    }
+  }
+  return args;
+}
+
+const args = parseArgs(process.argv.slice(2));
+
+if (args.selfTest) {
+  console.log('check-processes: --self-test OK');
+  process.exit(0);
+}
+
+const dir = resolve(process.cwd(), args.dir ?? '.a5c/processes');
+
+if (!existsSync(dir) || !statSync(dir).isDirectory()) {
+  console.log(`check-processes: no process directory at ${dir} — nothing to lint.`);
+  process.exit(0);
+}
+
+const files = readdirSync(dir).filter((f) => f.endsWith('.process.js'));
+
+let failed = 0;
+let hypLinted = 0;
+let hypFailed = 0;
+
+for (const f of files) {
+  const url = pathToFileURL(resolve(dir, f)).href;
+  let mod;
+  try {
+    mod = await import(url);
+    console.log(`  OK   ${f}`);
+  } catch (e) {
+    console.error(`  FAIL ${f}`);
+    console.error(`       ${e.message}`);
+    failed++;
+    continue;
+  }
+
+  // HYPOTHESES lint — optional, but if present each entry must have a falsifier.
+  const hyp = mod.HYPOTHESES ?? mod.PROCESS?.HYPOTHESES;
+  if (!Array.isArray(hyp)) continue;
+  hypLinted++;
+  const fieldNames = ['id', 'title', 'prediction'];
+  const falsifierAliases = ['falsifying_observation', 'falsifyingObservation'];
+  const problems = [];
+  hyp.forEach((entry, i) => {
+    if (!entry || typeof entry !== 'object') {
+      problems.push(`  - entry [${i}] is not an object`);
+      return;
+    }
+    for (const name of fieldNames) {
+      if (typeof entry[name] !== 'string' || entry[name].trim() === '') {
+        problems.push(`  - entry [${i}] (id=${entry.id ?? '?'}) missing/empty: ${name}`);
+      }
+    }
+    const fals = falsifierAliases.find(
+      (a) => typeof entry[a] === 'string' && entry[a].trim() !== '',
+    );
+    if (!fals) {
+      problems.push(
+        `  - entry [${i}] (id=${entry.id ?? '?'}) missing/empty: ` +
+          `falsifying_observation (or falsifyingObservation)`,
+      );
+    }
+  });
+  if (problems.length > 0) {
+    console.error(`  HYP-FAIL ${f}`);
+    for (const p of problems) console.error(p);
+    hypFailed++;
+  } else {
+    console.log(
+      `       HYPOTHESES (${hyp.length} entries) — all have falsifying_observation`,
+    );
+  }
+}
+
+if (failed > 0 || hypFailed > 0) {
+  if (failed > 0) {
+    console.error(`\n${failed} process file(s) failed to load. Fix before running them.`);
+  }
+  if (hypFailed > 0) {
+    console.error(
+      `${hypFailed} process file(s) have HYPOTHESES entries missing required fields ` +
+        `(see L7 — hypothesis ranking without falsification criteria is noise).`,
+    );
+  }
+  process.exit(1);
+}
+
+console.log(
+  `\nAll ${files.length} process file(s) load cleanly. ` +
+    `Linted ${hypLinted} HYPOTHESES array(s).`,
+);


### PR DESCRIPTION
## Summary

Adds `scripts/check-processes.mjs`, a small lint that walks any exported `HYPOTHESES` array in a `.a5c/processes/*.process.js` file and asserts every entry has a non-empty `falsifying_observation` (snake_case) or `falsifyingObservation` (camelCase). Wires `npm run check:processes` in `package.json`. Appends a "HYPOTHESES authoring requirement" section to the six `plugins/babysitter-{github,opencode,omp,pi,cursor,codex}/skills/plan/SKILL.md` plan-skill surfaces so the requirement is discoverable to the agents that author HYPOTHESES-tree plans.

## Closes

Closes #479 — the triage-bot comment on that issue is the spec; this PR is a verbatim implementation of its "Suggested Approach".

## Changes

| File | Change |
|---|---|
| `scripts/check-processes.mjs` (new) | The lint: walks exported HYPOTHESES, asserts non-empty `id`, `title`, `prediction`, and one of `falsifying_observation` / `falsifyingObservation`. Honors `--dir <path>` override and `--self-test` ergonomic flag. Exits 0 clean / 1 on any failure / 0 (no-op) when `.a5c/processes` is absent. |
| `package.json` | Add `check:processes` (spec-required) + `test:check-processes` (ergonomic alias) |
| `scripts/__fixtures__/processes/valid/valid.process.js` (new) | HYPOTHESES with snake_case `falsifying_observation` |
| `scripts/__fixtures__/processes/valid-camel/valid-camel.process.js` (new) | HYPOTHESES with camelCase `falsifyingObservation` |
| `scripts/__fixtures__/processes/missing-falsifier/missing-falsifier.process.js` (new) | HYPOTHESES entry missing falsifier (script should reject) |
| `scripts/__fixtures__/processes/no-hypotheses/no-hypotheses.process.js` (new) | Process with no HYPOTHESES export (script should ignore) |
| `scripts/__fixtures__/processes/mixed/*.process.js` (new) | All four fixtures copied into one directory for the multi-file exit-1 test |
| `scripts/__tests__/check-processes.test.mjs` (new) | 7 `node:test` cases covering all fixtures + `--self-test` + missing-directory no-op |
| `plugins/babysitter-{github,opencode,omp,pi,cursor,codex}/skills/plan/SKILL.md` (6 files) | Appended identical "## HYPOTHESES authoring requirement" section. Original 9-line wrapper preserved. |

## Behaviour

- **Default scan**: `.a5c/processes/*.process.js` (matches the cookbook convention).
- **Override**: `--dir <path>` for fixtures or alternate directories.
- **Ergonomics**: `--self-test` exits 0 immediately (useful in CI smoke).
- **Field rules** (per entry of an exported `HYPOTHESES` array):
  - `id`, `title`, `prediction` must each be a non-empty string
  - one of `falsifying_observation` (snake_case) / `falsifyingObservation` (camelCase) must be a non-empty string
- **Process files without HYPOTHESES are ignored** (script no-ops with success).
- **Output**: one line per file (`OK <file>` / `HYP-FAIL <file>` + indented bullets). Exit 0 on full clean; exit 1 on any failure.

## Tests

- 7 new `node:test` cases (no new dev-dep added)
- Manual checks:
  - `node scripts/check-processes.mjs --self-test` → exit 0
  - `node scripts/check-processes.mjs --dir scripts/__fixtures__/processes/mixed` → exit 1 (HYP-FAIL on the missing-falsifier fixture)
  - `npm run check:processes -- --self-test` → exit 0

Full SDK suite: 1505 passed / 9 failed; the 9 failures are pre-existing on `main` and unrelated to this PR's scope (this PR touches only `scripts/`, `package.json`, and the 6 plan SKILL.md surfaces — zero SDK runtime change).

## Cookbook reference implementation

The cookbook's local prototype (AI-7 from the May 22–27 voice-integration saga):
- `/Users/rogelsm/cookbook/scripts/validate-process.mjs` lines 36-69 — the HYPOTHESES walker

This PR ports that walker verbatim with three small adaptations: `--dir` override, `--self-test` flag, and graceful no-op when the default directory is absent. The walker's error messages, field aliases, and exit semantics are byte-for-byte the same. The cookbook script will eventually deprecate in favour of this upstream lint once it merges.

## Reference lesson

L7 from the cookbook retrospective at `.a5c/processes/voice-integration-retro-may-27.process.js`: "Hypothesis ranking without falsification criteria is noise."

The cookbook's VI-9 Phase A (iOS Safari forensics) demoted H3 (the actual root cause — Web Audio user-gesture token consumed by `HTMLAudioElement.play()`) to LOW likelihood based on a soft argument. A required `falsifying_observation` field would have forced the author to write *what observation would falsify H3*, which would have immediately surfaced: "H3 is FALSIFIED if cycle 2 also wedges with NO `HTMLAudioElement.play()` calls between cycles." That observation was trivially testable in Phase B; the missing field cost two wasted forensic cycles (Phase C / C2 / C3).

## Filed via

`/babysitter:yolo implement RD-1-3` (cookbook devplan-may-28, RD-1-3 = cradle-I1). Sibling of #564 (forwardFixStrikeBudget); the two PRs together complete RD-1-3.
