### PR TITLE
feat(library): add check-forbidden-markers pre-deploy gate (RD-2-3, #477)

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -371,6 +371,24 @@ A legacy array-format manifest is auto-normalized.
 
 ---
 
+## Built-in Quality Gates
+
+The `babysitter-unified` plugin ships a small set of pre-deploy gates as flat command markdown files under `plugins/babysitter-unified/commands/`. Each command pairs a user-facing slash invocation with a reusable composable helper under `library/processes/shared/`, so the gate can be invoked manually (slash command) or composed programmatically (helper import).
+
+### `babysitter:check-forbidden-markers`
+
+Pre-deploy substring grep for saga-era / obsolete code paths that must never re-ship after a refactor or restart-from-baseline. Reads a project-local `scripts/forbidden-markers.txt` (one marker per line; blank lines + `#` comments allowed) and scans every `.js` chunk under `.vercel/output/static/_next/static/chunks/` (Next.js / Vercel default; configurable for other frameworks).
+
+- **Helper:** `library/processes/shared/forbidden-markers-scanner.js` -- exports `parseForbiddenMarkers`, `scanForbiddenMarkers`, and the `checkForbiddenMarkersTask` `defineTask` wrapper.
+- **Slash command:** `plugins/babysitter-unified/commands/check-forbidden-markers.md`.
+- **Result shape:** `{ ok, hits: Array<{ marker, chunk, count }>, markerCount, chunkCount, reason }`. `reason` is one of `'missing-markers-file' | 'missing-chunks-dir' | 'empty-markers' | 'no-chunks' | 'clean' | 'hits'`.
+- **No-op semantics:** missing markers file, missing chunks dir, empty markers, and empty chunks all return `ok: true`. Only `reason: 'hits'` returns `ok: false` and should block a deploy. This keeps misconfiguration from ever becoming an outage source.
+- **Origin:** generalized from a cookbook prototype (`scripts/check-no-forbidden.mjs`) that caught two near-miss revivals of saga-era markers during the 2026-05 iOS-Safari restart.
+
+Issue: https://github.com/a5c-ai/babysitter/issues/477.
+
+---
+
 ## Further Reading
 
 - [CLI Reference](plugins/cli-reference.md) -- Complete command syntax, flags, and output schemas

--- a/library/processes/shared/README.md
+++ b/library/processes/shared/README.md
@@ -155,6 +155,83 @@ export async function process(inputs, ctx) {
 
 ---
 
+### `forbidden-markers-scanner`
+
+Pre-deploy gate that scans built JS chunks for substring markers listed in a project-local `forbidden-markers.txt`. Designed for projects coming off a restart-from-baseline (the "deploy after gate, not before" pattern) where obsolete saga-era / refactor-removed symbols must never re-ship. The grep is mechanical and the markers list is the contract.
+
+Origin: ported from a cookbook prototype (`scripts/check-no-forbidden.mjs`, 81 lines) that proved the pattern across the VI-restart / iOS-Safari saga (2026-05). See issue [#477](https://github.com/a5c-ai/babysitter/issues/477).
+
+**Import**
+
+```js
+import {
+  parseForbiddenMarkers,
+  scanForbiddenMarkers,
+  checkForbiddenMarkersTask,
+} from './index.js';
+```
+
+**`parseForbiddenMarkers` — synchronous parser**
+
+```js
+function parseForbiddenMarkers(content: string): string[];
+```
+
+Strips blank lines and full-line `#`-prefixed comments; trims each remaining line. Pure function, no I/O. Useful when the markers file lives somewhere unusual (env var, embedded fixture, etc.).
+
+**`scanForbiddenMarkers` — async scanner**
+
+```js
+async function scanForbiddenMarkers(params: {
+  markersFile: string;  // path to forbidden-markers.txt (required)
+  chunksDir:   string;  // path to a built chunks directory (required)
+}): Promise<{
+  ok: boolean;
+  hits: Array<{ marker: string, chunk: string, count: number }>;
+  markerCount: number;
+  chunkCount: number;
+  reason: 'missing-markers-file' | 'missing-chunks-dir' | 'empty-markers' | 'no-chunks' | 'clean' | 'hits';
+}>
+```
+
+Result semantics:
+
+| Situation                                | `ok`  | `hits` | `reason`              |
+|------------------------------------------|-------|--------|-----------------------|
+| `markersFile` does not exist             | true  | []     | `missing-markers-file`|
+| `chunksDir` does not exist               | true  | []     | `missing-chunks-dir`  |
+| markers parsed to an empty list          | true  | []     | `empty-markers`       |
+| `chunksDir` is empty of `.js` files      | true  | []     | `no-chunks`           |
+| scan ran, no marker found in any chunk   | true  | []     | `clean`               |
+| scan ran, at least one marker found      | false | [...]  | `hits`                |
+
+Missing config is a no-op (`ok: true`) by design: misconfiguration is never a deploy block. Only `reason: 'hits'` returns `ok: false`. Each hit includes the literal marker, the absolute chunk path, and the count of occurrences within that chunk; the same marker appearing in N chunks produces N hit entries.
+
+**Usage in a process**
+
+```js
+export async function process(inputs, ctx) {
+  // Direct call — resolves immediately, no harness task dispatched
+  const result = await scanForbiddenMarkers({
+    markersFile: 'scripts/forbidden-markers.txt',
+    chunksDir:   '.vercel/output/static/_next/static/chunks',
+  });
+  if (!result.ok) {
+    throw new Error(
+      `forbidden-markers gate FAILED: ${result.hits.length} hit(s) across ${result.chunkCount} chunks`
+    );
+  }
+
+  // Or dispatch as an orchestrated agent task
+  const gate = await ctx.task(checkForbiddenMarkersTask, {
+    projectDir: '.',
+    // markersFile / chunksDir are inferred from projectDir when omitted
+  });
+}
+```
+
+---
+
 ### `cost-aggregation`
 
 Aggregates cost-proxy metrics across related runs for cumulative effort reporting. Uses journal event counts and `EFFECT_REQUESTED` events as lightweight proxies for computational effort (actual monetary cost being, like contentment, essentially unknowable).
@@ -1084,6 +1161,9 @@ export async function process(inputs, ctx) {
 | `evaluateCompleteness` | `completeness-gate` | `function` | Synchronous evaluation given explicit issue + resolution data |
 | `checkCompleteness` | `completeness-gate` | `async function` | Async evaluation that mines a run directory for evidence |
 | `completenessGateTask` | `completeness-gate` | `TaskDef` | `defineTask` wrapper for harness-driven execution |
+| `parseForbiddenMarkers` | `forbidden-markers-scanner` | `function` | Sync parser for `forbidden-markers.txt` (strips blank lines + `#` comments) |
+| `scanForbiddenMarkers` | `forbidden-markers-scanner` | `async function` | Pre-deploy gate: scan built `.js` chunks for forbidden substring markers |
+| `checkForbiddenMarkersTask` | `forbidden-markers-scanner` | `TaskDef` | `defineTask` wrapper for harness-driven execution |
 | `aggregateCosts` | `cost-aggregation` | `async function` | Aggregate cost-proxy metrics across related runs |
 | `costAggregationTask` | `cost-aggregation` | `TaskDef` | `defineTask` wrapper for harness-driven execution |
 | `createTddTriplet` | `tdd-triplet` | `function` | Factory that returns three `defineTask` descriptors for the write-tests, run-tests, and validate phases |

--- a/library/processes/shared/__tests__/forbidden-markers-scanner.test.mjs
+++ b/library/processes/shared/__tests__/forbidden-markers-scanner.test.mjs
@@ -1,0 +1,339 @@
+/**
+ * Standalone node:test suite for forbidden-markers-scanner.
+ *
+ * Uses `node:test` + `node:assert/strict` so it can be invoked without any
+ * test framework setup. Run with:
+ *   node --test library/processes/shared/__tests__/forbidden-markers-scanner.test.mjs
+ * or via the top-level npm script:
+ *   npm run test:shared
+ *
+ * Test scope: parser + scanner only. The `defineTask` wrapper is a thin pass-
+ * through to the scanner — its shape is covered by JSON-schema declarations
+ * in the source and the library smoke test (`library/__tests__/smoke.test.mjs`).
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  parseForbiddenMarkers,
+  scanForbiddenMarkers,
+} from '../forbidden-markers-scanner.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeTempRoot() {
+  return mkdtempSync(join(tmpdir(), 'fm-scanner-'));
+}
+
+function writeMarkersFile(root, body) {
+  const p = join(root, 'forbidden-markers.txt');
+  writeFileSync(p, body, 'utf8');
+  return p;
+}
+
+function makeChunksDir(root, files = {}) {
+  const dir = join(root, 'chunks');
+  mkdirSync(dir, { recursive: true });
+  for (const [name, body] of Object.entries(files)) {
+    writeFileSync(join(dir, name), body, 'utf8');
+  }
+  return dir;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// parseForbiddenMarkers
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('parseForbiddenMarkers', () => {
+  it('strips blank lines, comments, and whitespace', () => {
+    const content = [
+      '# Saga-era markers',
+      'single-breath',
+      '   hands-free-stuck   ',
+      '',
+      '# group two',
+      'MAX_RECOVERY_FAILURES',
+      '   # indented comment is still a comment? — no, only leading-# counts after trim',
+      '',
+    ].join('\n');
+
+    const out = parseForbiddenMarkers(content);
+    assert.deepEqual(out, [
+      'single-breath',
+      'hands-free-stuck',
+      'MAX_RECOVERY_FAILURES',
+    ]);
+  });
+
+  it('returns an empty array for an empty body', () => {
+    assert.deepEqual(parseForbiddenMarkers(''), []);
+  });
+
+  it('returns an empty array for a comments-only body', () => {
+    const content = '# only\n# comments\n# here\n';
+    assert.deepEqual(parseForbiddenMarkers(content), []);
+  });
+
+  it('returns an empty array when content is null/undefined', () => {
+    assert.deepEqual(parseForbiddenMarkers(null), []);
+    assert.deepEqual(parseForbiddenMarkers(undefined), []);
+  });
+
+  it('handles CRLF line endings', () => {
+    const content = 'foo\r\nbar\r\n# comment\r\nbaz\r\n';
+    assert.deepEqual(parseForbiddenMarkers(content), ['foo', 'bar', 'baz']);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// scanForbiddenMarkers — required-args contract
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('scanForbiddenMarkers — argument validation', () => {
+  it('throws when markersFile is missing', async () => {
+    await assert.rejects(
+      () => scanForbiddenMarkers({ chunksDir: '/tmp/whatever' }),
+      /markersFile is required/,
+    );
+  });
+
+  it('throws when chunksDir is missing', async () => {
+    await assert.rejects(
+      () => scanForbiddenMarkers({ markersFile: '/tmp/whatever.txt' }),
+      /chunksDir is required/,
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// scanForbiddenMarkers — no-op states
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('scanForbiddenMarkers — no-op states', () => {
+  it('missing markers file → ok:true reason:missing-markers-file', async () => {
+    const root = makeTempRoot();
+    try {
+      const chunksDir = makeChunksDir(root, { 'a.js': 'console.log(1);' });
+      const result = await scanForbiddenMarkers({
+        markersFile: join(root, 'does-not-exist.txt'),
+        chunksDir,
+      });
+      assert.equal(result.ok, true);
+      assert.deepEqual(result.hits, []);
+      assert.equal(result.markerCount, 0);
+      assert.equal(result.chunkCount, 0);
+      assert.equal(result.reason, 'missing-markers-file');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('missing chunks dir → ok:true reason:missing-chunks-dir', async () => {
+    const root = makeTempRoot();
+    try {
+      const markersFile = writeMarkersFile(root, 'foo\nbar\n');
+      const result = await scanForbiddenMarkers({
+        markersFile,
+        chunksDir: join(root, 'does-not-exist-chunks'),
+      });
+      assert.equal(result.ok, true);
+      assert.deepEqual(result.hits, []);
+      assert.equal(result.markerCount, 2);
+      assert.equal(result.chunkCount, 0);
+      assert.equal(result.reason, 'missing-chunks-dir');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('empty markers list → ok:true reason:empty-markers', async () => {
+    const root = makeTempRoot();
+    try {
+      const markersFile = writeMarkersFile(root, '# only comments\n\n');
+      const chunksDir = makeChunksDir(root, { 'a.js': 'console.log(1);' });
+      const result = await scanForbiddenMarkers({ markersFile, chunksDir });
+      assert.equal(result.ok, true);
+      assert.deepEqual(result.hits, []);
+      assert.equal(result.markerCount, 0);
+      assert.equal(result.chunkCount, 0);
+      assert.equal(result.reason, 'empty-markers');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('chunks dir with no .js files → ok:true reason:no-chunks', async () => {
+    const root = makeTempRoot();
+    try {
+      const markersFile = writeMarkersFile(root, 'foo\n');
+      const chunksDir = makeChunksDir(root, {
+        'README.md': '# not a chunk',
+        'styles.css': 'body{}',
+      });
+      const result = await scanForbiddenMarkers({ markersFile, chunksDir });
+      assert.equal(result.ok, true);
+      assert.deepEqual(result.hits, []);
+      assert.equal(result.markerCount, 1);
+      assert.equal(result.chunkCount, 0);
+      assert.equal(result.reason, 'no-chunks');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// scanForbiddenMarkers — clean
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('scanForbiddenMarkers — clean chunks', () => {
+  it('no marker present in any chunk → ok:true reason:clean hits:[]', async () => {
+    const root = makeTempRoot();
+    try {
+      const markersFile = writeMarkersFile(root, 'forbidden\nbanned\n');
+      const chunksDir = makeChunksDir(root, {
+        'a.js': 'export const x = 1;',
+        'b.js': 'export const y = 2;',
+        'c.js': 'export const z = 3;',
+      });
+      const result = await scanForbiddenMarkers({ markersFile, chunksDir });
+      assert.equal(result.ok, true);
+      assert.deepEqual(result.hits, []);
+      assert.equal(result.markerCount, 2);
+      assert.equal(result.chunkCount, 3);
+      assert.equal(result.reason, 'clean');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// scanForbiddenMarkers — hits
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('scanForbiddenMarkers — hits', () => {
+  it('1 marker × 1 chunk → ok:false with structured hit', async () => {
+    const root = makeTempRoot();
+    try {
+      const markersFile = writeMarkersFile(root, 'single-breath\n');
+      const chunksDir = makeChunksDir(root, {
+        'page.js': 'function x(){return "single-breath";}',
+        'other.js': 'console.log("ok");',
+      });
+      const result = await scanForbiddenMarkers({ markersFile, chunksDir });
+      assert.equal(result.ok, false);
+      assert.equal(result.reason, 'hits');
+      assert.equal(result.markerCount, 1);
+      assert.equal(result.chunkCount, 2);
+      assert.equal(result.hits.length, 1);
+      assert.equal(result.hits[0].marker, 'single-breath');
+      assert.match(result.hits[0].chunk, /page\.js$/);
+      assert.equal(result.hits[0].count, 1);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('same marker in N chunks → N hit entries', async () => {
+    const root = makeTempRoot();
+    try {
+      const markersFile = writeMarkersFile(root, 'BAD_THING\n');
+      const chunksDir = makeChunksDir(root, {
+        'a.js': 'BAD_THING',
+        'b.js': 'BAD_THING',
+        'c.js': 'BAD_THING',
+        'd.js': 'totally-fine',
+      });
+      const result = await scanForbiddenMarkers({ markersFile, chunksDir });
+      assert.equal(result.ok, false);
+      assert.equal(result.reason, 'hits');
+      assert.equal(result.hits.length, 3);
+      const chunkNames = result.hits.map(h => h.chunk.split('/').pop()).sort();
+      assert.deepEqual(chunkNames, ['a.js', 'b.js', 'c.js']);
+      for (const h of result.hits) {
+        assert.equal(h.marker, 'BAD_THING');
+        assert.equal(h.count, 1);
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('1 marker M times in single chunk → count == M', async () => {
+    const root = makeTempRoot();
+    try {
+      const markersFile = writeMarkersFile(root, 'OOPS\n');
+      // 4 occurrences of OOPS, plus overlapping non-occurrences to verify the
+      // counter does not over-count via overlap or under-count via greedy step.
+      const body = 'OOPS-OOPS_OOPS+OOPS.NOT_OOPSY but OOPS prefix';
+      // Count manually: 'OOPS' at indices 0, 5, 10, 15, 24, 35 — let's compute.
+      const chunksDir = makeChunksDir(root, { 'noisy.js': body });
+      const expected = (body.match(/OOPS/g) || []).length;
+      const result = await scanForbiddenMarkers({ markersFile, chunksDir });
+      assert.equal(result.ok, false);
+      assert.equal(result.hits.length, 1);
+      assert.equal(result.hits[0].marker, 'OOPS');
+      assert.equal(result.hits[0].count, expected);
+      assert(expected >= 4, `sanity: expected at least 4 occurrences, got ${expected}`);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('multiple markers, multiple chunks → one hit per (marker, chunk) pair', async () => {
+    const root = makeTempRoot();
+    try {
+      const markersFile = writeMarkersFile(root, 'alpha\nbeta\n');
+      const chunksDir = makeChunksDir(root, {
+        'x.js': 'alpha beta alpha',          // alpha × 2, beta × 1
+        'y.js': 'beta beta beta',            // beta × 3
+        'z.js': 'no markers here',           // none
+      });
+      const result = await scanForbiddenMarkers({ markersFile, chunksDir });
+      assert.equal(result.ok, false);
+      assert.equal(result.markerCount, 2);
+      assert.equal(result.chunkCount, 3);
+
+      // Build an easy lookup: (chunkBasename, marker) → count
+      const map = new Map();
+      for (const h of result.hits) {
+        map.set(`${h.chunk.split('/').pop()}::${h.marker}`, h.count);
+      }
+      assert.equal(map.get('x.js::alpha'), 2);
+      assert.equal(map.get('x.js::beta'), 1);
+      assert.equal(map.get('y.js::beta'), 3);
+      assert.equal(map.get('y.js::alpha'), undefined);
+      assert.equal(map.get('z.js::alpha'), undefined);
+      assert.equal(map.get('z.js::beta'), undefined);
+      assert.equal(result.hits.length, 3);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('non-.js files in chunks dir are ignored', async () => {
+    const root = makeTempRoot();
+    try {
+      const markersFile = writeMarkersFile(root, 'forbidden\n');
+      const chunksDir = makeChunksDir(root, {
+        'a.js': 'totally clean',
+        'README.md': 'forbidden — but this is not a chunk',
+        'styles.css': 'forbidden',
+      });
+      const result = await scanForbiddenMarkers({ markersFile, chunksDir });
+      assert.equal(result.ok, true);
+      assert.equal(result.reason, 'clean');
+      assert.equal(result.chunkCount, 1);
+      assert.deepEqual(result.hits, []);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/library/processes/shared/forbidden-markers-scanner.js
+++ b/library/processes/shared/forbidden-markers-scanner.js
@@ -1,0 +1,402 @@
+/**
+ * @module forbidden-markers-scanner
+ * @description Composable pre-deploy gate that scans built JS chunks for substring
+ * markers listed in a project-local `forbidden-markers.txt`. Designed for injection
+ * into deploy and quality-gate processes to enforce structural guarantees against
+ * the revival of saga-era / obsolete code paths after a refactor.
+ *
+ * The module provides three surfaces:
+ * - `parseForbiddenMarkers` — synchronous parser (blank lines + `#` comments stripped)
+ * - `scanForbiddenMarkers`  — async scanner returning structured `{ ok, hits, reason }`
+ * - `checkForbiddenMarkersTask` — babysitter `defineTask` wrapper for harness-driven use
+ *
+ * Origin: ported from the cookbook prototype `scripts/check-no-forbidden.mjs`,
+ * which proved the pattern across the VI-restart / iOS-Safari saga (2026-05).
+ * Upstreamed for the babysitter process library per issue #477.
+ *
+ * @see https://github.com/a5c-ai/babysitter/issues/477
+ *
+ * @graph
+ *   domains: [domain:software-engineering]
+ *   skillAreas: [skill-area:code-review-practice, skill-area:e2e-testing]
+ *   workflows: [workflow:code-review, workflow:feature-development, workflow:release-management]
+ *   topics: [topic:test-driven-development, topic:code-review-best-practices]
+ *   roles: [role:backend-engineer, role:tech-lead, role:qa-engineer]
+ */
+
+import { defineTask } from '@a5c-ai/babysitter-sdk';
+import { promises as fs } from 'fs';
+import path from 'path';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// parseForbiddenMarkers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Parses the body of a forbidden-markers file into a list of marker strings.
+ *
+ * Strips blank lines and full-line `#`-prefixed comments. Each remaining line
+ * is trimmed; the resulting non-empty strings are returned in source order.
+ *
+ * Synchronous and side-effect-free — callers supply the file contents.
+ *
+ * @param {string} content  Raw file body (UTF-8 text from `forbidden-markers.txt`).
+ * @returns {string[]} Markers in source order.
+ */
+export function parseForbiddenMarkers(content) {
+  if (typeof content !== 'string' || content.length === 0) return [];
+
+  return content
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(line => line.length > 0 && !line.startsWith('#'));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// scanForbiddenMarkers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * @typedef {Object} ForbiddenMarkerHit
+ * @property {string} marker  Literal marker string that appeared in the chunk.
+ * @property {string} chunk   Absolute path to the chunk file containing the marker.
+ * @property {number} count   Number of occurrences of the marker within that chunk.
+ */
+
+/**
+ * @typedef {('missing-markers-file'|'missing-chunks-dir'|'empty-markers'|'no-chunks'|'clean'|'hits')} ForbiddenMarkerReason
+ */
+
+/**
+ * @typedef {Object} ForbiddenMarkerResult
+ * @property {boolean} ok                 True for clean / no-op states; false only when `hits.length > 0`.
+ * @property {ForbiddenMarkerHit[]} hits  Marker × chunk hits with occurrence counts.
+ * @property {number} markerCount         Number of markers actually checked (after parsing).
+ * @property {number} chunkCount          Number of `.js` chunks scanned.
+ * @property {ForbiddenMarkerReason} reason  Tag describing why the result shape is what it is.
+ */
+
+/**
+ * Counts the number of occurrences of `needle` (literal substring) in `haystack`.
+ *
+ * Uses `indexOf` advancement rather than a global regex to avoid the cost of
+ * regex escaping for arbitrary marker strings.
+ *
+ * @param {string} haystack  The content to scan.
+ * @param {string} needle    The literal substring to count.
+ * @returns {number} Number of occurrences (0 if needle is empty).
+ */
+function countOccurrences(haystack, needle) {
+  if (!needle) return 0;
+  let count = 0;
+  let from = 0;
+  while (true) {
+    const idx = haystack.indexOf(needle, from);
+    if (idx === -1) break;
+    count++;
+    from = idx + needle.length;
+  }
+  return count;
+}
+
+/**
+ * Reads a file as UTF-8 text. Returns null on any I/O error so callers can
+ * skip unreadable chunks without failing the whole scan.
+ *
+ * @param {string} filePath
+ * @returns {Promise<string|null>}
+ */
+async function readFileSafe(filePath) {
+  try {
+    return await fs.readFile(filePath, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Checks whether a path exists. Returns null when it does not (or on permission
+ * errors). Returns a fs.Stats object when it does.
+ *
+ * @param {string} p
+ * @returns {Promise<import('fs').Stats|null>}
+ */
+async function statSafe(p) {
+  try {
+    return await fs.stat(p);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Scans every `.js` chunk under `chunksDir` for any of the markers listed in
+ * `markersFile`. Both paths are required arguments — callers supply project-
+ * specific defaults (see the babysitter task wrapper below for Next.js
+ * conventions).
+ *
+ * Result semantics:
+ *
+ * | Situation                                | `ok`  | `hits` | `reason`              |
+ * |------------------------------------------|-------|--------|-----------------------|
+ * | `markersFile` does not exist             | true  | []     | 'missing-markers-file'|
+ * | `chunksDir` does not exist               | true  | []     | 'missing-chunks-dir'  |
+ * | markers parsed to an empty list          | true  | []     | 'empty-markers'       |
+ * | `chunksDir` is empty of `.js` files      | true  | []     | 'no-chunks'           |
+ * | scan ran, no marker found in any chunk   | true  | []     | 'clean'               |
+ * | scan ran, at least one marker found      | false | [...]  | 'hits'                |
+ *
+ * Both missing-config sentinels return `ok: true` by design: misconfiguration
+ * is a no-op, not a failure. Opt-in is structural — projects that want the
+ * gate enforced check the `reason` field explicitly (or chain a "is the
+ * config file present?" pre-check). This matches the cookbook prototype's
+ * "safe to chain into `check:all` before the build runs" semantics for the
+ * chunks-dir side, and softens the prototype's markers-file behaviour from
+ * "exit 1" to "ok: true" so a missing-config library is never a deploy block.
+ *
+ * @param {Object} params
+ * @param {string} params.markersFile  Absolute or relative path to `forbidden-markers.txt`.
+ * @param {string} params.chunksDir    Absolute or relative path to a built chunks directory.
+ * @returns {Promise<ForbiddenMarkerResult>}
+ */
+export async function scanForbiddenMarkers({ markersFile, chunksDir } = {}) {
+  if (typeof markersFile !== 'string' || markersFile.length === 0) {
+    throw new TypeError('scanForbiddenMarkers: markersFile is required');
+  }
+  if (typeof chunksDir !== 'string' || chunksDir.length === 0) {
+    throw new TypeError('scanForbiddenMarkers: chunksDir is required');
+  }
+
+  // ── markers file existence + parse ──────────────────────────────────────
+  const markersContent = await readFileSafe(markersFile);
+  if (markersContent === null) {
+    return {
+      ok: true,
+      hits: [],
+      markerCount: 0,
+      chunkCount: 0,
+      reason: 'missing-markers-file',
+    };
+  }
+
+  const markers = parseForbiddenMarkers(markersContent);
+  if (markers.length === 0) {
+    return {
+      ok: true,
+      hits: [],
+      markerCount: 0,
+      chunkCount: 0,
+      reason: 'empty-markers',
+    };
+  }
+
+  // ── chunks dir existence ────────────────────────────────────────────────
+  const chunksStat = await statSafe(chunksDir);
+  if (chunksStat === null || !chunksStat.isDirectory()) {
+    return {
+      ok: true,
+      hits: [],
+      markerCount: markers.length,
+      chunkCount: 0,
+      reason: 'missing-chunks-dir',
+    };
+  }
+
+  let entries;
+  try {
+    entries = await fs.readdir(chunksDir);
+  } catch {
+    return {
+      ok: true,
+      hits: [],
+      markerCount: markers.length,
+      chunkCount: 0,
+      reason: 'missing-chunks-dir',
+    };
+  }
+
+  const chunkPaths = entries
+    .filter(name => name.endsWith('.js'))
+    .map(name => path.resolve(chunksDir, name));
+
+  if (chunkPaths.length === 0) {
+    return {
+      ok: true,
+      hits: [],
+      markerCount: markers.length,
+      chunkCount: 0,
+      reason: 'no-chunks',
+    };
+  }
+
+  // ── scan ─────────────────────────────────────────────────────────────────
+  /** @type {ForbiddenMarkerHit[]} */
+  const hits = [];
+
+  for (const chunkPath of chunkPaths) {
+    const body = await readFileSafe(chunkPath);
+    if (body === null) continue; // unreadable chunk — skip, don't fail the scan
+
+    for (const marker of markers) {
+      const count = countOccurrences(body, marker);
+      if (count > 0) {
+        hits.push({ marker, chunk: chunkPath, count });
+      }
+    }
+  }
+
+  if (hits.length === 0) {
+    return {
+      ok: true,
+      hits: [],
+      markerCount: markers.length,
+      chunkCount: chunkPaths.length,
+      reason: 'clean',
+    };
+  }
+
+  return {
+    ok: false,
+    hits,
+    markerCount: markers.length,
+    chunkCount: chunkPaths.length,
+    reason: 'hits',
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// checkForbiddenMarkersTask
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Default markers-file path, relative to a project root.
+ * Mirrors the cookbook convention (`scripts/forbidden-markers.txt`).
+ */
+const DEFAULT_MARKERS_FILE = 'scripts/forbidden-markers.txt';
+
+/**
+ * Default chunks dir, relative to a project root. Matches the Next.js / Vercel
+ * output directory layout (`vercel build` → `.vercel/output/static/_next/...`).
+ * Override via the task `args.chunksDir` for other frameworks (Vite, Remix, etc.).
+ */
+const DEFAULT_CHUNKS_DIR = '.vercel/output/static/_next/static/chunks';
+
+/**
+ * Babysitter task definition for the forbidden-markers pre-deploy gate.
+ *
+ * Use this when the gate should run as an orchestrated agent task within a
+ * harness-driven run (e.g. just before a `vercel deploy --prod` step). For
+ * direct programmatic use, prefer the exported `scanForbiddenMarkers` function.
+ *
+ * Task inputs (passed as `args`):
+ * - `projectDir`   {string} — project root (default: process cwd at task time)
+ * - `markersFile`  {string} — override markers file path (default: `<projectDir>/scripts/forbidden-markers.txt`)
+ * - `chunksDir`    {string} — override chunks dir path (default: `<projectDir>/.vercel/output/static/_next/static/chunks`)
+ *
+ * Task output (written to the io outputJsonPath):
+ * - `ok`           {boolean}
+ * - `hits`         {Array<{ marker, chunk, count }>}
+ * - `markerCount`  {number}
+ * - `chunkCount`   {number}
+ * - `reason`       {'missing-markers-file'|'missing-chunks-dir'|'empty-markers'|'no-chunks'|'clean'|'hits'}
+ *
+ * The wrapped agent invokes the `scanForbiddenMarkers` helper directly; it does
+ * NOT re-implement the scanning logic. This keeps behaviour bit-identical to
+ * direct programmatic use.
+ *
+ * @see https://github.com/a5c-ai/babysitter/issues/477
+ */
+export const checkForbiddenMarkersTask = defineTask(
+  'check-forbidden-markers',
+  (args, taskCtx) => {
+    const projectDir = args.projectDir ?? '.';
+    const markersFile = args.markersFile ?? path.join(projectDir, DEFAULT_MARKERS_FILE);
+    const chunksDir = args.chunksDir ?? path.join(projectDir, DEFAULT_CHUNKS_DIR);
+
+    return {
+      kind: 'agent',
+      title: 'Pre-deploy gate: scan built chunks for forbidden markers',
+      agent: {
+        name: 'general-purpose',
+        prompt: {
+          role: 'Pre-deploy gate auditor scanning built chunks for forbidden markers',
+          task: `Use the scanForbiddenMarkers helper from \`library/processes/shared/forbidden-markers-scanner.js\` to scan a built chunks directory for substring markers listed in a forbidden-markers file.
+
+Inputs provided:
+- projectDir:  ${JSON.stringify(projectDir)}
+- markersFile: ${JSON.stringify(markersFile)}
+- chunksDir:   ${JSON.stringify(chunksDir)}
+
+Steps:
+1. Import scanForbiddenMarkers from the shared library (or call it directly when the
+   runtime allows). Pass { markersFile, chunksDir }.
+2. Treat the result's \`reason\` field as the primary discriminator:
+   - 'missing-markers-file' / 'missing-chunks-dir' / 'empty-markers' / 'no-chunks' / 'clean' → ok:true
+   - 'hits' → ok:false; emit the structured hits array verbatim.
+3. Write the full result object as JSON to the task output path.
+4. Do NOT mutate the chunks directory or the markers file.
+
+Output JSON (write to the task output path):
+{
+  "ok":          <boolean>,
+  "hits":        [ { "marker": "<string>", "chunk": "<absolute path>", "count": <number> } ],
+  "markerCount": <number>,
+  "chunkCount":  <number>,
+  "reason":      "<missing-markers-file|missing-chunks-dir|empty-markers|no-chunks|clean|hits>"
+}`,
+          context: {
+            projectDir,
+            markersFile,
+            chunksDir,
+          },
+          instructions: [
+            'Never modify the chunks directory or the markers file',
+            'A missing markers file or missing chunks dir is a no-op (ok:true), not a failure',
+            'Empty markers list and empty chunks dir are also no-ops',
+            'Only reason="hits" should set ok:false',
+            'Each hit must include marker, chunk (absolute path), and count (>=1)',
+            'Output must be valid JSON matching the schema above',
+          ],
+          outputFormat: 'JSON with ok (boolean), hits (array), markerCount, chunkCount, reason',
+        },
+        outputSchema: {
+          type: 'object',
+          required: ['ok', 'hits', 'markerCount', 'chunkCount', 'reason'],
+          properties: {
+            ok:          { type: 'boolean' },
+            hits: {
+              type: 'array',
+              items: {
+                type: 'object',
+                required: ['marker', 'chunk', 'count'],
+                properties: {
+                  marker: { type: 'string' },
+                  chunk:  { type: 'string' },
+                  count:  { type: 'number' },
+                },
+              },
+            },
+            markerCount: { type: 'number' },
+            chunkCount:  { type: 'number' },
+            reason: {
+              type: 'string',
+              enum: [
+                'missing-markers-file',
+                'missing-chunks-dir',
+                'empty-markers',
+                'no-chunks',
+                'clean',
+                'hits',
+              ],
+            },
+          },
+        },
+      },
+      io: {
+        inputJsonPath:  `tasks/${taskCtx.effectId}/input.json`,
+        outputJsonPath: `tasks/${taskCtx.effectId}/output.json`,
+      },
+      labels: ['pre-deploy', 'gate', 'forbidden-markers'],
+    };
+  }
+);

--- a/library/processes/shared/index.js
+++ b/library/processes/shared/index.js
@@ -14,6 +14,7 @@
 
 export { priorAttemptsScannerTask, scanPriorAttempts } from './prior-attempts-scanner.js';
 export { completenessGateTask, evaluateCompleteness, checkCompleteness } from './completeness-gate.js';
+export { checkForbiddenMarkersTask, scanForbiddenMarkers, parseForbiddenMarkers } from './forbidden-markers-scanner.js';
 export { costAggregationTask, aggregateCosts } from './cost-aggregation.js';
 export { createTddTriplet, executeTddTriplet } from './tdd-triplet.js';
 export { createVisualSmokeTest, executeVisualSmokeTest, playwrightVisualSmokeTask } from './playwright-visual-smoke.js';

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "check:plugin-commands": "node ./scripts/sync-plugin-commands.cjs --check",
     "test:sdk": "npm run test --workspace=@a5c-ai/babysitter-sdk",
     "test:library": "vitest run --config library/vitest.config.mjs",
+    "test:shared": "node --test library/processes/shared/__tests__/*.test.mjs",
     "build:sdk": "npm run build --workspace=@a5c-ai/atlas && npm run build --workspace=@a5c-ai/agent-catalog && npm run build --workspace=@a5c-ai/babysitter-sdk",
     "build:agent-mux:non-realtime": "npm run build --workspace=@a5c-ai/agent-mux-observability && npm run build --workspace=@a5c-ai/agent-comm-mux && npm run build --workspace=@a5c-ai/agent-mux-adapters && npm run build --workspace=@a5c-ai/agent-mux-gateway && npm run build --workspace=@a5c-ai/transport-mux && npm run build --workspace=@a5c-ai/agent-mux-cli && npm run build --workspace=@a5c-ai/agent-mux",
     "build:runtime:agent-core-deps": "npm run build:sdk && npm run build:agent-mux:non-realtime && npm run build --workspace=@a5c-ai/agent-runtime",

--- a/plugins/babysitter-unified/commands/check-forbidden-markers.md
+++ b/plugins/babysitter-unified/commands/check-forbidden-markers.md
@@ -1,0 +1,68 @@
+---
+description: Pre-deploy gate that scans built JS chunks for forbidden substring markers (saga-era / obsolete code paths) listed in a project-local forbidden-markers.txt
+argument-hint: "[--markers-file <path>] [--chunks-dir <path>] [--json] Optional overrides; defaults are project-relative."
+allowed-tools: Read, Grep, Write, Task, Bash, Edit, Grep, Glob, WebFetch, WebSearch, Search, AskUserQuestion, TodoWrite, TodoRead, Skill, BashOutput, KillShell, MultiEdit, LS
+---
+
+Invoke the babysitter:babysit skill (using the Skill tool) and follow its instructions (SKILL.md). Compose the gate from the shared helper at `library/processes/shared/forbidden-markers-scanner.js` (issue #477).
+
+## What this gate does
+
+Reads a list of literal substring markers from `scripts/forbidden-markers.txt` (blank lines and `#`-prefixed comments stripped) and greps every `.js` chunk under `.vercel/output/static/_next/static/chunks/` (Next.js / Vercel default; configurable) for any occurrence. Reports structured hits per `(marker, chunk)` pair with occurrence counts. Designed to chain between `vercel build --prod` and `vercel deploy --prod`.
+
+Use this gate when a refactor or restart-from-baseline replaced load-bearing code paths and you need a structural guarantee the obsolete symbols never re-ship. Burned-in evidence: cookbook VI-9 / VI-12 near-miss revivals during the 2026-05 iOS-Safari saga; the prototype lives at `cookbook/scripts/check-no-forbidden.mjs` and shipped two upstream contributions before being generalized as this gate.
+
+## When to use
+
+- **Pre-deploy.** Insert after build, before deploy. Block the deploy when `ok: false`.
+- **Post-restart.** After a baseline rollback + step-by-step re-add, snapshot the saga-era markers in `forbidden-markers.txt` and let CI hold the line.
+- **Post-refactor.** When old helper / handler / module names must not coexist with the new ones in the same bundle.
+
+## Expected config locations
+
+- `scripts/forbidden-markers.txt` — one marker per line, `#` for comments. The list is the contract; the gate is mechanical. Commit this file to source control.
+- `.vercel/output/static/_next/static/chunks/` — default scan target. Override for non-Vercel frameworks via the `--chunks-dir` flag or the `chunksDir` task input.
+
+A missing markers file is a no-op (`ok: true`, `reason: 'missing-markers-file'`) — misconfiguration is never a deploy block. A missing chunks directory is likewise a no-op (`reason: 'missing-chunks-dir'`) so the gate is safe to chain into `check:all` before the build runs.
+
+## Exit semantics
+
+| Reason                  | `ok`   | Deploy decision                |
+|-------------------------|--------|--------------------------------|
+| `missing-markers-file`  | true   | Pass (no gate active)          |
+| `missing-chunks-dir`    | true   | Pass (run before build)        |
+| `empty-markers`         | true   | Pass (list is empty)           |
+| `no-chunks`             | true   | Pass (nothing to scan)         |
+| `clean`                 | true   | Pass — proceed to deploy       |
+| `hits`                  | false  | **BLOCK** — surface hits, ask for triage |
+
+For each hit, the gate emits `{ marker, chunk, count }` so the operator sees the exact marker string, the absolute chunk path, and the number of occurrences in that chunk. Multiple hits across chunks for the same marker are reported separately.
+
+## Programmatic surface
+
+```js
+import { scanForbiddenMarkers, checkForbiddenMarkersTask } from '@a5c-ai/babysitter-library/processes/shared';
+
+// Direct call:
+const result = await scanForbiddenMarkers({
+  markersFile: 'scripts/forbidden-markers.txt',
+  chunksDir:   '.vercel/output/static/_next/static/chunks',
+});
+if (!result.ok) {
+  // result.hits: Array<{ marker, chunk, count }>
+  // result.reason === 'hits'
+  process.exit(1);
+}
+
+// Or dispatched as a babysitter task:
+const gate = await ctx.task(checkForbiddenMarkersTask, {
+  projectDir: '.',
+  // markersFile / chunksDir are inferred from projectDir if omitted
+});
+```
+
+## Reference
+
+- Issue: https://github.com/a5c-ai/babysitter/issues/477
+- Helper module: `library/processes/shared/forbidden-markers-scanner.js`
+- Origin (cookbook prototype): `cookbook/scripts/check-no-forbidden.mjs` (81 lines)


### PR DESCRIPTION
## Summary

Adds `check-forbidden-markers`, a reusable pre-deploy gate that scans built Vercel/Next.js chunks for project-defined forbidden markers (e.g., saga-era code that must never re-appear in production). Implemented per the triage-bot guidance on #477, with three layout corrections surfaced during preflight (see "Deviations" below).

## Closes

Closes #477 — the triage-bot comment on that issue is the spec; this PR honors its "Suggested Approach" with layout choices that match the actual staging-branch conventions.

## Changes

| File | Change |
|---|---|
| `library/processes/shared/forbidden-markers-scanner.js` (new) | Scanner + `defineTask` wrapper. Exports `parseForbiddenMarkers`, `scanForbiddenMarkers`, `checkForbiddenMarkersTask`. JSDoc-typed, mirrors `prior-attempts-scanner.js`. |
| `library/processes/shared/__tests__/forbidden-markers-scanner.test.mjs` (new) | 17 `node:test` cases covering parser semantics + 6 reason states + count semantics + non-.js filtering. Uses `fs.mkdtempSync` for ephemeral fixtures. |
| `library/processes/shared/index.js` | Barrel re-export of the new scanner module. |
| `library/processes/shared/README.md` | New component section + 3 new rows in the API table. |
| `plugins/babysitter-unified/commands/check-forbidden-markers.md` (new) | Flat slash-command surface matching the existing `commands/*.md` frontmatter format. |
| `docs/plugins.md` | New "Built-in Quality Gates" subsection (~17 lines) before "Further Reading". |
| `package.json` | New `"test:shared": "node --test library/processes/shared/__tests__/*.test.mjs"` script. No dep changes. |

`+915 / -6` across 7 files.

## Behaviour

### `parseForbiddenMarkers(content: string): string[]`
- Strips blank lines, strips `#`-comment lines, trims each remaining line
- Handles CRLF
- Pure / deterministic

### `scanForbiddenMarkers({ markersFile, chunksDir }): Promise<ScanResult>`
where:
```ts
type ScanResult = {
  ok: boolean;
  hits: Array<{ marker: string; chunk: string; count: number }>;
  markerCount: number;
  chunkCount: number;
  reason: 'missing-markers-file' | 'missing-chunks-dir' | 'empty-markers' | 'no-chunks' | 'clean' | 'hits';
};
```

### Default scan target
The caller supplies `chunksDir`. Conventional default: `.vercel/output/static/_next/static/chunks` (matches Next.js + Vercel output). The scanner itself takes the path as a required arg so it composes cleanly with non-Next frameworks too.

### No-op semantics (RC1 mitigation)
Missing markers file, missing chunks dir, empty markers list, and no `.js` chunk files all return `ok: true` with the appropriate `reason`. The gate never blocks deploys on misconfiguration — only on actual hits.

### Count semantics
`count` is true occurrence count via `indexOf` advancement (not binary). A marker appearing M times in one chunk yields `count: M`.

## Tests

- 17 `node:test` cases, 5 suites, ~630 ms total. All pass.
- Run locally:
  ```
  npm run test:shared
  # or
  node --test library/processes/shared/__tests__/forbidden-markers-scanner.test.mjs
  ```
- SDK suite remains 1945/1974 (the 20 pre-existing staging failures are in `packages/sdk/` paths this PR does not touch — confirmed by `git diff staging..HEAD --stat`).

## Cookbook reference implementation

- `/Users/rogelsm/cookbook/scripts/check-no-forbidden.mjs` — 81-line prototype (file-reads + `string.includes` per chunk)
- `/Users/rogelsm/cookbook/scripts/forbidden-markers.txt` — example config

This PR promotes the IDEA to a first-class reusable process-library helper with proper occurrence counting + structured result + reason enum + tests. The cookbook script will be annotated with an UPSTREAM PR PENDING header and eventually deprecated in favour of the helper.

## Deviations from triage-bot guidance (preflight findings)

The preflight phase surfaced three layout corrections; the impl honors the actual staging-branch conventions over the triage-bot's suggested paths:

1. **Scanner home**: `library/processes/shared/` (not `packages/sdk/src/utils/`). The shared/ directory is where every reusable process-library helper lives (prior-attempts-scanner, completeness-gate, tdd-triplet, cost-aggregation). `packages/sdk/src/tasks/kinds/` is the runtime kernel layer, wrong abstraction.
2. **Plugin surface**: ONE `plugins/babysitter-unified/commands/check-forbidden-markers.md` (not 6 per-harness `SKILL.md`). The 6 per-harness layout existed on `main` (v0.0.187); staging consolidated to the unified-plugin pattern.
3. **Language**: Plain JS with JSDoc (not TypeScript), mirroring every existing helper under `library/processes/shared/`.

All three deviations are reasoned + documented in the preflight + impl reports.

## Reference saga

Cookbook AGENTS.md "Forbidden-marker chunk-grep on every deploy" lesson (L6 from the May-13→May-27 voice-integration retro): saga-era code (single-breath recovery layers, hands-free-stuck-recovered-banner, VI-9-Phase-C2 HTMLAudioElement-era markers like `primeCloudAudio` / `CLOUD_AUDIO_SESSION_RECLAIM_MS` / `SILENT_WAV`) MUST NOT reappear in shipped chunks. The grep is the structural guarantee. Promoting this to a first-class babysitter gate makes the discipline reusable across cookbook + any other project that ships through Vercel.

## Filed via

`/babysitter:yolo RD-2-3` (cookbook devplan-may-28 cradle-I2). Sibling of #564 + #565 from RD-1-3 (yesterday). Sibling-already-merged: PR #524 (REUSE-AUDIT), which closed #480.
