### PR TITLE
fix(plugins): quote observe command argument-hint so it loads

### DIFF
--- a/plugins/babysitter/commands/observe.md
+++ b/plugins/babysitter/commands/observe.md
@@ -1,6 +1,6 @@
 ---
 description: Launch the babysitter observer dashboard. Installs and runs the real-time observer UI that watches babysitter runs, displaying task progress, journal events, and orchestration state in your browser.
-argument-hint: [--watch-dir <dir>]
+argument-hint: "[--watch-dir <dir>]"
 allowed-tools: Read, Grep, Write, Task, Bash
 ---
 


### PR DESCRIPTION
## Bug Description

The `observe` command (`plugins/babysitter/commands/observe.md`) fails to load. The Copilot CLI command/skill loader reports:

```
argument-hint must be a string
```

Its frontmatter value `argument-hint: [--watch-dir <dir>]` is unquoted. Because the value begins with `[`, the YAML parser interprets it as a flow sequence (array) rather than a string, so the loader's string-type validation rejects the file and the command fails to load.

## Fix Description

Quote the value so YAML parses it as a scalar string:

```diff
-argument-hint: [--watch-dir <dir>]
+argument-hint: "[--watch-dir <dir>]"
```

This matches the quoting convention already used by the other commands whose hints begin with `[` (`doctor.md`, `retrospect.md`, `cleanup.md`).

## Test Results

- Tests: PASS — parsed all 14 command frontmatter files in `plugins/babysitter/commands` with a YAML parser; all load and all `argument-hint` values are strings (0 failures).
- Lint: PASS — no source code changed; single-line frontmatter edit, CRLF preserved.

## Files Changed

- `plugins/babysitter/commands/observe.md`

## Environment

- Babysitter SDK: 0.0.187 (global)
- AI Harness: GitHub Copilot CLI
- OS: Darwin 24.6.0 (arm64)
- Node.js: v25.9.0
