### PR TITLE
fix(genty-ui): align verify:release paths to packages/genty/ui (v6 rename)

### DIFF
--- a/packages/genty/ui/package.json
+++ b/packages/genty/ui/package.json
@@ -123,7 +123,7 @@
     "build:realtime": "npm run build --workspace=@a5c-ai/atlas && npm run build --workspace=@a5c-ai/comm-adapter && npm run build",
     "clean": "rimraf dist tsconfig.tsbuildinfo",
     "codegen": "tsx src/codegen/swift-types.ts && tsx src/codegen/kotlin-types.ts",
-    "test": "vitest run --root ../../.. --config vitest.config.ts packages/adapters/ui",
+    "test": "vitest run --root ../../.. --config vitest.config.ts packages/genty/ui",
     "test:realtime": "vitest run --root ../../.. --config vitest.config.ts \"packages/genty/ui/src/session-flow*.test.ts\" \"packages/genty/ui/src/screens/SessionDetailScreen.test.tsx\" \"packages/genty/ui/src/release-verification.test.ts\"",
     "verify:release": "node ./scripts/verify-release.mjs",
     "prepublishOnly": "npm run build:realtime && npm run test:realtime && npm run verify:release"

--- a/packages/genty/ui/scripts/verify-release.mjs
+++ b/packages/genty/ui/scripts/verify-release.mjs
@@ -40,42 +40,42 @@ export function verifyAgentMuxUiRelease({ packageRoot, manifest, packEntries }) 
   const packedPaths = new Set(packEntries.map((entry) => normalizePackPath(entry.path)));
   const readme = fs.readFileSync(path.join(packageRoot, 'README.md'), 'utf8');
 
-  expect(manifest.name === '@a5c-ai/genty-ui', 'packages/adapters/ui/package.json name must stay @a5c-ai/genty-ui');
+  expect(manifest.name === '@a5c-ai/genty-ui', 'packages/genty/ui/package.json name must stay @a5c-ai/genty-ui');
   expect(
     manifest.publishConfig?.access === 'public',
-    'packages/adapters/ui/package.json publishConfig.access must stay public'
+    'packages/genty/ui/package.json publishConfig.access must stay public'
   );
   expect(
     scripts['build:realtime'] === 'npm run build --workspace=@a5c-ai/atlas && npm run build --workspace=@a5c-ai/comm-adapter && npm run build',
-    'packages/adapters/ui/package.json build:realtime must remain a package-local realtime build entrypoint'
+    'packages/genty/ui/package.json build:realtime must remain a package-local realtime build entrypoint'
   );
   expect(
-    scripts.test === 'vitest run --root ../../.. --config vitest.config.ts packages/adapters/ui',
-    'packages/adapters/ui/package.json test must keep the package-local Vitest filter stable'
+    scripts.test === 'vitest run --root ../../.. --config vitest.config.ts packages/genty/ui',
+    'packages/genty/ui/package.json test must keep the package-local Vitest filter stable'
   );
   expect(
     typeof scripts['test:realtime'] === 'string' &&
-      scripts['test:realtime'].includes('packages/adapters/ui/src/session-flow*.test.ts') &&
-      scripts['test:realtime'].includes('packages/adapters/ui/src/screens/SessionDetailScreen.test.tsx') &&
-      scripts['test:realtime'].includes('packages/adapters/ui/src/release-verification.test.ts'),
-    'packages/adapters/ui/package.json test:realtime must keep the projector, screen, and release assertions together'
+      scripts['test:realtime'].includes('packages/genty/ui/src/session-flow*.test.ts') &&
+      scripts['test:realtime'].includes('packages/genty/ui/src/screens/SessionDetailScreen.test.tsx') &&
+      scripts['test:realtime'].includes('packages/genty/ui/src/release-verification.test.ts'),
+    'packages/genty/ui/package.json test:realtime must keep the projector, screen, and release assertions together'
   );
   expect(
     scripts['verify:release'] === 'node ./scripts/verify-release.mjs',
-    'packages/adapters/ui/package.json verify:release must point at the package-local release verifier'
+    'packages/genty/ui/package.json verify:release must point at the package-local release verifier'
   );
   expect(
     scripts.prepublishOnly === 'npm run build:realtime && npm run test:realtime && npm run verify:release',
-    'packages/adapters/ui/package.json prepublishOnly must exercise the realtime package seam directly'
+    'packages/genty/ui/package.json prepublishOnly must exercise the realtime package seam directly'
   );
   expect(
     sessionFlowExport.types === './dist/session-flow.d.ts' &&
       sessionFlowExport.default === './dist/session-flow.js',
-    'packages/adapters/ui/package.json must keep exporting ./session-flow from dist/session-flow.*'
+    'packages/genty/ui/package.json must keep exporting ./session-flow from dist/session-flow.*'
   );
   expect(
     readme.includes('@a5c-ai/genty-ui/session-flow'),
-    'packages/adapters/ui/README.md must keep documenting the public session-flow export'
+    'packages/genty/ui/README.md must keep documenting the public session-flow export'
   );
 
   for (const relativePath of REQUIRED_BUILD_PATHS) {

--- a/packages/genty/ui/src/release-verification.test.ts
+++ b/packages/genty/ui/src/release-verification.test.ts
@@ -20,9 +20,9 @@ const baseManifest = {
   },
   scripts: {
     'build:realtime': 'npm run build --workspace=@a5c-ai/atlas && npm run build --workspace=@a5c-ai/comm-adapter && npm run build',
-    test: 'vitest run --root ../../.. --config vitest.config.ts packages/adapters/ui',
+    test: 'vitest run --root ../../.. --config vitest.config.ts packages/genty/ui',
     'test:realtime':
-      'vitest run --root ../../.. --config vitest.config.ts "packages/adapters/ui/src/session-flow*.test.ts" "packages/adapters/ui/src/screens/SessionDetailScreen.test.tsx" "packages/adapters/ui/src/release-verification.test.ts"',
+      'vitest run --root ../../.. --config vitest.config.ts "packages/genty/ui/src/session-flow*.test.ts" "packages/genty/ui/src/screens/SessionDetailScreen.test.tsx" "packages/genty/ui/src/release-verification.test.ts"',
     'verify:release': 'node ./scripts/verify-release.mjs',
     prepublishOnly: 'npm run build:realtime && npm run test:realtime && npm run verify:release',
   },
@@ -93,7 +93,7 @@ describe('verifyAgentMuxUiRelease', () => {
             ...baseManifest,
             scripts: {
               ...baseManifest.scripts,
-              'test:realtime': 'vitest run --root ../../.. --config vitest.config.ts "packages/adapters/ui/src/session-flow*.test.ts"',
+              'test:realtime': 'vitest run --root ../../.. --config vitest.config.ts "packages/genty/ui/src/session-flow*.test.ts"',
             },
           },
           packEntries: basePackEntries,
@@ -111,7 +111,7 @@ describe('verifyAgentMuxUiRelease', () => {
             ...baseManifest,
             scripts: {
               ...baseManifest.scripts,
-              test: 'vitest run --root ../../.. --config vitest.config.ts "packages/adapters/ui/src/**/*.test.ts"',
+              test: 'vitest run --root ../../.. --config vitest.config.ts "packages/genty/ui/src/**/*.test.ts"',
             },
           },
           packEntries: basePackEntries,


### PR DESCRIPTION
## Why

The **Publish Packages From Tag** release job ([run 28436342274](https://github.com/a5c-ai/babysitter/actions/runs/28436342274/job/84263103134)) failed with:

> Error: packages/adapters/ui/package.json test:realtime must keep the projector, screen, and release assertions together

## Root cause

The v6 reorg renamed `packages/adapters/ui` → `packages/genty/ui`. The `test:realtime` glob in `package.json` was updated to the new path, but three things were left pointing at the dead `packages/adapters/ui` path:

- `packages/genty/ui/scripts/verify-release.mjs` — assertions + error-message strings
- `packages/genty/ui/src/release-verification.test.ts` — positive + negative fixtures
- the `test` script in `package.json`

At publish time `prepublishOnly` runs `verify:release`, whose assertion threw and failed the job.

## Fix

Rewrites every `packages/adapters/ui` → `packages/genty/ui` across those three files (18 occurrences). No other files touched; the package name and README export string were already correct.

## Verification

`release-verification.test.ts` vitest suite passes (5/5), no stale `packages/adapters/ui` refs remain, and the real `package.json` scripts now reference `packages/genty/ui`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)