### PR TITLE
fix(codex): per-repo marketplace + docs · release 6.0.2

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "babysitter",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "source": {
         "source": "url",
         "url": "https://github.com/a5c-ai/babysitter-codex.git",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "babysitter",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "source": {
         "source": "url",
         "url": "https://github.com/a5c-ai/babysitter-claude.git",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "babysitter",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "source": {
         "source": "url",
         "url": "https://github.com/a5c-ai/babysitter-cursor.git",

--- a/docs/development/03-babysitter-plugin-flows.md
+++ b/docs/development/03-babysitter-plugin-flows.md
@@ -180,7 +180,7 @@ graph TB
 
 **Installation:**
 - Claude Code: `claude plugin marketplace add a5c-ai/babysitter-claude && claude plugin install --scope project babysitter@a5c.ai`
-- Codex: `codex plugin marketplace add a5c-ai/babysitter --ref staging --sparse .agents/plugins`
+- Codex: `codex plugin marketplace add a5c-ai/babysitter --ref main --sparse .agents/plugins` (add the monorepo, not `a5c-ai/babysitter-codex`; never `--ref staging`)
 - Others: `babysitter harness:install-plugin <harness> --workspace <cwd>`
 
 ---

--- a/docs/development/03-babysitter-plugin-flows.md
+++ b/docs/development/03-babysitter-plugin-flows.md
@@ -180,7 +180,7 @@ graph TB
 
 **Installation:**
 - Claude Code: `claude plugin marketplace add a5c-ai/babysitter-claude && claude plugin install --scope project babysitter@a5c.ai`
-- Codex: `codex plugin marketplace add a5c-ai/babysitter --ref main --sparse .agents/plugins` (add the monorepo, not `a5c-ai/babysitter-codex`; never `--ref staging`)
+- Codex: `codex plugin marketplace add a5c-ai/babysitter-codex && codex plugin add babysitter --marketplace babysitter` (per-repo manifest; monorepo alt uses `a5c-ai/babysitter --sparse .agents/plugins`, never `--ref staging`)
 - Others: `babysitter harness:install-plugin <harness> --workspace <cwd>`
 
 ---

--- a/docs/user-guide/harnesses/codex.md
+++ b/docs/user-guide/harnesses/codex.md
@@ -33,13 +33,18 @@ Install the [plugin](../reference/glossary.md) once, and Babysitter surfaces as 
 # 1. Core CLI (host-side)
 npm install -g @a5c-ai/babysitter
 
-# 2a. Marketplace path
-codex plugin marketplace add a5c-ai/babysitter --ref <released-tag> --sparse .agents/plugins
+# 2a. Marketplace path (per-repo — the package repo ships its own
+#     .agents/plugins/marketplace.json, so no --sparse needed)
+codex plugin marketplace add a5c-ai/babysitter-codex
 codex plugin list --marketplace babysitter
 codex plugin add babysitter --marketplace babysitter
+
+# 2a-alt. From the monorepo with a sparse checkout:
+codex plugin marketplace add a5c-ai/babysitter --ref <released-tag> --sparse .agents/plugins
 ```
 
-> Use the harness's released default branch / tag for `--ref` - **never** `--ref staging`. The Codex plugin publishes its own released tag; do not use a `5.1.1-staging.*` build-metadata version.
+> `--marketplace babysitter` is the marketplace **name** declared in the manifest, not the repo name.
+> For the monorepo form, use the released default branch / tag for `--ref` - **never** `--ref staging`. The Codex plugin publishes its own released tag; do not use a `6.0.x-staging.*` build-metadata version.
 
 **Alternative (npx installer):**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "babysitter",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "babysitter",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "workspaces": [
         "packages/genty/core",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babysitter",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "license": "MIT",
   "private": true,
   "workspaces": [

--- a/plugins/atlas-unified/plugin.json
+++ b/plugins/atlas-unified/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atlas",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "Turn a stated need into a full system design by mining the Atlas knowledge graph.",
   "author": "a5c.ai",
   "license": "MIT",

--- a/plugins/atlas-unified/versions.json
+++ b/plugins/atlas-unified/versions.json
@@ -1,4 +1,4 @@
 {
-  "sdkVersion": "6.0.1",
-  "extensionVersion": "6.0.1"
+  "sdkVersion": "6.0.2",
+  "extensionVersion": "6.0.2"
 }

--- a/plugins/babysitter-unified/per-harness/codex/README.md
+++ b/plugins/babysitter-unified/per-harness/codex/README.md
@@ -46,12 +46,20 @@ npx --yes @a5c-ai/babysitter-codex install --global
 npx --yes @a5c-ai/babysitter-codex install --workspace /path/to/repo
 ```
 
-Alternatively, use the official Codex marketplace CLI to add the babysitter
-marketplace directly from GitHub:
+Alternatively, use the official Codex marketplace CLI. The Codex marketplace
+manifest lives in the **monorepo** at `.agents/plugins/marketplace.json`, so add
+`a5c-ai/babysitter` with `--sparse .agents/plugins` — **not** `a5c-ai/babysitter-codex`
+(the per-harness package repo ships a `.codex-plugin/` plugin bundle, not a
+marketplace root, so `codex plugin marketplace add a5c-ai/babysitter-codex` fails
+with "marketplace root does not contain a supported manifest"):
 
 ```bash
-codex plugin marketplace add a5c-ai/babysitter --ref staging --sparse .agents/plugins
+codex plugin marketplace add a5c-ai/babysitter --ref main --sparse .agents/plugins
 ```
+
+> Use the released default branch (`main`) or a released tag for `--ref` —
+> **never** `--ref staging`. Codex resolves a released plugin version; a
+> `6.0.x-staging.*` build-metadata prerelease will not resolve.
 
 Or from a local clone:
 

--- a/plugins/babysitter-unified/per-harness/codex/README.md
+++ b/plugins/babysitter-unified/per-harness/codex/README.md
@@ -46,26 +46,29 @@ npx --yes @a5c-ai/babysitter-codex install --global
 npx --yes @a5c-ai/babysitter-codex install --workspace /path/to/repo
 ```
 
-Alternatively, use the official Codex marketplace CLI. The Codex marketplace
-manifest lives in the **monorepo** at `.agents/plugins/marketplace.json`, so add
-`a5c-ai/babysitter` with `--sparse .agents/plugins` — **not** `a5c-ai/babysitter-codex`
-(the per-harness package repo ships a `.codex-plugin/` plugin bundle, not a
-marketplace root, so `codex plugin marketplace add a5c-ai/babysitter-codex` fails
-with "marketplace root does not contain a supported manifest"):
+Alternatively, use the official Codex marketplace CLI. This repo ships a
+self-contained codex marketplace manifest (`.agents/plugins/marketplace.json`),
+so add it directly and install the `babysitter` plugin from it:
+
+```bash
+codex plugin marketplace add a5c-ai/babysitter-codex
+codex plugin add babysitter --marketplace babysitter
+```
+
+> `--marketplace babysitter` is the marketplace **name** declared in
+> `.agents/plugins/marketplace.json` (not the repo name).
+
+You can also add the marketplace from the **monorepo** with a sparse checkout, or
+from a local clone:
 
 ```bash
 codex plugin marketplace add a5c-ai/babysitter --ref main --sparse .agents/plugins
+codex plugin marketplace add ./path/to/babysitter-codex
 ```
 
-> Use the released default branch (`main`) or a released tag for `--ref` —
-> **never** `--ref staging`. Codex resolves a released plugin version; a
-> `6.0.x-staging.*` build-metadata prerelease will not resolve.
-
-Or from a local clone:
-
-```bash
-codex plugin marketplace add ./path/to/babysitter
-```
+> For the monorepo form, use the released default branch (`main`) or a released
+> tag for `--ref` — **never** `--ref staging`. Codex resolves a released plugin
+> version; a `6.0.x-staging.*` build-metadata prerelease will not resolve.
 
 Then browse and install:
 

--- a/plugins/babysitter-unified/plugin.json
+++ b/plugins/babysitter-unified/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "babysitter",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "Orchestrate complex, multi-step workflows with event-sourced state management, hook-based extensibility, and human-in-the-loop approval",
   "author": "a5c.ai",
   "license": "MIT",

--- a/plugins/babysitter-unified/versions.json
+++ b/plugins/babysitter-unified/versions.json
@@ -1,4 +1,4 @@
 {
-  "sdkVersion": "6.0.1",
-  "extensionVersion": "6.0.1"
+  "sdkVersion": "6.0.2",
+  "extensionVersion": "6.0.2"
 }

--- a/scripts/sync-external-plugin-repos.mjs
+++ b/scripts/sync-external-plugin-repos.mjs
@@ -125,46 +125,70 @@ function writeMarketplace(repoDir, spec) {
   writeFileSync(out, `${JSON.stringify(data, null, 2)}\n`);
 }
 
-// Every plugin repo needs a self-contained `.claude-plugin/marketplace.json` so
-// `claude plugin marketplace add <repo>@<branch>` works on ALL branches (not just
-// whichever branch happened to retain a stale leftover). Derive it from the
-// repo's own plugin manifest — a single-plugin marketplace pointing at the repo
-// root. See issue #955.
+// Every plugin repo needs a self-contained marketplace manifest so
+// `<harness> plugin marketplace add <repo>@<branch>` works on ALL branches (not
+// just whichever branch happened to retain a stale leftover). Each is derived
+// from the repo's own plugin manifest — a single-plugin marketplace pointing at
+// the repo root — in the FORMAT/LOCATION its harness expects. See issue #955.
 //
-// Codex-format repos ship `.codex-plugin/plugin.json` (no `.claude-plugin/`), so
-// fall back to it. Codex recognizes `.claude-plugin/marketplace.json` as a legacy
-// marketplace root, so writing it here makes `codex plugin marketplace add
-// a5c-ai/babysitter-codex` resolve WITHOUT `--sparse` — symmetric with the claude
-// per-repo flow (previously it failed with "marketplace root does not contain a
-// supported manifest" because only the monorepo `.agents/plugins/` had a manifest).
+//  - Claude: `.claude-plugin/marketplace.json` (claude format, `source: "./"`).
+//  - Codex:  `.agents/plugins/marketplace.json` (codex format, `source: {source:
+//    "local", path: "./"}`). Codex reads `$REPO_ROOT/.agents/plugins/marketplace.json`
+//    by default for `codex plugin marketplace add owner/repo`, so this makes
+//    `codex plugin marketplace add a5c-ai/babysitter-codex` resolve without
+//    `--sparse` (previously it failed with "marketplace root does not contain a
+//    supported manifest" — only the monorepo had a codex marketplace manifest).
 function writeRepoMarketplace(repoDir) {
-  const pluginJsonPath = [
-    join(repoDir, '.claude-plugin', 'plugin.json'),
-    join(repoDir, '.codex-plugin', 'plugin.json'),
-  ].find((candidate) => existsSync(candidate));
-  if (!pluginJsonPath) return;
-  const plugin = JSON.parse(readFileSync(pluginJsonPath, 'utf8'));
-  const author =
-    plugin.author && typeof plugin.author === 'object'
-      ? plugin.author
-      : { name: typeof plugin.author === 'string' ? plugin.author : 'a5c.ai' };
-  const marketplace = {
-    name: 'a5c.ai',
-    owner: { name: 'a5c.ai', email: 'support@a5c.ai' },
-    plugins: [
-      {
-        name: plugin.name,
-        source: './',
-        description: plugin.description ?? '',
-        version: plugin.version,
-        author,
-      },
-    ],
-  };
-  writeFileSync(
-    join(repoDir, '.claude-plugin', 'marketplace.json'),
-    `${JSON.stringify(marketplace, null, 2)}\n`,
-  );
+  const claudePluginPath = join(repoDir, '.claude-plugin', 'plugin.json');
+  if (existsSync(claudePluginPath)) {
+    const plugin = JSON.parse(readFileSync(claudePluginPath, 'utf8'));
+    const author =
+      plugin.author && typeof plugin.author === 'object'
+        ? plugin.author
+        : { name: typeof plugin.author === 'string' ? plugin.author : 'a5c.ai' };
+    const marketplace = {
+      name: 'a5c.ai',
+      owner: { name: 'a5c.ai', email: 'support@a5c.ai' },
+      plugins: [
+        {
+          name: plugin.name,
+          source: './',
+          description: plugin.description ?? '',
+          version: plugin.version,
+          author,
+        },
+      ],
+    };
+    writeFileSync(
+      join(repoDir, '.claude-plugin', 'marketplace.json'),
+      `${JSON.stringify(marketplace, null, 2)}\n`,
+    );
+  }
+
+  const codexPluginPath = join(repoDir, '.codex-plugin', 'plugin.json');
+  if (existsSync(codexPluginPath)) {
+    const plugin = JSON.parse(readFileSync(codexPluginPath, 'utf8'));
+    const displayName =
+      plugin.interface?.displayName ??
+      String(plugin.name || 'plugin').replace(/(^|[-_/])([a-z])/g, (_, sep, ch) => sep.replace(/[-_/]/, ' ') + ch.toUpperCase()).trim();
+    const marketplace = {
+      name: plugin.name,
+      version: plugin.version,
+      interface: { displayName },
+      plugins: [
+        {
+          name: plugin.name,
+          version: plugin.version,
+          source: { source: 'local', path: './' },
+          policy: { installation: 'AVAILABLE', authentication: 'ON_INSTALL' },
+          category: plugin.interface?.category ?? 'Coding',
+        },
+      ],
+    };
+    const out = join(repoDir, '.agents', 'plugins', 'marketplace.json');
+    mkdirSync(dirname(out), { recursive: true });
+    writeFileSync(out, `${JSON.stringify(marketplace, null, 2)}\n`);
+  }
 }
 
 function writeExternalReleaseFiles(repoDir, target) {

--- a/scripts/sync-external-plugin-repos.mjs
+++ b/scripts/sync-external-plugin-repos.mjs
@@ -125,14 +125,24 @@ function writeMarketplace(repoDir, spec) {
   writeFileSync(out, `${JSON.stringify(data, null, 2)}\n`);
 }
 
-// Every claude-plugin-format repo needs a `.claude-plugin/marketplace.json` so
+// Every plugin repo needs a self-contained `.claude-plugin/marketplace.json` so
 // `claude plugin marketplace add <repo>@<branch>` works on ALL branches (not just
 // whichever branch happened to retain a stale leftover). Derive it from the
-// repo's own `.claude-plugin/plugin.json` — a single-plugin marketplace pointing
-// at the repo root. See issue #955.
+// repo's own plugin manifest — a single-plugin marketplace pointing at the repo
+// root. See issue #955.
+//
+// Codex-format repos ship `.codex-plugin/plugin.json` (no `.claude-plugin/`), so
+// fall back to it. Codex recognizes `.claude-plugin/marketplace.json` as a legacy
+// marketplace root, so writing it here makes `codex plugin marketplace add
+// a5c-ai/babysitter-codex` resolve WITHOUT `--sparse` — symmetric with the claude
+// per-repo flow (previously it failed with "marketplace root does not contain a
+// supported manifest" because only the monorepo `.agents/plugins/` had a manifest).
 function writeRepoMarketplace(repoDir) {
-  const pluginJsonPath = join(repoDir, '.claude-plugin', 'plugin.json');
-  if (!existsSync(pluginJsonPath)) return;
+  const pluginJsonPath = [
+    join(repoDir, '.claude-plugin', 'plugin.json'),
+    join(repoDir, '.codex-plugin', 'plugin.json'),
+  ].find((candidate) => existsSync(candidate));
+  if (!pluginJsonPath) return;
   const plugin = JSON.parse(readFileSync(pluginJsonPath, 'utf8'));
   const author =
     plugin.author && typeof plugin.author === 'object'


### PR DESCRIPTION
## Codex marketplace fix

`codex plugin marketplace add a5c-ai/babysitter-codex` failed ("marketplace root does not contain a supported manifest") because the per-harness repo shipped only a `.codex-plugin/plugin.json` bundle — no marketplace root. Only the monorepo's `.agents/plugins/marketplace.json` had one (needs `--sparse`). Claude's external repo is self-contained (`.claude-plugin/marketplace.json`, #955); codex got nothing.

**Fix:** `sync-external-plugin-repos.mjs` `writeRepoMarketplace` now also writes a **codex-format** `.agents/plugins/marketplace.json` (self-sourced `{source:"local", path:"./"}`) into codex repos — the path/format OpenAI Codex reads for `codex plugin marketplace add owner/repo`. So the per-repo flow works without `--sparse`:

```bash
codex plugin marketplace add a5c-ai/babysitter-codex
codex plugin add babysitter --marketplace babysitter
```

Docs (codex README, `codex.md`, plugin-flows) rewritten to the per-repo flow; the `--ref staging` bug corrected to `--ref main`.

Takes effect for the external `babysitter-codex` repo on the next external-repo sync (triggered by this merge to main). Ref: [OpenAI Codex plugin docs](https://developers.openai.com/codex/plugins/build).

## Release 6.0.2

Base-version bump so the Publish run republishes `@latest` with the corrected codex install docs (same manifest-triple bump as 6.0.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)