### PR TITLE
RFC(observer-dashboard): concrete deltas vs the current package — breakpoint approval, liveness, discovery, counting, perf, triage UX

### DIFF
--- a/packages/observer-dashboard/docs/OBSERVER-PORT-RFC.md
+++ b/packages/observer-dashboard/docs/OBSERVER-PORT-RFC.md
@@ -1,0 +1,61 @@
+# RFC: Upstreaming a production-proven observer experience
+
+**Status:** Discussion — no code lands until direction is agreed.
+**Scope:** `packages/observer-dashboard` only.
+
+## Motivation
+
+A downstream fork of this observer dashboard has been iterated in sustained daily production use, watching hundreds of real runs, and has been independently published to npm. Over that period several capabilities proved their value in day-to-day operation:
+
+- **Fast page loads** on large `.a5c/runs` trees (slimmed run digests + virtualized lists).
+- **A working breakpoint experience** — real SDK questions render, answers are recorded correctly, and the UI reflects the true "recorded, awaiting resume" state.
+- **Honest liveness** — activity-based freshness derived from journal events, instead of lock files that real runs in practice do not write (which makes lock-based liveness structurally report nothing as active).
+- **Counts that match the eye** — reconciled classification so KPIs and column totals equal the rows actually shown, with ghost/incomplete run directories filtered at discovery.
+- **A board (kanban) view** for at-a-glance triage of what needs attention.
+- **Scheduled-run identification** so cron/forever-style runs read as scheduled rather than as stalled one-shots.
+- **Semantic color tokens** — one hue, one meaning; a single action color for the one write the dashboard performs.
+
+This RFC offers those capabilities for upstreaming as a sequence of small, independently reviewable milestones, each re-derived natively in this package's idioms (not cherry-picked from the fork), and asks the maintainers three direction questions before any code is opened.
+
+A hard lesson motivates the shape of this ladder: a correctness-only patch set on the current list shell was fully built and gated green, and still failed a live usability test — the fixes were right, but the experience remained the bottleneck. **Every milestone below therefore ships a user-visible UI slice together with its logic; none is a fixes-only drop.**
+
+## Proposed milestone ladder
+
+Each milestone is independently shippable and reviewable, ships UI + logic together, and respects dependencies (liveness feeds counting; counting feeds the board).
+
+| # | Milestone | User-visible outcome |
+|---|---|---|
+| 1 | **Perf: slim digest + list virtualization** | First paint and navigation stay fast on large `.a5c/runs` trees (slimmed per-run digest for the list endpoint, virtualized/paginated run list). |
+| 2 | **Breakpoint experience + activity-based liveness** | Payload-nested question/options render for real SDK breakpoints; a disk-derived "answer recorded — awaiting resume" state; a double-answer (overwrite) guard. Liveness switches to journal-event freshness (newest event within an activity threshold) instead of lock files, plus a distinct *scheduled* state so sleeping cron/forever runs are not misread as stalled. |
+| 3 | **Reconciled counting + ghost-run discovery filter** | KPI totals, health cards, and filters agree with the visible rows; malformed/empty run directories are excluded at discovery so no phantom "working" runs appear. |
+| 4 | **Board (kanban) view** | A four-column triage board (needs-attention / working / stalled / done) with keyboard navigation and a view toggle; the list view is retained. Depends on 2 and 3. |
+| 5 | **Scheduled-run identifiers/badges** | Scheduled/forever/cron-driven runs get a kind badge and can be grouped or filtered, so they read correctly at a glance. |
+| 6 | **Semantic color tokens + UX polish** | One-hue-one-meaning token set in a neutral palette, a single action color for the sole write path, honest read-only copy, and empty/error-state polish. Can fold into 4 if fewer PRs are preferred. |
+
+## Contract every PR would honor
+
+1. **Read-only observation.** The dashboard observes runs; it never mutates, resumes, or executes them.
+2. **Package-only.** All changes confined to `packages/observer-dashboard/**` — verifiable from the diff of every PR.
+3. **Minimal-posting.** The breakpoint-approval record remains the *sole* write path; no new write surfaces are introduced.
+4. **Generic for all users of the package.** No personal-tooling assumptions, no downstream branding or fork-specific styling — neutral tokens, generic copy, behavior driven only by what is on disk.
+
+Each PR would also carry its ported/rewritten tests and an end-to-end check of the milestone's user-visible behavior.
+
+## Direction questions for maintainers
+
+1. **List vs board:** keep the list view as the primary experience and layer these capabilities onto it, or adopt the board view as the default experience (with the list view retained as a toggle)?
+2. **Versioning:** a stream of 6.x minors, roughly one per milestone — or a single 7.0 major carrying the board as the headline change?
+3. **PR granularity:** one milestone per PR (smaller, faster reviews), or fewer larger PRs that bundle adjacent milestones?
+
+Answers to these determine milestone 4's default-view behavior and the release plan; everything else in the ladder is direction-independent.
+
+## Evidence
+
+A prepared, package-only diff of roughly 1,200 lines already exists as a concrete demonstration of the gap and of contract-safe porting. It contains:
+
+- the breakpoint approve fix — writing `approved: true` plus the SDK-expected `response` key, so approvals actually take effect;
+- payload-nested question rendering and the double-answer guard;
+- activity-based liveness (journal-event freshness);
+- the ghost-run discovery filter.
+
+It applies on top of 6.0.0 with the full test suite green (1074 tests). It is offered here for inspection — it can be attached to this discussion, or opened directly as the first milestone PR once direction is agreed. It is deliberately **not** being shipped unilaterally: the point of this RFC is to agree on the destination before moving code.

--- a/packages/observer-dashboard/docs/OBSERVER-PORT-RFC.md
+++ b/packages/observer-dashboard/docs/OBSERVER-PORT-RFC.md
@@ -1,61 +1,45 @@
-# RFC: Upstreaming a production-proven observer experience
+# RFC: Concrete deltas vs the current observer-dashboard package
 
 **Status:** Discussion — no code lands until direction is agreed.
 **Scope:** `packages/observer-dashboard` only.
 
 ## Motivation
 
-A downstream fork of this observer dashboard has been iterated in sustained daily production use, watching hundreds of real runs, and has been independently published to npm. Over that period several capabilities proved their value in day-to-day operation:
+A downstream fork of this dashboard has been iterated in sustained daily production use watching hundreds of real runs, and has been independently published to npm. This RFC offers the capabilities that proved themselves there for upstreaming. The whole document is organized around one thing: **exactly what would change versus this package as it is today**, stated per capability.
 
-- **Fast page loads** on large `.a5c/runs` trees (slimmed run digests + virtualized lists).
-- **A working breakpoint experience** — real SDK questions render, answers are recorded correctly, and the UI reflects the true "recorded, awaiting resume" state.
-- **Honest liveness** — activity-based freshness derived from journal events, instead of lock files that real runs in practice do not write (which makes lock-based liveness structurally report nothing as active).
-- **Counts that match the eye** — reconciled classification so KPIs and column totals equal the rows actually shown, with ghost/incomplete run directories filtered at discovery.
-- **A board (kanban) view** for at-a-glance triage of what needs attention.
-- **Scheduled-run identification** so cron/forever-style runs read as scheduled rather than as stalled one-shots.
-- **Semantic color tokens** — one hue, one meaning; a single action color for the one write the dashboard performs.
+## What changes vs the current package
 
-This RFC offers those capabilities for upstreaming as a sequence of small, independently reviewable milestones, each re-derived natively in this package's idioms (not cherry-picked from the fork), and asks the maintainers three direction questions before any code is opened.
+Each row states the current behavior of this package (verified against the source in this repo), the proposed behavior, and why the delta matters in operation.
 
-A hard lesson motivates the shape of this ladder: a correctness-only patch set on the current list shell was fully built and gated green, and still failed a live usability test — the fixes were right, but the experience remained the bottleneck. **Every milestone below therefore ships a user-visible UI slice together with its logic; none is a fixes-only drop.**
+| Capability | Current behavior (this package today) | Proposed behavior | Why it matters |
+|---|---|---|---|
+| **Breakpoint approval** (the dashboard's one write path) | The approve action (`src/app/actions/approve-breakpoint.ts`) writes `tasks/<effectId>/result.json` containing `{ answer, approvedAt, approvedBy }` — no `approved: true` flag, and the answer sits under a key the SDK runtime does not read. Nothing prevents a second submit from silently overwriting a recorded answer. | Write `approved: true` plus the SDK-expected `response` key (keeping the existing fields for display), and add a double-answer/overwrite guard so a recorded answer cannot be silently clobbered. | Today the runtime reads an approval as **not approved** and drops the answer — the dashboard's single write path does not actually take effect. This closes the loop: approve in the UI, the run resumes with the answer. |
+| **Breakpoint question rendering** | The parser (`src/lib/parser.ts`) reads top-level `inputs.question`. Real SDK breakpoints nest their data under `inputs.payload.*`, so real runs fall through to the generic `"Approval required"` fallback with no question text and no options. | Read `inputs.payload.*` with a top-level fallback, so real questions and options render. After an answer is recorded, show a disk-derived **"answer recorded — awaiting resume"** state instead of leaving the breakpoint looking pending. | Operators can see *what* they are approving, choose among the actual options, and — after answering — see the true state (recorded, not yet resumed) rather than a breakpoint that appears stuck. |
+| **Liveness** | Status is derived purely from journal events (`pending` / `waiting` / `completed` / `failed`), with a single staleness timestamp (default 1 h `staleThresholdMs`) as the only freshness signal. There is no "actively working" state: an in-flight run is indistinguishable from an abandoned one until the stale threshold trips, and sleeping cron/forever-style runs read as stalled one-shots. | Activity-based liveness derived from newest-journal-event freshness within a configurable threshold (`activeThresholdMs`), plus a distinct **scheduled** state for sleeping cron/forever runs. Deliberately journal-derived rather than lock-file-derived: downstream production experience shows real runs do not reliably write lock files, so any lock-based liveness structurally reports zero working runs. | "What is working *right now*" becomes answerable at a glance; scheduled runs stop polluting the stalled bucket; working counts reflect reality instead of conflating executing and abandoned runs. |
+| **Run discovery** | Every subdirectory of a `.a5c/runs` source is treated as a run (`src/lib/source-discovery.ts`). A `run.json` check exists only as a tie-breaker when the same run id appears under multiple sources — a ghost/never-started directory still surfaces as a run. | Keep a candidate directory only if it has a `run.json` **or** a `journal/` directory. | No phantom rows, no phantom counts: everything the dashboard shows corresponds to a run that actually started (or was at least materialized by the SDK). |
+| **Counting** | KPI totals (project summaries, digest counters) are computed on a separate path from the visible list rows, so pills, tiles, and column counts can disagree with the rows actually shown. | One reconciled classification source consumed by all surfaces — pills, tiles, and columns always equal what is visibly listed. | Trust. A dashboard whose numbers do not match its rows trains operators to stop believing it; reconciled counts make every number auditable by eye. |
+| **Performance** | The list endpoint strips journal events but still ships full task payloads per run, so responses grow with the runs tree and first paint slows on large `.a5c/runs` trees. | Slimmed per-run digests for list surfaces, plus pagination/virtualization of the run list. | First paint and navigation stay fast at hundreds of runs — the scale at which an observer dashboard is most needed. |
+| **Triage UX** | List-only. | An **optional** board (kanban) view for at-a-glance triage — the list view is retained — plus scheduled-run badges and semantic color tokens (one hue = one meaning; a single action color for the sole write path). | Attention routing: what needs a human, what is working, what is stalled, and what is done are separable at a glance instead of by reading rows. |
 
-## Proposed milestone ladder
+The first three rows are correctness deltas (the current behavior is wrong against the SDK's on-disk contract); the next three are honesty/scale deltas; the last is an additive UX option.
 
-Each milestone is independently shippable and reviewable, ships UI + logic together, and respects dependencies (liveness feeds counting; counting feeds the board).
+## Delivery
 
-| # | Milestone | User-visible outcome |
-|---|---|---|
-| 1 | **Perf: slim digest + list virtualization** | First paint and navigation stay fast on large `.a5c/runs` trees (slimmed per-run digest for the list endpoint, virtualized/paginated run list). |
-| 2 | **Breakpoint experience + activity-based liveness** | Payload-nested question/options render for real SDK breakpoints; a disk-derived "answer recorded — awaiting resume" state; a double-answer (overwrite) guard. Liveness switches to journal-event freshness (newest event within an activity threshold) instead of lock files, plus a distinct *scheduled* state so sleeping cron/forever runs are not misread as stalled. |
-| 3 | **Reconciled counting + ghost-run discovery filter** | KPI totals, health cards, and filters agree with the visible rows; malformed/empty run directories are excluded at discovery so no phantom "working" runs appear. |
-| 4 | **Board (kanban) view** | A four-column triage board (needs-attention / working / stalled / done) with keyboard navigation and a view toggle; the list view is retained. Depends on 2 and 3. |
-| 5 | **Scheduled-run identifiers/badges** | Scheduled/forever/cron-driven runs get a kind badge and can be grouped or filtered, so they read correctly at a glance. |
-| 6 | **Semantic color tokens + UX polish** | One-hue-one-meaning token set in a neutral palette, a single action color for the sole write path, honest read-only copy, and empty/error-state polish. Can fold into 4 if fewer PRs are preferred. |
-
-## Contract every PR would honor
-
-1. **Read-only observation.** The dashboard observes runs; it never mutates, resumes, or executes them.
-2. **Package-only.** All changes confined to `packages/observer-dashboard/**` — verifiable from the diff of every PR.
-3. **Minimal-posting.** The breakpoint-approval record remains the *sole* write path; no new write surfaces are introduced.
-4. **Generic for all users of the package.** No personal-tooling assumptions, no downstream branding or fork-specific styling — neutral tokens, generic copy, behavior driven only by what is on disk.
-
-Each PR would also carry its ported/rewritten tests and an end-to-end check of the milestone's user-visible behavior.
-
-## Direction questions for maintainers
-
-1. **List vs board:** keep the list view as the primary experience and layer these capabilities onto it, or adopt the board view as the default experience (with the list view retained as a toggle)?
-2. **Versioning:** a stream of 6.x minors, roughly one per milestone — or a single 7.0 major carrying the board as the headline change?
-3. **PR granularity:** one milestone per PR (smaller, faster reviews), or fewer larger PRs that bundle adjacent milestones?
-
-Answers to these determine milestone 4's default-view behavior and the release plan; everything else in the ladder is direction-independent.
+- **Small, independently reviewable milestone PRs**, roughly one delta row (or one pair of tightly coupled rows) each, in dependency order: approval + question rendering first, then liveness, then discovery + counting, then performance, then triage UX.
+- **Every milestone ships UI and logic together.** A hard downstream lesson motivates this: a correctness-only patch set was fully built and gated green, and still failed a live usability test — the fixes were right, but the experience remained the bottleneck. No milestone here is a fixes-only drop.
+- **Fresh re-derivation, not cherry-picks.** Each change is re-implemented natively in this package's idioms (parser, cache, services, component conventions), with tests written against this package — not transplanted fork commits.
+- **Contract on every PR:**
+  1. **Read-only observation** — the dashboard never mutates, resumes, or executes runs.
+  2. **Package-only** — all changes confined to `packages/observer-dashboard/**`, verifiable from each diff.
+  3. **Minimal-posting** — the breakpoint-approval record remains the *sole* write path; no new write surfaces.
+  4. **Generic for all users** — no downstream branding or fork-specific assumptions; neutral tokens, generic copy, behavior driven only by what is on disk.
 
 ## Evidence
 
-A prepared, package-only diff of roughly 1,200 lines already exists as a concrete demonstration of the gap and of contract-safe porting. It contains:
+A prepared, package-only diff of roughly 1,200 lines already exists covering the first three delta rows (breakpoint approval, question rendering + the double-answer guard, activity-based liveness, plus the ghost-run discovery filter). It applies on top of 6.0.0 with the full test suite green (1,074 tests). It can be attached to this discussion for inspection, or opened directly as the first milestone PR once direction is agreed. It is deliberately not being shipped unilaterally — the point of this RFC is to agree on the destination before moving code.
 
-- the breakpoint approve fix — writing `approved: true` plus the SDK-expected `response` key, so approvals actually take effect;
-- payload-nested question rendering and the double-answer guard;
-- activity-based liveness (journal-event freshness);
-- the ghost-run discovery filter.
+## Open questions (input welcome)
 
-It applies on top of 6.0.0 with the full test suite green (1074 tests). It is offered here for inspection — it can be attached to this discussion, or opened directly as the first milestone PR once direction is agreed. It is deliberately **not** being shipped unilaterally: the point of this RFC is to agree on the destination before moving code.
+1. **Versioning:** a stream of 6.x minors (roughly one per milestone), or a single 7.0 major?
+2. **PR granularity:** one delta row per PR (smaller, faster reviews), or fewer larger PRs bundling adjacent rows?
+3. **Board default:** should the board view eventually become the default experience (with the list retained as a toggle), or stay an opt-in view? This only affects the final milestone — everything above it is view-independent.


### PR DESCRIPTION
# RFC(observer-dashboard): concrete deltas vs the current package

**Docs-only discussion PR** — adds one RFC document (`packages/observer-dashboard/docs/OBSERVER-PORT-RFC.md`), no code changes. Nothing lands beyond the document until direction is agreed.

A downstream fork of this dashboard has been iterated in sustained daily production use and independently published to npm. This RFC offers its proven capabilities for upstreaming, organized as a **per-capability delta versus this package today**:

- **Breakpoint approval** — today the approve action writes `{ answer, approvedAt, approvedBy }` with no `approved: true` and the answer under a key the SDK does not read, so the runtime treats an approval as not approved and drops the answer → write `approved: true` + the SDK `response` key, plus a double-answer/overwrite guard.
- **Breakpoint question rendering** — today the parser reads top-level `inputs.question` while real SDK breakpoints nest under `inputs.payload.*`, so real runs show a generic "Approval required" with no question or options → read `inputs.payload.*` (top-level fallback), render real questions/options, and show a disk-derived "answer recorded — awaiting resume" state.
- **Liveness** — today status is journal-event-only with a single 1 h staleness timestamp: no "working" state, and sleeping cron/forever runs read as stalled → activity-based liveness from journal-event freshness within a configurable threshold, plus a distinct *scheduled* state.
- **Run discovery** — today every subdirectory of `.a5c/runs` surfaces as a run, including ghost/never-started directories → keep a candidate only if it has `run.json` or a `journal/` directory.
- **Counting** — today KPI totals and visible rows can disagree → one reconciled classification source so pills, tiles, and columns always match what is shown.
- **Performance** — today the list endpoint ships full task payloads, slowing first paint on large runs trees → slimmed per-run digests + pagination/virtualization.
- **Triage UX** — today list-only → an optional board (kanban) view (list retained), scheduled-run badges, and semantic color tokens (one hue = one meaning).

**Delivery:** small, independently reviewable milestone PRs, each shipping UI + logic together, freshly re-derived in this package's idioms (not cherry-picks). **Contract on every PR:** read-only observation; changes confined to `packages/observer-dashboard`; the breakpoint-approval write stays the sole write path; generic for all users of the package.

**Evidence:** a prepared ~1,200-line package-only diff covering the first three deltas exists, tests green on top of 6.0.0 (1,074 tests) — it can be attached here or opened as the first milestone PR once direction is agreed.

**Open questions:** 6.x minors vs a 7.0 major; one delta per PR vs bundled PRs; and whether the board view should eventually become the default (list retained). Feedback on any part is very welcome.
