### PR TITLE
fix(observe): restore the standalone dashboard package (0.14.0)

### DIFF
--- a/plugins/babysitter-unified/commands/help.md
+++ b/plugins/babysitter-unified/commands/help.md
@@ -230,7 +230,7 @@ SECONDARY COMMANDS
   effect status in your browser. Useful when running /yolo or /forever to watch
   progress without interrupting the run.
 
-  How it works: Runs npx @a5c-ai/babysitter-observer-dashboard@latest which watches
+  How it works: Runs npx @yoavmayer/babysitter-observer-dashboard@latest which watches
   the .a5c/runs/ directory (or a parent directory containing multiple projects) and
   serves a live dashboard. The process is blocking -- it runs until you stop it, and
   it prints the local URL to share with the user. Do not use `babysitter observe`

--- a/plugins/babysitter-unified/commands/observe.md
+++ b/plugins/babysitter-unified/commands/observe.md
@@ -7,7 +7,7 @@ allowed-tools: Read, Grep, Write, Task, Bash
 Run the babysitter observer dashboard:
 
 1. Determine the watch directory — this is usually the project's container directory (the parent of the project dir), or the current working directory if not specified.
-2. Launch the standalone dashboard package: `npx -y @a5c-ai/babysitter-observer-dashboard@latest --watch-dir <dir>`.
+2. Launch the standalone dashboard package: `npx -y @yoavmayer/babysitter-observer-dashboard@latest --watch-dir <dir>`.
 3. This is a blocking process — it will keep running until stopped.
 4. Report the URL printed by the dashboard to the user, then open it in the browser.
 

--- a/plugins/babysitter-unified/per-harness/gemini/README.md
+++ b/plugins/babysitter-unified/per-harness/gemini/README.md
@@ -111,7 +111,7 @@ Invoke them in Gemini CLI with `/babysitter:<command>`.
 |---------|-------------|
 | `/babysitter:assimilate [target]` | Convert an external methodology, harness, or specification into native babysitter process definitions with skills and agents. Accepts a repo URL, harness name, or spec path. |
 | `/babysitter:cleanup [--dry-run] [--keep-days N]` | Aggregate insights from completed/failed runs into `docs/run-history-insights.md`, then remove old run data. Defaults to keeping runs newer than 7 days. |
-| `/babysitter:observe [--watch-dir dir]` | Launch the real-time observer dashboard (`@a5c-ai/babysitter-observer-dashboard`) and open it in the browser. |
+| `/babysitter:observe [--watch-dir dir]` | Launch the real-time observer dashboard (`@yoavmayer/babysitter-observer-dashboard`) and open it in the browser. |
 
 ### Setup Commands
 


### PR DESCRIPTION
# fix(observe): restore the standalone dashboard package (0.14.0)

## What

One-line change (three doc/launch lines): `/babysitter:observe` launches `@yoavmayer/babysitter-observer-dashboard@latest` again — the standalone dashboard this command launched before it was switched to the monorepo package.

## Why

The standalone package remained in continuous production use and just shipped **0.14.2**:

- 4-column board triage (Needs-you / Working / Stalled / Done)
- Working breakpoint answering — writes `approved: true` + `response` in the shape the runtime actually reads (strict read-only contract otherwise)
- Activity-based liveness detection + scheduled-run states
- Reconciled run/task counts
- Honest orphaned / no-driver labeling

The monorepo package currently published at `@latest` (6.0.0) shows a generic approval banner without the breakpoint question, and its approve write is not read as approved by the runtime — so answering a breakpoint from the dashboard does not work.

## Visual evidence

### Home / board

| previous standalone release 0.12.3 | 0.14.0 |
|---|---|
| ![home — previous standalone release 0.12.3](https://raw.githubusercontent.com/YoavMayer/babysitter-observer-dashboard/main/docs/compare-0.12.3-vs-0.14.2/c1-home-old.png) | ![home — 0.14.0](https://raw.githubusercontent.com/YoavMayer/babysitter-observer-dashboard/main/docs/compare-0.12.3-vs-0.14.2/c1-home-new.png) |

### Breakpoint answering

| previous standalone release 0.12.3 | 0.14.0 |
|---|---|
| ![breakpoint — previous standalone release 0.12.3](https://raw.githubusercontent.com/YoavMayer/babysitter-observer-dashboard/main/docs/compare-0.12.3-vs-0.14.2/c2-breakpoint-old.png) | ![breakpoint — 0.14.0](https://raw.githubusercontent.com/YoavMayer/babysitter-observer-dashboard/main/docs/compare-0.12.3-vs-0.14.2/c2-breakpoint-new.png) |

### Run status / liveness

| previous standalone release 0.12.3 | 0.14.0 |
|---|---|
| ![status — previous standalone release 0.12.3](https://raw.githubusercontent.com/YoavMayer/babysitter-observer-dashboard/main/docs/compare-0.12.3-vs-0.14.2/c3-status-old.png) | ![status — 0.14.0](https://raw.githubusercontent.com/YoavMayer/babysitter-observer-dashboard/main/docs/compare-0.12.3-vs-0.14.2/c3-status-new.png) |

Full side-by-side comparison: [COMPARISON.md](https://github.com/YoavMayer/babysitter-observer-dashboard/blob/main/docs/compare-0.12.3-vs-0.14.2/COMPARISON.md)

## Note

Zero code changes to this repository — only the package name in the launch instructions/docs. Revert-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

