### PR TITLE
cleanup-runs: detect no-op scans + skip heavy phases

### DIFF
--- a/library/cradle/cleanup-runs.js
+++ b/library/cradle/cleanup-runs.js
@@ -146,6 +146,60 @@ const verifyCleanup = defineTask("verify-cleanup", (args) => ({
   }
 }));
 
+// ─── No-op short-circuit helper ────────────────────────────────────────────────
+// Returns true when nothing is eligible for removal. Saves ~2 heavy agent-task
+// invocations on cleanup passes where the prior pass was thorough and nothing
+// new has accumulated.
+function isNoopScan(scan, keepRecentDays) {
+  const runs = scan?.runs || [];
+  const processes = scan?.processes || [];
+
+  const removableRuns = runs.filter(
+    (r) => (r.state === "completed" || r.state === "failed") && r.ageDays > keepRecentDays,
+  );
+  const orphanedProcesses = processes.filter((p) => p.isOrphaned);
+
+  return removableRuns.length === 0 && orphanedProcesses.length === 0;
+}
+
+const writeNoopAuditEntry = defineTask("write-noop-audit", (args) => ({
+  kind: "shell",
+  title: "Write no-op audit entry to docs/run-history-insights.md",
+  shell: {
+    command: `cd "${args.repoRoot}" && mkdir -p docs && {
+      DATE=$(date -u +%Y-%m-%d)
+      RUNS_COUNT=${args.scan?.stats?.totalRuns ?? 0}
+      ACTIVE=${args.scan?.stats?.activeRuns ?? 0}
+      DISK=$(du -sh ${args.runsDir} 2>/dev/null | cut -f1)
+      ENTRY=$(cat <<EOF
+## Cleanup pass · $DATE (no-op)
+
+Scan found nothing eligible for removal (no terminal runs older than ${args.keepRecentDays}d, no orphaned process files). Skipped Phase 2 (aggregate) and Phase 3 (cleanup) — both are heavy agent tasks that produce no value when nothing is removable.
+
+| Snapshot | Value |
+|---|---|
+| Total runs | $RUNS_COUNT |
+| Active / in-flight | $ACTIVE |
+| .a5c/runs/ disk | $DISK |
+
+---
+
+EOF
+      )
+      if [ -f docs/run-history-insights.md ]; then
+        # Prepend to existing file
+        TMP=$(mktemp)
+        printf "%s" "$ENTRY" > "$TMP"
+        cat docs/run-history-insights.md >> "$TMP"
+        mv "$TMP" docs/run-history-insights.md
+      else
+        printf "%s" "$ENTRY" > docs/run-history-insights.md
+      fi
+      echo "audit entry prepended to docs/run-history-insights.md"
+    }`,
+  }
+}));
+
 // ─── Main process ──────────────────────────────────────────────────────────────
 
 export async function process(inputs, ctx) {
@@ -163,6 +217,29 @@ export async function process(inputs, ctx) {
     processesDir,
     keepRecentDays,
   });
+
+  // ── No-op short-circuit ──
+  // If nothing is eligible for removal, skip the heavy Phase 2 (aggregate) and
+  // Phase 3 (cleanup) agent tasks. Write a brief audit-trail entry instead and
+  // exit cleanly. This pattern emerged from cookbook usage (2026-06-05) where
+  // a thorough prior pass left nothing meaningful to reclaim — running full
+  // ceremony burned ~2 agent invocations to produce no useful change.
+  if (isNoopScan(scan, keepRecentDays)) {
+    ctx.log("No-op scan detected — nothing eligible for removal. Skipping Phases 2-3.");
+    await ctx.task(writeNoopAuditEntry, {
+      repoRoot,
+      runsDir,
+      scan,
+      keepRecentDays,
+    });
+    const verification = await ctx.task(verifyCleanup, { repoRoot });
+    return {
+      success: true,
+      summary: `No-op cleanup pass. ${scan?.stats?.totalRuns ?? 0} total runs scanned, 0 removable. Audit entry written to docs/run-history-insights.md.`,
+      scan,
+      noop: true,
+    };
+  }
 
   // Phase 2: Aggregate insights
   ctx.log("Phase 2: Aggregating insights from terminal runs...");


### PR DESCRIPTION
## Summary

The `cradle/cleanup-runs` process currently runs all 4 phases unconditionally — scan → aggregate-insights → cleanup-old-data → verify. When a recent cleanup pass was thorough and nothing new has accumulated, phases 2 and 3 still fire as full agent tasks and produce no useful change.

This PR adds a no-op short-circuit after Phase 1 (scan):

- If the scan returns **0 removable runs** (no terminal runs older than `keepRecentDays`) AND **0 orphaned processes**, skip Phases 2 + 3.
- Write a brief audit entry to `docs/run-history-insights.md` so the audit trail stays continuous.
- Run Phase 4 verify as normal.
- Return `{ noop: true, ... }` so callers/wrappers can detect the short-circuit.

When the scan DOES find work, behavior is identical to before — Phase 2 aggregate, Phase 3 cleanup, Phase 4 verify, same return shape.

## Why

Pattern observed in cookbook usage (2026-06-05):

> Day 1 cleanup pass: removed 30 + 30 MB lane worktrees, 191 MB main-repo build cache, 300 MB build cache in worktree, 2 RUN_FAILED runs. ~580 MB reclaimed.
>
> Day 2 cleanup pass: scan found 0 terminal-old runs, 0 orphaned processes, 0 new build artifacts. Phase 2 and Phase 3 still fired the full agent tasks, producing a rewritten insights file with no meaningful change.

The proposed short-circuit saves ~2 agent invocations per no-op pass (which is the steady-state behavior once a project has any cleanup discipline at all).

## Implementation

- `isNoopScan(scan, keepRecentDays)` — pure helper, decides removable-runs + orphaned-processes counts. Easy to unit-test.
- `writeNoopAuditEntry` — shell task that prepends a `## Cleanup pass · YYYY-MM-DD (no-op)` block to `docs/run-history-insights.md`. Schema-stable; downstream readers can detect via the `(no-op)` marker.
- Short-circuit guard in `process()` runs the audit + verify tasks then returns early.

## Diff size

77 lines added, 0 removed. Backwards-compatible (existing callers see no change in API or behavior when there IS work to do).

## Verification

Reviewed against the existing cleanup-runs.js logic; no other state-machine assumptions broken. The verify phase still runs in the no-op path so disk/file-count snapshots remain accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)