### PR TITLE
feat(sdk): public run:create-convergent capability with durable hook markers

### DIFF
--- a/packages/babysitter-sdk/src/cli/__tests__/runCreateConvergent.test.ts
+++ b/packages/babysitter-sdk/src/cli/__tests__/runCreateConvergent.test.ts
@@ -1,0 +1,70 @@
+import crypto from "node:crypto";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createBabysitterCli } from "../main";
+
+let root: string;
+let logSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(async () => {
+  root = await fs.mkdtemp(path.join(os.tmpdir(), "cli-run-create-convergent-"));
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+});
+
+afterEach(async () => {
+  logSpy.mockRestore();
+  await fs.rm(root, { recursive: true, force: true });
+});
+
+describe("run:create-convergent CLI", () => {
+  it("Given canonical source files, When run:create-convergent is retried, Then JSON output is exact and the run is reused", async () => {
+    const runsDir = path.join(root, "runs");
+    const inputsPath = path.join(root, "inputs.json");
+    const processPath = path.join(root, "hermes-wave.mjs");
+    await fs.writeFile(inputsPath, JSON.stringify({ objective: "recover" }, null, 2) + "\n");
+    await fs.writeFile(processPath, "export async function process() { return 'ok'; }\n");
+    const args = [
+      "run:create-convergent",
+      "--runs-dir", runsDir,
+      "--run-id", "hermes-wave-7107-r2",
+      "--request", "hermes-wave",
+      "--process-id", "hermes-wave",
+      "--entry", `${processPath}#process`,
+      "--inputs", inputsPath,
+      "--canonical-input-sha256", await sha256File(inputsPath),
+      "--process-snapshot-sha256", await sha256File(processPath),
+      "--replacement-session-id", "ses_fresh_replacement",
+      "--json",
+    ];
+    const cli = createBabysitterCli();
+
+    const firstExitCode = await cli.run(args);
+    const first = readLastJson();
+    const secondExitCode = await cli.run(args);
+    const second = readLastJson();
+
+    expect(firstExitCode).toBe(0);
+    expect(secondExitCode).toBe(0);
+    expect(first).toEqual(second);
+    expect(Object.keys(first).sort()).toEqual([
+      "completionMarkerPath",
+      "completionMarkerSelfHash",
+      "hookResultSha256",
+      "hookStatus",
+      "runCreatedEventSha256",
+      "runCreatedEventUlid",
+      "runId",
+      "runJsonSha256",
+    ]);
+  });
+});
+
+async function sha256File(filePath: string): Promise<string> {
+  return crypto.createHash("sha256").update(await fs.readFile(filePath)).digest("hex");
+}
+
+function readLastJson(): Record<string, unknown> {
+  return JSON.parse(String(logSpy.mock.calls.at(-1)?.[0] ?? "{}"));
+}

--- a/packages/babysitter-sdk/src/cli/main/argFlagParsers.ts
+++ b/packages/babysitter-sdk/src/cli/main/argFlagParsers.ts
@@ -144,6 +144,22 @@ export const FLAG_PARSERS: Record<string, FlagParser> = {
     parsed.inputsPath = expectFlagValue(args, index + 1, "--inputs");
     return index + 1;
   },
+  "--canonical-input-sha256": (parsed, args, index) => {
+    parsed.canonicalInputSha256 = expectFlagValue(args, index + 1, "--canonical-input-sha256");
+    return index + 1;
+  },
+  "--process-snapshot-sha256": (parsed, args, index) => {
+    parsed.processSnapshotHash = expectFlagValue(args, index + 1, "--process-snapshot-sha256");
+    return index + 1;
+  },
+  "--expected-run-json-sha256": (parsed, args, index) => {
+    parsed.expectedRunJsonSha256 = expectFlagValue(args, index + 1, "--expected-run-json-sha256");
+    return index + 1;
+  },
+  "--replacement-session-id": (parsed, args, index) => {
+    parsed.replacementSessionId = expectFlagValue(args, index + 1, "--replacement-session-id");
+    return index + 1;
+  },
   "--run-id": (parsed, args, index) => {
     const runId = expectFlagValue(args, index + 1, "--run-id");
     parsed.runIdOverride = runId;

--- a/packages/babysitter-sdk/src/cli/main/dispatchRunSession.ts
+++ b/packages/babysitter-sdk/src/cli/main/dispatchRunSession.ts
@@ -36,6 +36,7 @@ import type { PluginCommandArgs } from "../commands/plugin";
 import { handleSkillDiscover, handleSkillFetchRemote } from "../commands/skill";
 import {
   handleRunCreate,
+  handleRunCreateConvergent,
   handleRunEvents,
   handleRunIterate,
   handleRunAssignProcess,
@@ -64,6 +65,8 @@ async function executeRunTaskCommand(parsed: ParsedArgs): Promise<number | undef
   switch (parsed.command) {
     case "run:create":
       return await handleRunCreate(parsed);
+    case "run:create-convergent":
+      return await handleRunCreateConvergent(parsed);
     case "run:assign-process":
       return await handleRunAssignProcess(parsed);
     case "run:rebuild-state":

--- a/packages/babysitter-sdk/src/cli/main/program.ts
+++ b/packages/babysitter-sdk/src/cli/main/program.ts
@@ -58,7 +58,7 @@ export const HARNESS_INSTALL_COMMANDS = [
 ] as const;
 
 const SHARED_VALID_COMMANDS = [
-  "run:create", "run:assign-process", "run:status", "run:iterate", "run:events", "run:rebuild-state", "run:repair-journal", "run:recover-process-error", "run:halt",
+  "run:create", "run:create-convergent", "run:assign-process", "run:status", "run:iterate", "run:events", "run:rebuild-state", "run:repair-journal", "run:recover-process-error", "run:halt",
   "task:post", "task:cancel", "task:list", "task:show",
   "log", "hook:log", "hook:run", "skill:discover", "skill:fetch-remote",
   "process-library:clone", "process-library:update", "process-library:use", "process-library:active",

--- a/packages/babysitter-sdk/src/cli/main/runCommands.ts
+++ b/packages/babysitter-sdk/src/cli/main/runCommands.ts
@@ -6,4 +6,5 @@ export {
   handleRunHalt,
 } from "./runCreate";
 export { handleRunAssignProcess } from "./runAssignProcess";
+export { handleRunCreateConvergent } from "./runCreateConvergent";
 export { handleRunEvents, handleRunIterate, handleRunStatus } from "./runInspection";

--- a/packages/babysitter-sdk/src/cli/main/runCreateConvergent.ts
+++ b/packages/babysitter-sdk/src/cli/main/runCreateConvergent.ts
@@ -1,0 +1,54 @@
+import path from "node:path";
+import { createRunConvergent } from "../../runtime/createRunConvergent";
+import { collapseDoubledA5cRuns } from "./args";
+import { parseEntrypointSpecifier, validateProcessEntrypoint } from "./runSupport";
+import type { ParsedArgs } from "./types";
+
+const REQUIRED_FLAGS = [
+  ["--run-id", "runIdOverride"],
+  ["--request", "requestId"],
+  ["--process-id", "processId"],
+  ["--entry", "entrySpecifier"],
+  ["--inputs", "inputsPath"],
+  ["--canonical-input-sha256", "canonicalInputSha256"],
+  ["--process-snapshot-sha256", "processSnapshotHash"],
+  ["--replacement-session-id", "replacementSessionId"],
+] as const;
+
+export async function handleRunCreateConvergent(parsed: ParsedArgs): Promise<number> {
+  const missing = REQUIRED_FLAGS
+    .filter(([, field]) => parsed[field] === undefined)
+    .map(([flag]) => flag);
+  if (missing.length > 0) {
+    console.error(`[run:create-convergent] missing required flags: ${missing.join(", ")}`);
+    return 1;
+  }
+  const entry = parseEntrypointSpecifier(parsed.entrySpecifier ?? "");
+  const processSnapshotPath = path.resolve(entry.importPath);
+  await validateProcessEntrypoint(processSnapshotPath, entry.exportName);
+  const result = await createRunConvergent({
+    canonicalInputSha256: parsed.canonicalInputSha256 ?? "",
+    expectedRunJsonSha256: parsed.expectedRunJsonSha256,
+    harness: parsed.harness,
+    inputsPath: path.resolve(parsed.inputsPath ?? ""),
+    process: {
+      exportName: entry.exportName,
+      importPath: processSnapshotPath,
+      processId: parsed.processId ?? "",
+    },
+    processRevision: parsed.processRevision,
+    processSnapshotHash: parsed.processSnapshotHash ?? "",
+    processSnapshotPath,
+    prompt: parsed.prompt,
+    replacementSessionId: parsed.replacementSessionId ?? "",
+    request: parsed.requestId ?? "",
+    runId: parsed.runIdOverride ?? "",
+    runsDir: collapseDoubledA5cRuns(path.resolve(parsed.runsDir)),
+  });
+  if (parsed.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(`[run:create-convergent] runId=${result.runId} completionMarkerPath=${result.completionMarkerPath}`);
+  }
+  return 0;
+}

--- a/packages/babysitter-sdk/src/cli/main/types.ts
+++ b/packages/babysitter-sdk/src/cli/main/types.ts
@@ -35,6 +35,10 @@ export interface ParsedArgs {
   processId?: string;
   entrySpecifier?: string;
   inputsPath?: string;
+  canonicalInputSha256?: string;
+  processSnapshotHash?: string;
+  expectedRunJsonSha256?: string;
+  replacementSessionId?: string;
   runIdOverride?: string;
   processRevision?: string;
   requestId?: string;

--- a/packages/babysitter-sdk/src/cli/main/usage.ts
+++ b/packages/babysitter-sdk/src/cli/main/usage.ts
@@ -3,6 +3,7 @@ import { CORE_PROGRAM, type CliProgram } from "./program";
 
 function coreAgentUsage(commandName: string): string {
   return `  ${commandName} run:create --process-id <id> [--entry <path#export>] [--inputs <file>] [--run-id <id>] [--process-revision <rev>] [--request <id>] [--prompt <text>] [--harness <name>] [--session-id <id>] [--non-interactive] [--json] [--dry-run]
+  ${commandName} run:create-convergent --run-id <id> --request <id> --process-id <id> --entry <path#export> --inputs <file> --canonical-input-sha256 <sha256> --process-snapshot-sha256 <sha256> --replacement-session-id <id> [--expected-run-json-sha256 <sha256>] [--json]
   ${commandName} run:assign-process <runDir> --entry <path#export> [--process-id <id>] [--process-revision <rev>] [--force] [--json] [--dry-run]
   ${commandName} run:status <runDir> [--json]
   ${commandName} run:events <runDir> [--json] [--limit <n>] [--reverse] [--filter-type <type>]

--- a/packages/babysitter-sdk/src/runtime/__tests__/createRunConvergent.test.ts
+++ b/packages/babysitter-sdk/src/runtime/__tests__/createRunConvergent.test.ts
@@ -1,0 +1,179 @@
+import crypto from "node:crypto";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createRunConvergent } from "../createRunConvergent";
+import * as runtimeHooks from "../hooks/runtime";
+import { createRunDir } from "../../storage/createRunDir";
+import { classifyConvergentRun } from "../convergentRun/classify";
+
+let root: string;
+let inputsPath: string;
+let processSnapshotPath: string;
+
+beforeEach(async () => {
+  root = await fs.mkdtemp(path.join(os.tmpdir(), "sdk-create-convergent-"));
+  inputsPath = path.join(root, "inputs.json");
+  processSnapshotPath = path.join(root, "hermes-wave.mjs");
+  await fs.writeFile(inputsPath, JSON.stringify({ objective: "recover" }, null, 2) + "\n");
+  await fs.writeFile(processSnapshotPath, "export async function process() { return 'ok'; }\n");
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await fs.rm(root, { recursive: true, force: true });
+});
+
+describe("createRunConvergent", () => {
+  it("Given an absent run, When creation completes, Then a reread completion marker makes retry read-only", async () => {
+    const options = await createOptions("hermes-wave-7101-r2");
+    const hookSpy = vi.spyOn(runtimeHooks, "callRuntimeHook").mockResolvedValue({
+      hookType: "on-run-start",
+      success: true,
+      output: { ready: true },
+      executedHooks: [],
+    });
+
+    await expect(classifyConvergentRun(options)).resolves.toEqual({ kind: "ABSENT" });
+    const first = await createRunConvergent(options);
+    const second = await createRunConvergent(options);
+
+    expect(second).toEqual(first);
+    expect(Object.keys(first).sort()).toEqual([
+      "completionMarkerPath",
+      "completionMarkerSelfHash",
+      "hookResultSha256",
+      "hookStatus",
+      "runCreatedEventSha256",
+      "runCreatedEventUlid",
+      "runId",
+      "runJsonSha256",
+    ]);
+    expect(hookSpy).toHaveBeenCalledTimes(1);
+    await expect(fs.access(first.completionMarkerPath)).resolves.toBeUndefined();
+  });
+
+  it("Given an exact pre-journal run, When no run.json digest is supplied, Then resume is rejected without rewriting bytes", async () => {
+    const options = await createOptions("hermes-wave-7102-r2");
+    const runDir = path.join(root, options.runId);
+    await createRunDir({
+      runsRoot: root,
+      runId: options.runId,
+      request: options.request,
+      processId: options.process.processId,
+      inputs: { objective: "recover" },
+      entrypoint: {
+        importPath: path.relative(runDir, processSnapshotPath),
+        exportName: options.process.exportName,
+      },
+      processPath: path.relative(runDir, processSnapshotPath),
+      extraMetadata: {
+        processCodeHash: options.processSnapshotHash,
+      },
+    });
+    const runJsonPath = path.join(runDir, "run.json");
+    const before = await fs.readFile(runJsonPath);
+
+    await expect(classifyConvergentRun(options)).resolves.toMatchObject({ kind: "PRE_JOURNAL_EXACT" });
+
+    await expect(createRunConvergent(options)).rejects.toMatchObject({
+      name: "RUN_CREATE_RESUME_UNSUPPORTED",
+    });
+
+    expect(await fs.readFile(runJsonPath)).toEqual(before);
+  });
+
+  it("Given a pre-hook marker, When creation resumes, Then it invokes the hook exactly once", async () => {
+    const options = await createOptions("hermes-wave-7103-r2");
+    const hookSpy = vi.spyOn(runtimeHooks, "callRuntimeHook").mockResolvedValue({
+      hookType: "on-run-start",
+      success: true,
+      output: null,
+      executedHooks: [],
+    });
+    const complete = await createRunConvergent(options);
+    const markerDirectory = path.dirname(complete.completionMarkerPath);
+    await fs.rm(complete.completionMarkerPath);
+    await fs.rename(
+      path.join(markerDirectory, "hook-may-have-started.json"),
+      path.join(markerDirectory, "hook-not-started.json"),
+    );
+    hookSpy.mockClear();
+
+    await expect(classifyConvergentRun(options)).resolves.toMatchObject({ kind: "JOURNALED_PRE_HOOK_PROVEN" });
+
+    await createRunConvergent(options);
+
+    expect(hookSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("Given hook finalization is unknown, When creation retries, Then it fails closed without another hook call", async () => {
+    const options = await createOptions("hermes-wave-7104-r2");
+    const hookSpy = vi.spyOn(runtimeHooks, "callRuntimeHook").mockRejectedValue(new Error("simulated kill"));
+
+    await expect(createRunConvergent(options)).rejects.toMatchObject({
+      name: "RUN_CREATE_HOOK_FINALIZATION_UNKNOWN",
+    });
+    const markerPath = path.join(root, options.runId, "state", "run-create-convergent-v1", "hook-may-have-started.json");
+    const beforeRetry = await fs.readFile(markerPath);
+    await expect(classifyConvergentRun(options)).resolves.toEqual({ kind: "JOURNALED_HOOK_FINALIZATION_UNKNOWN" });
+    await expect(createRunConvergent(options)).rejects.toMatchObject({
+      name: "RUN_CREATE_HOOK_FINALIZATION_UNKNOWN",
+    });
+
+    expect(hookSpy).toHaveBeenCalledTimes(1);
+    expect(await fs.readFile(markerPath)).toEqual(beforeRetry);
+  });
+
+  it("Given a divergent completion marker or partial run, When creation retries, Then it returns the precise fail-closed code", async () => {
+    const options = await createOptions("hermes-wave-7105-r2");
+    vi.spyOn(runtimeHooks, "callRuntimeHook").mockResolvedValue({
+      hookType: "on-run-start",
+      success: true,
+      output: null,
+      executedHooks: [],
+    });
+    const complete = await createRunConvergent(options);
+    await expect(classifyConvergentRun(options)).resolves.toMatchObject({ kind: "CREATED_COMPLETE" });
+    await fs.appendFile(complete.completionMarkerPath, "\n");
+
+    await expect(createRunConvergent(options)).rejects.toMatchObject({
+      name: "RUN_CREATE_COMPLETION_MARKER_DIVERGED",
+    });
+
+    const partialOptions = await createOptions("hermes-wave-7106-r2");
+    await fs.mkdir(path.join(root, partialOptions.runId));
+    await fs.writeFile(path.join(root, partialOptions.runId, "unexpected"), "partial");
+
+    await expect(classifyConvergentRun(partialOptions)).resolves.toEqual({ kind: "PARTIAL_UNKNOWN" });
+
+    await expect(createRunConvergent(partialOptions)).rejects.toMatchObject({
+      name: "RUN_CREATE_PARTIAL_INVALID",
+    });
+  });
+});
+
+async function createOptions(runId: string) {
+  const inputBytes = await fs.readFile(inputsPath);
+  const snapshotBytes = await fs.readFile(processSnapshotPath);
+  return {
+    runsDir: root,
+    runId,
+    request: "hermes-wave",
+    process: {
+      processId: "hermes-wave",
+      importPath: processSnapshotPath,
+      exportName: "process",
+    },
+    inputsPath,
+    canonicalInputSha256: sha256(inputBytes),
+    processSnapshotPath,
+    processSnapshotHash: sha256(snapshotBytes),
+    replacementSessionId: "ses_fresh_replacement",
+  };
+}
+
+function sha256(bytes: Buffer): string {
+  return crypto.createHash("sha256").update(bytes).digest("hex");
+}

--- a/packages/babysitter-sdk/src/runtime/convergentRun/classify.ts
+++ b/packages/babysitter-sdk/src/runtime/convergentRun/classify.ts
@@ -1,0 +1,124 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { loadJournal } from "../../storage/journal";
+import { INPUTS_FILE, RUN_METADATA_FILE } from "../../storage/paths";
+import { readRunMetadata } from "../../storage/runFiles";
+import type { JournalEvent, RunMetadata } from "../../storage/types";
+import { type CompletionMarker, type ConvergentRunContext, type CreateRunConvergentOptions, sha256 } from "./contracts";
+import { classifyMarkers } from "./markerValidation";
+import { pathExists } from "./durable";
+
+const RUN_DIRECTORIES = ["journal", "tasks", "blobs", "state", "orphaned", "process"] as const;
+const RUN_FILES = [".gitignore", RUN_METADATA_FILE, INPUTS_FILE] as const;
+
+export type ConvergentRunClassification =
+  | { readonly kind: "ABSENT" }
+  | { readonly kind: "PRE_JOURNAL_EXACT"; readonly metadata: RunMetadata; readonly runDir: string; readonly runJsonSha256: string }
+  | { readonly kind: "JOURNALED_PRE_HOOK_PROVEN"; readonly context: ConvergentRunContext }
+  | { readonly kind: "JOURNALED_HOOK_FINALIZATION_UNKNOWN" }
+  | { readonly kind: "CREATED_COMPLETE"; readonly context: ConvergentRunContext; readonly completion: CompletionMarker }
+  | { readonly kind: "COMPLETION_MARKER_DIVERGED" }
+  | { readonly kind: "PARTIAL_UNKNOWN" };
+
+export async function classifyConvergentRun(options: CreateRunConvergentOptions): Promise<ConvergentRunClassification> {
+  const runDir = path.resolve(options.runsDir, options.runId);
+  if (!(await pathExists(runDir))) return { kind: "ABSENT" };
+  if (!(await hasExactRunLayout(runDir))) return { kind: "PARTIAL_UNKNOWN" };
+
+  const existing = await readExistingRun(runDir, options);
+  if (existing === null) return { kind: "PARTIAL_UNKNOWN" };
+  const journal = await readExactJournal(runDir);
+  if (journal === null) return { kind: "PARTIAL_UNKNOWN" };
+  if (journal.length === 0) {
+    return {
+      kind: "PRE_JOURNAL_EXACT",
+      metadata: existing.metadata,
+      runDir,
+      runJsonSha256: existing.runJsonSha256,
+    };
+  }
+  if (journal.length !== 1 || journal[0]?.type !== "RUN_CREATED" || !(await hasNoTasks(runDir))) {
+    return { kind: "PARTIAL_UNKNOWN" };
+  }
+
+  const event = journal[0];
+  if (!matchesRunCreatedEvent(event, existing.metadata, options)) return { kind: "PARTIAL_UNKNOWN" };
+  const context: ConvergentRunContext = {
+    event,
+    metadata: existing.metadata,
+    runDir,
+    runJsonSha256: existing.runJsonSha256,
+  };
+  return await classifyMarkers(context, options);
+}
+
+async function hasExactRunLayout(runDir: string): Promise<boolean> {
+  const entries = await fs.readdir(runDir, { withFileTypes: true });
+  const names = new Set(entries.map((entry) => entry.name));
+  const allowed = new Set([...RUN_DIRECTORIES, ...RUN_FILES, "run.lock"]);
+  if (entries.some((entry) => !allowed.has(entry.name))) return false;
+  if (RUN_DIRECTORIES.some((name) => !names.has(name)) || RUN_FILES.some((name) => !names.has(name))) return false;
+  for (const name of RUN_DIRECTORIES) {
+    const entry = entries.find((candidate) => candidate.name === name);
+    if (!entry?.isDirectory()) return false;
+  }
+  return true;
+}
+
+async function readExistingRun(runDir: string, options: CreateRunConvergentOptions): Promise<{
+  readonly metadata: RunMetadata;
+  readonly runJsonSha256: string;
+} | null> {
+  try {
+    const runJson = await fs.readFile(path.join(runDir, RUN_METADATA_FILE));
+    const inputs = await fs.readFile(path.join(runDir, INPUTS_FILE));
+    const snapshot = await fs.readFile(options.processSnapshotPath);
+    const metadata = await readRunMetadata(runDir);
+    const runJsonSha256 = sha256(runJson);
+    if (options.expectedRunJsonSha256 !== undefined && options.expectedRunJsonSha256 !== runJsonSha256) return null;
+    if (!inputs.equals(await fs.readFile(options.inputsPath))) return null;
+    if (sha256(snapshot) !== options.processSnapshotHash) return null;
+    if (!matchesMetadata(metadata, runDir, options)) return null;
+    return { metadata, runJsonSha256 };
+  } catch (error) {
+    if (error instanceof Error) return null;
+    throw error;
+  }
+}
+
+function matchesMetadata(metadata: RunMetadata, runDir: string, options: CreateRunConvergentOptions): boolean {
+  const entryImport = path.posix.normalize(path.relative(runDir, options.process.importPath).replace(/\\/g, "/"));
+  return metadata.runId === options.runId
+    && metadata.request === options.request
+    && metadata.processId === options.process.processId
+    && metadata.processCodeHash === options.processSnapshotHash
+    && metadata.entrypoint.importPath === entryImport
+    && metadata.entrypoint.exportName === options.process.exportName
+    && metadata.prompt === options.prompt;
+}
+
+async function readExactJournal(runDir: string): Promise<readonly JournalEvent[] | null> {
+  try {
+    const names = await fs.readdir(path.join(runDir, "journal"));
+    if (names.some((name) => !/^\d{6}\.[A-Za-z0-9]+\.json$/.test(name))) return null;
+    const events = await loadJournal(runDir);
+    return events.length === names.length ? events : null;
+  } catch (error) {
+    if (error instanceof Error) return null;
+    throw error;
+  }
+}
+
+async function hasNoTasks(runDir: string): Promise<boolean> {
+  const entries = await fs.readdir(path.join(runDir, "tasks"));
+  return entries.length === 0;
+}
+
+function matchesRunCreatedEvent(event: JournalEvent, metadata: RunMetadata, options: CreateRunConvergentOptions): boolean {
+  return event.data.runId === options.runId
+    && event.data.processId === metadata.processId
+    && event.data.inputsRef === INPUTS_FILE
+    && JSON.stringify(event.data.entrypoint) === JSON.stringify(metadata.entrypoint)
+    && event.data.processCodeHash === metadata.processCodeHash
+    && event.data.prompt === options.prompt;
+}

--- a/packages/babysitter-sdk/src/runtime/convergentRun/contracts.ts
+++ b/packages/babysitter-sdk/src/runtime/convergentRun/contracts.ts
@@ -1,0 +1,156 @@
+import crypto from "node:crypto";
+import { z } from "zod";
+import type { HookResult } from "../../hooks/types";
+import type { JournalEvent, RunMetadata } from "../../storage/types";
+
+export const CONVERGENT_RUN_STATE_DIR = "run-create-convergent-v1";
+export const HOOK_NOT_STARTED_FILE = "hook-not-started.json";
+export const HOOK_MAY_HAVE_STARTED_FILE = "hook-may-have-started.json";
+export const COMPLETION_FILE = "completion.json";
+
+const SHA256 = /^[a-f0-9]{64}$/;
+
+export type ConvergentRunProcess = {
+  readonly processId: string;
+  readonly importPath: string;
+  readonly exportName?: string;
+};
+
+export type CreateRunConvergentOptions = {
+  readonly runsDir: string;
+  readonly runId: string;
+  readonly request: string;
+  readonly process: ConvergentRunProcess;
+  readonly inputsPath: string;
+  readonly canonicalInputSha256: string;
+  readonly processSnapshotPath: string;
+  readonly processSnapshotHash: string;
+  readonly replacementSessionId: string;
+  readonly expectedRunJsonSha256?: string;
+  readonly prompt?: string;
+  readonly harness?: string;
+  readonly processRevision?: string;
+  readonly lockOwner?: string;
+  readonly logger?: (message: string) => void;
+};
+
+export type CreateRunConvergentResult = {
+  readonly completionMarkerPath: string;
+  readonly completionMarkerSelfHash: string;
+  readonly hookResultSha256: string;
+  readonly hookStatus: "completed-success" | "completed-failure";
+  readonly runCreatedEventSha256: string;
+  readonly runCreatedEventUlid: string;
+  readonly runId: string;
+  readonly runJsonSha256: string;
+};
+
+export type ConvergentRunContext = {
+  readonly event: JournalEvent;
+  readonly metadata: RunMetadata;
+  readonly runDir: string;
+  readonly runJsonSha256: string;
+};
+
+export const boundaryMarkerSchema = z.object({
+  canonicalInputSha256: z.string().regex(SHA256),
+  processSnapshotHash: z.string().regex(SHA256),
+  processSnapshotPath: z.string().min(1),
+  replacementSessionId: z.string().min(1),
+  runCreatedEventSha256: z.string().regex(SHA256),
+  runCreatedEventUlid: z.string().min(1),
+  runId: z.string().min(1),
+  runJsonSha256: z.string().regex(SHA256),
+  schema: z.literal("babysitter-run-create-hook-boundary/v1"),
+  selfHash: z.string().regex(SHA256),
+}).strict();
+
+export const completionMarkerSchema = z.object({
+  canonicalInputSha256: z.string().regex(SHA256),
+  hook: z.object({
+    resultSha256: z.string().regex(SHA256),
+    status: z.enum(["completed-success", "completed-failure"]),
+  }).strict(),
+  process: z.object({
+    snapshotHash: z.string().regex(SHA256),
+    snapshotPath: z.string().min(1),
+  }).strict(),
+  replacementSessionId: z.string().min(1),
+  runCreated: z.object({
+    eventSha256: z.string().regex(SHA256),
+    ulid: z.string().min(1),
+  }).strict(),
+  runId: z.string().min(1),
+  runJsonSha256: z.string().regex(SHA256),
+  schema: z.literal("babysitter-run-create-completion/v1"),
+  selfHash: z.string().regex(SHA256),
+}).strict();
+
+export type BoundaryMarker = z.infer<typeof boundaryMarkerSchema>;
+export type CompletionMarker = z.infer<typeof completionMarkerSchema>;
+
+export function sha256(bytes: Buffer | string): string {
+  return crypto.createHash("sha256").update(bytes).digest("hex");
+}
+
+export function canonicalJson(value: unknown): string {
+  if (value === null) return "null";
+  switch (typeof value) {
+    case "boolean":
+    case "number":
+    case "string":
+      return JSON.stringify(value);
+    case "object":
+      if (Array.isArray(value)) {
+        return `[${value.map((entry) => canonicalJson(entry)).join(",")}]`;
+      }
+      {
+        const record = z.record(z.string(), z.unknown()).parse(value);
+        return `{${Object.keys(record).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`).join(",")}}`;
+      }
+    default:
+      throw new TypeError("Canonical JSON only accepts JSON values");
+  }
+}
+
+export function withoutSelfHash(marker: BoundaryMarker | CompletionMarker): Record<string, unknown> {
+  const { selfHash: _selfHash, ...preimage } = marker;
+  return preimage;
+}
+
+export function runCreatedEventSha256(event: JournalEvent): string {
+  return sha256(canonicalJson({
+    data: event.data,
+    filename: event.filename,
+    recordedAt: event.recordedAt,
+    seq: event.seq,
+    type: event.type,
+    ulid: event.ulid,
+  }));
+}
+
+export function hookResultProjection(result: HookResult): Record<string, unknown> {
+  return {
+    error: result.error ?? null,
+    executedHooks: result.executedHooks.map((hook) => ({
+      exitCode: hook.exitCode ?? null,
+      hookLocation: hook.hookLocation,
+      hookName: hook.hookName,
+      hookPath: hook.hookPath,
+      status: hook.status,
+    })),
+    hookType: "on-run-start",
+    output: result.output ?? null,
+    success: result.success,
+  };
+}
+
+export function hookStatus(result: HookResult): "completed-success" | "completed-failure" {
+  return result.success ? "completed-success" : "completed-failure";
+}
+
+export function validateSha256(value: string, label: string): void {
+  if (!SHA256.test(value)) {
+    throw new TypeError(`${label} must be a lowercase SHA-256 digest`);
+  }
+}

--- a/packages/babysitter-sdk/src/runtime/convergentRun/durable.ts
+++ b/packages/babysitter-sdk/src/runtime/convergentRun/durable.ts
@@ -1,0 +1,90 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
+
+export async function ensurePrivateDirectory(directory: string): Promise<void> {
+  const created = await fs.mkdir(directory, { recursive: true, mode: 0o700 });
+  if (created !== undefined) {
+    await fs.chmod(directory, 0o700);
+    await fsyncDirectory(path.dirname(directory));
+  }
+  await requireMode(directory, 0o700);
+}
+
+export async function publishCreateOnce(directory: string, filename: string, bytes: Buffer): Promise<string> {
+  const targetPath = path.join(directory, filename);
+  const temporaryPath = path.join(directory, `.${filename}.${process.pid}.${crypto.randomUUID()}.tmp`);
+  const handle = await fs.open(temporaryPath, "wx", 0o600);
+  try {
+    await handle.writeFile(bytes);
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+
+  try {
+    await requireMode(temporaryPath, 0o600);
+    await requireExactBytes(temporaryPath, bytes);
+    await fs.link(temporaryPath, targetPath);
+    await fsyncDirectory(directory);
+    await requireMode(targetPath, 0o600);
+    await requireExactBytes(targetPath, bytes);
+    return targetPath;
+  } finally {
+    await fs.rm(temporaryPath, { force: true });
+  }
+}
+
+export async function renameNoReplace(sourcePath: string, targetPath: string): Promise<void> {
+  await requireAbsent(targetPath);
+  await fs.rename(sourcePath, targetPath);
+  await fsyncDirectory(path.dirname(targetPath));
+}
+
+export async function readPrivateFile(filePath: string): Promise<Buffer> {
+  await requireMode(filePath, 0o600);
+  return await fs.readFile(filePath);
+}
+
+export async function requireMode(targetPath: string, expected: number): Promise<void> {
+  const stat = await fs.stat(targetPath);
+  if ((stat.mode & 0o777) !== expected) {
+    throw new Error(`${targetPath} must have mode ${expected.toString(8)}`);
+  }
+}
+
+export async function requireExactBytes(targetPath: string, expected: Buffer): Promise<void> {
+  const actual = await fs.readFile(targetPath);
+  if (!actual.equals(expected)) {
+    throw new Error(`${targetPath} bytes diverged during durable publication`);
+  }
+}
+
+export async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await fs.lstat(targetPath);
+    return true;
+  } catch (error) {
+    if (isErrno(error, "ENOENT")) return false;
+    throw error;
+  }
+}
+
+export async function requireAbsent(targetPath: string): Promise<void> {
+  if (await pathExists(targetPath)) {
+    throw new Error(`${targetPath} already exists`);
+  }
+}
+
+export async function fsyncDirectory(directory: string): Promise<void> {
+  const handle = await fs.open(directory, "r");
+  try {
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+function isErrno(error: unknown, code: string): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === code;
+}

--- a/packages/babysitter-sdk/src/runtime/convergentRun/errors.ts
+++ b/packages/babysitter-sdk/src/runtime/convergentRun/errors.ts
@@ -1,0 +1,7 @@
+import { BabysitterRuntimeError, ErrorCategory } from "../exceptions";
+
+export class ConvergentRunError extends BabysitterRuntimeError {
+  constructor(code: string, message: string) {
+    super(code, message, { category: ErrorCategory.Runtime });
+  }
+}

--- a/packages/babysitter-sdk/src/runtime/convergentRun/execution.ts
+++ b/packages/babysitter-sdk/src/runtime/convergentRun/execution.ts
@@ -1,0 +1,163 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { invokeRunStartHook } from "../createRun";
+import { classifyConvergentRun } from "./classify";
+import {
+  COMPLETION_FILE,
+  CONVERGENT_RUN_STATE_DIR,
+  HOOK_MAY_HAVE_STARTED_FILE,
+  HOOK_NOT_STARTED_FILE,
+  canonicalJson,
+  hookResultProjection,
+  hookStatus,
+  runCreatedEventSha256,
+  sha256,
+  type BoundaryMarker,
+  type CompletionMarker,
+  type ConvergentRunContext,
+  type CreateRunConvergentOptions,
+  type CreateRunConvergentResult,
+} from "./contracts";
+import { ensurePrivateDirectory, publishCreateOnce, renameNoReplace } from "./durable";
+import { ConvergentRunError } from "./errors";
+import { loadJournal } from "../../storage/journal";
+import { RUN_METADATA_FILE } from "../../storage/paths";
+import type { CreateRunOptions, CreateRunResult } from "../types";
+
+export type ConvergentHookExecution = {
+  readonly context: ConvergentRunContext;
+  readonly options: CreateRunConvergentOptions;
+  readonly runOptions: CreateRunOptions;
+};
+
+export async function publishBoundaryAndInvoke(args: ConvergentHookExecution): Promise<CreateRunConvergentResult> {
+  const markerDirectory = path.join(args.context.runDir, "state", CONVERGENT_RUN_STATE_DIR);
+  await ensurePrivateDirectory(markerDirectory);
+  await publishCreateOnce(markerDirectory, HOOK_NOT_STARTED_FILE, markerBytes(boundaryMarker(args.context, args.options)));
+  return await invokeFromProvenBoundary(args);
+}
+
+export async function invokeFromProvenBoundary(args: ConvergentHookExecution): Promise<CreateRunConvergentResult> {
+  const markerDirectory = path.join(args.context.runDir, "state", CONVERGENT_RUN_STATE_DIR);
+  await renameNoReplace(
+    path.join(markerDirectory, HOOK_NOT_STARTED_FILE),
+    path.join(markerDirectory, HOOK_MAY_HAVE_STARTED_FILE),
+  );
+  const result: CreateRunResult = {
+    metadata: args.context.metadata,
+    runDir: args.context.runDir,
+    runId: args.options.runId,
+  };
+  let hook: Awaited<ReturnType<typeof invokeRunStartHook>>;
+  try {
+    hook = await invokeRunStartHook({ result, options: args.runOptions });
+  } catch (error) {
+    if (error instanceof Error) {
+      throw new ConvergentRunError("RUN_CREATE_HOOK_FINALIZATION_UNKNOWN", "on-run-start threw after hook-may-have-started was published");
+    }
+    throw error;
+  }
+  try {
+    await publishCreateOnce(markerDirectory, COMPLETION_FILE, markerBytes(completionMarker(args.context, args.options, hook)));
+  } catch (error) {
+    if (error instanceof Error) {
+      throw new ConvergentRunError("RUN_CREATE_HOOK_FINALIZATION_UNKNOWN", "on-run-start returned before completion marker publication was proven");
+    }
+    throw error;
+  }
+  const classification = await classifyConvergentRun(args.options);
+  switch (classification.kind) {
+    case "CREATED_COMPLETE":
+      return completionResult(classification.context, classification.completion);
+    case "COMPLETION_MARKER_DIVERGED":
+      throw new ConvergentRunError("RUN_CREATE_COMPLETION_MARKER_DIVERGED", "completion marker diverged after publication");
+    case "ABSENT":
+    case "PRE_JOURNAL_EXACT":
+    case "JOURNALED_PRE_HOOK_PROVEN":
+    case "JOURNALED_HOOK_FINALIZATION_UNKNOWN":
+    case "PARTIAL_UNKNOWN":
+      throw new ConvergentRunError("RUN_CREATE_HOOK_FINALIZATION_UNKNOWN", "completion marker was not revalidated after hook completion");
+    default:
+      return assertNever(classification);
+  }
+}
+
+export async function reopenRunCreatedContext(args: {
+  readonly event: ConvergentRunContext["event"];
+  readonly result: CreateRunResult;
+}): Promise<ConvergentRunContext> {
+  const journal = await loadJournal(args.result.runDir);
+  const reopened = journal[0];
+  if (journal.length !== 1 || reopened === undefined || reopened.type !== "RUN_CREATED" || runCreatedEventSha256(reopened) !== runCreatedEventSha256(args.event)) {
+    throw new ConvergentRunError("RUN_CREATE_PARTIAL_INVALID", "RUN_CREATED could not be reopened exactly");
+  }
+  return {
+    event: reopened,
+    metadata: args.result.metadata,
+    runDir: args.result.runDir,
+    runJsonSha256: sha256(await fs.readFile(path.join(args.result.runDir, RUN_METADATA_FILE))),
+  };
+}
+
+export function completionResult(context: ConvergentRunContext, completion: CompletionMarker): CreateRunConvergentResult {
+  return {
+    completionMarkerPath: path.join(context.runDir, "state", CONVERGENT_RUN_STATE_DIR, COMPLETION_FILE),
+    completionMarkerSelfHash: completion.selfHash,
+    hookResultSha256: completion.hook.resultSha256,
+    hookStatus: completion.hook.status,
+    runCreatedEventSha256: completion.runCreated.eventSha256,
+    runCreatedEventUlid: completion.runCreated.ulid,
+    runId: completion.runId,
+    runJsonSha256: completion.runJsonSha256,
+  };
+}
+
+function boundaryMarker(context: ConvergentRunContext, options: CreateRunConvergentOptions): BoundaryMarker {
+  const marker = {
+    canonicalInputSha256: options.canonicalInputSha256,
+    processSnapshotHash: options.processSnapshotHash,
+    processSnapshotPath: options.processSnapshotPath,
+    replacementSessionId: options.replacementSessionId,
+    runCreatedEventSha256: runCreatedEventSha256(context.event),
+    runCreatedEventUlid: context.event.ulid,
+    runId: options.runId,
+    runJsonSha256: context.runJsonSha256,
+    schema: "babysitter-run-create-hook-boundary/v1" as const,
+  };
+  return { ...marker, selfHash: sha256(canonicalJson(marker)) };
+}
+
+function completionMarker(
+  context: ConvergentRunContext,
+  options: CreateRunConvergentOptions,
+  hook: Awaited<ReturnType<typeof invokeRunStartHook>>,
+): CompletionMarker {
+  const marker = {
+    canonicalInputSha256: options.canonicalInputSha256,
+    hook: {
+      resultSha256: sha256(canonicalJson(hookResultProjection(hook))),
+      status: hookStatus(hook),
+    },
+    process: {
+      snapshotHash: options.processSnapshotHash,
+      snapshotPath: options.processSnapshotPath,
+    },
+    replacementSessionId: options.replacementSessionId,
+    runCreated: {
+      eventSha256: runCreatedEventSha256(context.event),
+      ulid: context.event.ulid,
+    },
+    runId: options.runId,
+    runJsonSha256: context.runJsonSha256,
+    schema: "babysitter-run-create-completion/v1" as const,
+  };
+  return { ...marker, selfHash: sha256(canonicalJson(marker)) };
+}
+
+function markerBytes(marker: BoundaryMarker | CompletionMarker): Buffer {
+  return Buffer.from(`${JSON.stringify(marker, null, 2)}\n`, "utf8");
+}
+
+function assertNever(value: never): never {
+  throw new ConvergentRunError("RUN_CREATE_PARTIAL_INVALID", `Unhandled convergent state: ${JSON.stringify(value)}`);
+}

--- a/packages/babysitter-sdk/src/runtime/convergentRun/markerValidation.ts
+++ b/packages/babysitter-sdk/src/runtime/convergentRun/markerValidation.ts
@@ -1,0 +1,112 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import {
+  COMPLETION_FILE,
+  CONVERGENT_RUN_STATE_DIR,
+  HOOK_MAY_HAVE_STARTED_FILE,
+  HOOK_NOT_STARTED_FILE,
+  boundaryMarkerSchema,
+  canonicalJson,
+  completionMarkerSchema,
+  runCreatedEventSha256,
+  sha256,
+  withoutSelfHash,
+  type BoundaryMarker,
+  type CompletionMarker,
+  type ConvergentRunContext,
+  type CreateRunConvergentOptions,
+} from "./contracts";
+import { pathExists, readPrivateFile, requireMode } from "./durable";
+import type { ConvergentRunClassification } from "./classify";
+
+export async function classifyMarkers(
+  context: ConvergentRunContext,
+  options: CreateRunConvergentOptions,
+): Promise<ConvergentRunClassification> {
+  const markerDirectory = path.join(context.runDir, "state", CONVERGENT_RUN_STATE_DIR);
+  if (!(await pathExists(markerDirectory))) return { kind: "JOURNALED_HOOK_FINALIZATION_UNKNOWN" };
+  try {
+    await requireMode(markerDirectory, 0o700);
+  } catch (error) {
+    if (error instanceof Error) return { kind: "PARTIAL_UNKNOWN" };
+    throw error;
+  }
+  const entries = new Set(await fs.readdir(markerDirectory));
+  const boundaryPath = path.join(markerDirectory, HOOK_NOT_STARTED_FILE);
+  const mayHaveStartedPath = path.join(markerDirectory, HOOK_MAY_HAVE_STARTED_FILE);
+  const completionPath = path.join(markerDirectory, COMPLETION_FILE);
+  const hasBoundary = await pathExists(boundaryPath);
+  const hasMayHaveStarted = await pathExists(mayHaveStartedPath);
+  const hasCompletion = await pathExists(completionPath);
+  if (hasCompletion) {
+    if (hasBoundary || !hasMayHaveStarted || entries.size !== 2) return { kind: "COMPLETION_MARKER_DIVERGED" };
+    const completion = await readCompletion(completionPath);
+    if (completion === null || !matchesCompletion(completion, context, options)) return { kind: "COMPLETION_MARKER_DIVERGED" };
+    return { kind: "CREATED_COMPLETE", context, completion };
+  }
+  if (hasBoundary && !hasMayHaveStarted && entries.size === 1) {
+    const boundary = await readBoundary(boundaryPath);
+    return boundary !== null && matchesBoundary(boundary, context, options)
+      ? { kind: "JOURNALED_PRE_HOOK_PROVEN", context }
+      : { kind: "PARTIAL_UNKNOWN" };
+  }
+  return { kind: "JOURNALED_HOOK_FINALIZATION_UNKNOWN" };
+}
+
+async function readBoundary(markerPath: string): Promise<BoundaryMarker | null> {
+  try {
+    const bytes = await readPrivateFile(markerPath);
+    const parsed = boundaryMarkerSchema.safeParse(JSON.parse(bytes.toString("utf8")));
+    if (
+      !parsed.success
+      || !bytes.equals(canonicalMarkerBytes(parsed.data))
+      || parsed.data.selfHash !== sha256(canonicalJson(withoutSelfHash(parsed.data)))
+    ) return null;
+    return parsed.data;
+  } catch (error) {
+    if (error instanceof Error) return null;
+    throw error;
+  }
+}
+
+async function readCompletion(markerPath: string): Promise<CompletionMarker | null> {
+  try {
+    const bytes = await readPrivateFile(markerPath);
+    const parsed = completionMarkerSchema.safeParse(JSON.parse(bytes.toString("utf8")));
+    if (
+      !parsed.success
+      || !bytes.equals(canonicalMarkerBytes(parsed.data))
+      || parsed.data.selfHash !== sha256(canonicalJson(withoutSelfHash(parsed.data)))
+    ) return null;
+    return parsed.data;
+  } catch (error) {
+    if (error instanceof Error) return null;
+    throw error;
+  }
+}
+
+function canonicalMarkerBytes(marker: BoundaryMarker | CompletionMarker): Buffer {
+  return Buffer.from(`${JSON.stringify(marker, null, 2)}\n`, "utf8");
+}
+
+function matchesBoundary(marker: BoundaryMarker, context: ConvergentRunContext, options: CreateRunConvergentOptions): boolean {
+  return marker.runId === options.runId
+    && marker.canonicalInputSha256 === options.canonicalInputSha256
+    && marker.processSnapshotHash === options.processSnapshotHash
+    && marker.processSnapshotPath === path.resolve(options.processSnapshotPath)
+    && marker.replacementSessionId === options.replacementSessionId
+    && marker.runJsonSha256 === context.runJsonSha256
+    && marker.runCreatedEventUlid === context.event.ulid
+    && marker.runCreatedEventSha256 === runCreatedEventSha256(context.event);
+}
+
+function matchesCompletion(marker: CompletionMarker, context: ConvergentRunContext, options: CreateRunConvergentOptions): boolean {
+  return marker.runId === options.runId
+    && marker.canonicalInputSha256 === options.canonicalInputSha256
+    && marker.process.snapshotHash === options.processSnapshotHash
+    && marker.process.snapshotPath === path.resolve(options.processSnapshotPath)
+    && marker.replacementSessionId === options.replacementSessionId
+    && marker.runJsonSha256 === context.runJsonSha256
+    && marker.runCreated.ulid === context.event.ulid
+    && marker.runCreated.eventSha256 === runCreatedEventSha256(context.event);
+}

--- a/packages/babysitter-sdk/src/runtime/createRun.ts
+++ b/packages/babysitter-sdk/src/runtime/createRun.ts
@@ -4,7 +4,7 @@ import { createRunDir } from "../storage/createRunDir";
 import { appendEvent } from "../storage/journal";
 import { acquireRunLock, releaseRunLock } from "../storage/lock";
 import { INPUTS_FILE, getRunDir } from "../storage/paths";
-import { RunEntrypointMetadata } from "../storage/types";
+import { RunEntrypointMetadata, type JournalEvent } from "../storage/types";
 import { nextUlid } from "../storage/ulids";
 import type { CreateRunOptions, CreateRunResult } from "./types";
 import { callRuntimeHook } from "./hooks/runtime";
@@ -14,6 +14,24 @@ import { resolveProjectRootForRun, resolveRunsDir } from "../config";
 import { hashProcessCodeFile } from "./processCodeHash";
 
 export async function createRun(options: CreateRunOptions): Promise<CreateRunResult> {
+  const result = await initializeRun(options);
+  let lockAcquired = false;
+  try {
+    await acquireRunLock(result.runDir, options.lockOwner ?? "runtime:createRun");
+    lockAcquired = true;
+    await appendRunCreatedEvent({ result, options });
+  } finally {
+    if (lockAcquired) {
+      await releaseRunLock(result.runDir);
+    }
+  }
+
+  await invokeRunStartHook({ result, options });
+
+  return result;
+}
+
+export async function initializeRun(options: CreateRunOptions): Promise<CreateRunResult> {
   const runId = options.runId ?? nextUlid();
   validateRunId(runId);
   const runsDir = path.resolve(options.runsDir ?? resolveRunsDir());
@@ -69,71 +87,77 @@ export async function createRun(options: CreateRunOptions): Promise<CreateRunRes
     outputSchema: options.outputSchema,
   });
 
-  let lockAcquired = false;
-  try {
-    await acquireRunLock(runDir, options.lockOwner ?? "runtime:createRun");
-    lockAcquired = true;
-    const eventPayload: Record<string, unknown> = {
-      runId,
-      processId: metadata.processId,
-      entrypoint: metadata.entrypoint,
-    };
-    if (metadata.harness) {
-      eventPayload.harness = metadata.harness;
-    }
-    if (metadata.nested) {
-      eventPayload.nested = metadata.nested;
-    }
-    if (metadata.processRevision) {
-      eventPayload.processRevision = metadata.processRevision;
-    }
-    if (metadata.processCodeHash) {
-      eventPayload.processCodeHash = metadata.processCodeHash;
-    }
-    if (options.inputs !== undefined) {
-      eventPayload.inputsRef = INPUTS_FILE;
-    }
-    if (options.prompt !== undefined) {
-      eventPayload.prompt = options.prompt;
-    }
-    await appendEvent({
-      runDir,
-      eventType: "RUN_CREATED",
-      event: eventPayload,
-    });
-  } finally {
-    if (lockAcquired) {
-      await releaseRunLock(runDir);
-    }
-  }
-
-  // Call on-run-start hook
-  const entryString = metadata.entrypoint.exportName
-    ? `${metadata.entrypoint.importPath}#${metadata.entrypoint.exportName}`
-    : metadata.entrypoint.importPath;
-
-  const projectRoot = resolveProjectRootForRun(runDir, metadata.entrypoint?.importPath);
-  if (!options.nested?.skipRunStartHook) {
-    await callRuntimeHook(
-      "on-run-start",
-      {
-        runId,
-        processId: metadata.processId,
-        entry: entryString,
-        inputs: options.inputs,
-      },
-      {
-        cwd: projectRoot,
-        logger: options.logger,
-      }
-    );
-  }
-
   return {
     runId,
     runDir,
     metadata,
   };
+}
+
+export type AppendRunCreatedEventArgs = {
+  readonly result: CreateRunResult;
+  readonly options: CreateRunOptions;
+  readonly sessionId?: string;
+};
+
+export async function appendRunCreatedEvent(args: AppendRunCreatedEventArgs): Promise<JournalEvent> {
+  const { result, options, sessionId } = args;
+  const eventPayload: Record<string, unknown> = {
+    runId: result.runId,
+    processId: result.metadata.processId,
+    entrypoint: result.metadata.entrypoint,
+  };
+  if (result.metadata.harness) eventPayload.harness = result.metadata.harness;
+  if (result.metadata.nested) eventPayload.nested = result.metadata.nested;
+  if (result.metadata.processRevision) eventPayload.processRevision = result.metadata.processRevision;
+  if (result.metadata.processCodeHash) eventPayload.processCodeHash = result.metadata.processCodeHash;
+  if (options.inputs !== undefined) eventPayload.inputsRef = INPUTS_FILE;
+  if (options.prompt !== undefined) eventPayload.prompt = options.prompt;
+  if (sessionId !== undefined) eventPayload.sessionId = sessionId;
+  const appended = await appendEvent({
+    runDir: result.runDir,
+    eventType: "RUN_CREATED",
+    event: eventPayload,
+  });
+  return {
+    ...appended,
+    data: eventPayload,
+    type: "RUN_CREATED",
+  };
+}
+
+export type InvokeRunStartHookArgs = {
+  readonly result: CreateRunResult;
+  readonly options: CreateRunOptions;
+};
+
+export async function invokeRunStartHook(args: InvokeRunStartHookArgs): Promise<Awaited<ReturnType<typeof callRuntimeHook>>> {
+  const { result, options } = args;
+  const entryString = result.metadata.entrypoint.exportName
+    ? `${result.metadata.entrypoint.importPath}#${result.metadata.entrypoint.exportName}`
+    : result.metadata.entrypoint.importPath;
+  const projectRoot = resolveProjectRootForRun(result.runDir, result.metadata.entrypoint.importPath);
+  if (options.nested?.skipRunStartHook) {
+    return {
+      hookType: "on-run-start",
+      success: true,
+      output: null,
+      executedHooks: [],
+    };
+  }
+  return await callRuntimeHook(
+    "on-run-start",
+    {
+      runId: result.runId,
+      processId: result.metadata.processId,
+      entry: entryString,
+      inputs: options.inputs,
+    },
+    {
+      cwd: projectRoot,
+      logger: options.logger,
+    },
+  );
 }
 
 function validateRunId(runId: string) {

--- a/packages/babysitter-sdk/src/runtime/createRunConvergent.ts
+++ b/packages/babysitter-sdk/src/runtime/createRunConvergent.ts
@@ -1,0 +1,226 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { appendRunCreatedEvent, initializeRun } from "./createRun";
+import { classifyConvergentRun, type ConvergentRunClassification } from "./convergentRun/classify";
+import {
+  sha256,
+  validateSha256,
+  type CreateRunConvergentOptions,
+  type CreateRunConvergentResult,
+} from "./convergentRun/contracts";
+import { ConvergentRunError } from "./convergentRun/errors";
+import { completionResult, invokeFromProvenBoundary, publishBoundaryAndInvoke, reopenRunCreatedContext } from "./convergentRun/execution";
+import { withRunLock } from "../storage/lock";
+import type { CreateRunOptions, CreateRunResult } from "./types";
+
+type PreparedRequest = {
+  readonly inputs: unknown;
+  readonly options: CreateRunConvergentOptions;
+};
+
+type LockedTransition = {
+  readonly classification: ConvergentRunClassification;
+  readonly request: PreparedRequest;
+};
+
+export { ConvergentRunError } from "./convergentRun/errors";
+
+export async function createRunConvergent(options: CreateRunConvergentOptions): Promise<CreateRunConvergentResult> {
+  const request = await prepareRequest(options);
+  const classification = await classifyConvergentRun(request.options);
+  switch (classification.kind) {
+    case "ABSENT":
+      return await createAbsentRun(request);
+    case "PRE_JOURNAL_EXACT":
+    case "JOURNALED_PRE_HOOK_PROVEN":
+      return await withRunLock(
+        path.join(request.options.runsDir, request.options.runId),
+        request.options.lockOwner ?? "runtime:createRunConvergent",
+        async () => await resolveLockedTransition({
+          classification: await classifyConvergentRun(request.options),
+          request,
+        }),
+      );
+    case "JOURNALED_HOOK_FINALIZATION_UNKNOWN":
+    case "CREATED_COMPLETE":
+    case "COMPLETION_MARKER_DIVERGED":
+    case "PARTIAL_UNKNOWN":
+      return resolveTerminalClassification(classification);
+    default:
+      return assertNever(classification);
+  }
+}
+
+async function prepareRequest(options: CreateRunConvergentOptions): Promise<PreparedRequest> {
+  requireNonEmpty(options.runId, "runId");
+  requireNonEmpty(options.request, "request");
+  requireNonEmpty(options.process.processId, "process.processId");
+  requireNonEmpty(options.replacementSessionId, "replacementSessionId");
+  validateSha256(options.canonicalInputSha256, "canonicalInputSha256");
+  validateSha256(options.processSnapshotHash, "processSnapshotHash");
+  if (options.expectedRunJsonSha256 !== undefined) validateSha256(options.expectedRunJsonSha256, "expectedRunJsonSha256");
+  const normalized = {
+    ...options,
+    inputsPath: path.resolve(options.inputsPath),
+    process: {
+      ...options.process,
+      importPath: path.resolve(options.process.importPath),
+    },
+    processSnapshotPath: path.resolve(options.processSnapshotPath),
+    runsDir: path.resolve(options.runsDir),
+  };
+  if (normalized.process.importPath !== normalized.processSnapshotPath) {
+    throw new ConvergentRunError("RUN_CREATE_PARTIAL_INVALID", "process.importPath must equal processSnapshotPath");
+  }
+  const inputBytes = await fs.readFile(normalized.inputsPath);
+  if (sha256(inputBytes) !== normalized.canonicalInputSha256) {
+    throw new ConvergentRunError("RUN_CREATE_PARTIAL_INVALID", "inputsPath does not match canonicalInputSha256");
+  }
+  const inputs = parseCanonicalInputs(inputBytes);
+  const processSnapshot = await fs.readFile(normalized.processSnapshotPath);
+  if (sha256(processSnapshot) !== normalized.processSnapshotHash) {
+    throw new ConvergentRunError("RUN_CREATE_PARTIAL_INVALID", "processSnapshotPath does not match processSnapshotHash");
+  }
+  return { inputs, options: normalized };
+}
+
+async function createAbsentRun(request: PreparedRequest): Promise<CreateRunConvergentResult> {
+  const runDir = path.join(request.options.runsDir, request.options.runId);
+  await fs.mkdir(request.options.runsDir, { recursive: true });
+  try {
+    await fs.mkdir(runDir);
+  } catch (error) {
+    if (isAlreadyExists(error)) return await createRunConvergent(request.options);
+    throw error;
+  }
+  const runOptions = toCreateRunOptions(request);
+  const result = await initializeRun(runOptions);
+  return await withRunLock(
+    result.runDir,
+    request.options.lockOwner ?? "runtime:createRunConvergent",
+    async () => {
+      const event = await appendRunCreatedEvent({
+        result,
+        options: runOptions,
+        sessionId: request.options.replacementSessionId,
+      });
+      return await publishBoundaryAndInvoke({
+        context: await reopenRunCreatedContext({ event, result }),
+        options: request.options,
+        runOptions,
+      });
+    },
+  );
+}
+
+async function resolveLockedTransition(transition: LockedTransition): Promise<CreateRunConvergentResult> {
+  const { classification, request } = transition;
+  switch (classification.kind) {
+    case "PRE_JOURNAL_EXACT":
+      if (request.options.expectedRunJsonSha256 === undefined) {
+        throw new ConvergentRunError("RUN_CREATE_RESUME_UNSUPPORTED", "expectedRunJsonSha256 is required to resume a pre-journal run");
+      }
+      return await resumePreJournalRun({ classification, request });
+    case "JOURNALED_PRE_HOOK_PROVEN":
+      return await invokeFromProvenBoundary({
+        context: classification.context,
+        options: request.options,
+        runOptions: toCreateRunOptions(request),
+      });
+    case "JOURNALED_HOOK_FINALIZATION_UNKNOWN":
+      throw new ConvergentRunError("RUN_CREATE_HOOK_FINALIZATION_UNKNOWN", "on-run-start may have started without a valid completion marker");
+    case "CREATED_COMPLETE":
+      return completionResult(classification.context, classification.completion);
+    case "COMPLETION_MARKER_DIVERGED":
+      throw new ConvergentRunError("RUN_CREATE_COMPLETION_MARKER_DIVERGED", "completion marker diverges from the convergent creation inputs");
+    case "PARTIAL_UNKNOWN":
+      throw new ConvergentRunError("RUN_CREATE_PARTIAL_INVALID", "run directory does not match a convergent creation state");
+    case "ABSENT":
+      return await createAbsentRun(request);
+    default:
+      return assertNever(classification);
+  }
+}
+
+function resolveTerminalClassification(
+  classification: Exclude<ConvergentRunClassification, { readonly kind: "ABSENT" | "PRE_JOURNAL_EXACT" | "JOURNALED_PRE_HOOK_PROVEN" }>,
+): CreateRunConvergentResult {
+  switch (classification.kind) {
+    case "JOURNALED_HOOK_FINALIZATION_UNKNOWN":
+      throw new ConvergentRunError("RUN_CREATE_HOOK_FINALIZATION_UNKNOWN", "on-run-start may have started without a valid completion marker");
+    case "CREATED_COMPLETE":
+      return completionResult(classification.context, classification.completion);
+    case "COMPLETION_MARKER_DIVERGED":
+      throw new ConvergentRunError("RUN_CREATE_COMPLETION_MARKER_DIVERGED", "completion marker diverges from the convergent creation inputs");
+    case "PARTIAL_UNKNOWN":
+      throw new ConvergentRunError("RUN_CREATE_PARTIAL_INVALID", "run directory does not match a convergent creation state");
+    default:
+      return assertNever(classification);
+  }
+}
+
+async function resumePreJournalRun(args: {
+  readonly classification: Extract<ConvergentRunClassification, { readonly kind: "PRE_JOURNAL_EXACT" }>;
+  readonly request: PreparedRequest;
+}): Promise<CreateRunConvergentResult> {
+  const { classification, request } = args;
+  const result: CreateRunResult = {
+    metadata: classification.metadata,
+    runDir: classification.runDir,
+    runId: request.options.runId,
+  };
+  const event = await appendRunCreatedEvent({
+    result,
+    options: toCreateRunOptions(request),
+    sessionId: request.options.replacementSessionId,
+  });
+  return await publishBoundaryAndInvoke({
+    context: await reopenRunCreatedContext({ event, result }),
+    options: request.options,
+    runOptions: toCreateRunOptions(request),
+  });
+}
+
+function toCreateRunOptions(request: PreparedRequest): CreateRunOptions {
+  return {
+    harness: request.options.harness,
+    inputs: request.inputs,
+    lockOwner: request.options.lockOwner,
+    logger: request.options.logger,
+    process: request.options.process,
+    processRevision: request.options.processRevision,
+    prompt: request.options.prompt,
+    request: request.options.request,
+    runId: request.options.runId,
+    runsDir: request.options.runsDir,
+  };
+}
+
+function parseCanonicalInputs(bytes: Buffer): unknown {
+  try {
+    const inputs: unknown = JSON.parse(bytes.toString("utf8"));
+    const canonicalBytes = Buffer.from(`${JSON.stringify(inputs, null, 2)}\n`, "utf8");
+    if (!bytes.equals(canonicalBytes)) {
+      throw new ConvergentRunError("RUN_CREATE_PARTIAL_INVALID", "inputsPath is not canonical JSON bytes");
+    }
+    return inputs;
+  } catch (error) {
+    if (error instanceof ConvergentRunError) throw error;
+    if (error instanceof SyntaxError) {
+      throw new ConvergentRunError("RUN_CREATE_PARTIAL_INVALID", "inputsPath must contain valid JSON");
+    }
+    throw error;
+  }
+}
+
+function requireNonEmpty(value: string, label: string): void {
+  if (value.trim() === "") throw new ConvergentRunError("RUN_CREATE_PARTIAL_INVALID", `${label} must be non-empty`);
+}
+
+function isAlreadyExists(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === "EEXIST";
+}
+
+function assertNever(value: never): never {
+  throw new ConvergentRunError("RUN_CREATE_PARTIAL_INVALID", `Unhandled convergent state: ${JSON.stringify(value)}`);
+}

--- a/packages/babysitter-sdk/src/runtime/index.ts
+++ b/packages/babysitter-sdk/src/runtime/index.ts
@@ -1,4 +1,6 @@
 export { createRun } from "./createRun";
+export { createRunConvergent, ConvergentRunError } from "./createRunConvergent";
+export type { CreateRunConvergentOptions, CreateRunConvergentResult } from "./convergentRun/contracts";
 export { orchestrateIteration } from "./orchestrateIteration";
 export { commitEffectResult, commitEffectCancellation } from "./commitEffectResult";
 export { createReplayEngine } from "./replay";


### PR DESCRIPTION
## Summary

Adds a public, versioned `run:create-convergent` capability (runtime API + CLI) that makes run creation safely resumable after interruption, implementing a fail-closed state machine with durable hook boundary markers.

### State machine

Interrupted creation is classified from public state only:

- `ABSENT` — no runDir; safe to create.
- `PRE_JOURNAL_EXACT` — runDir/metadata/inputs exist, zero events/tasks; resumed only under the public capability (never by re-running legacy `createRun`, which rewrites metadata and appends a duplicate `RUN_CREATED`).
- `JOURNALED_PRE_HOOK_PROVEN` — exactly one `RUN_CREATED`, durable proof the `on-run-start` hook was NOT yet invoked; resumable.
- `JOURNALED_HOOK_FINALIZATION_UNKNOWN` — hook may have started but no completion marker; terminally blocked (`RUN_CREATE_HOOK_FINALIZATION_UNKNOWN`), hook is NEVER rerun.
- `CREATED_COMPLETE` — valid completion marker; read-only convergence.
- `PARTIAL_UNKNOWN` — anything else; blocked (`RUN_CREATE_PARTIAL_INVALID`).

### Durable hook boundary

Before the dispatcher can run, the capability publishes a complete fsynced `hook-not-started.json` marker, then atomically renames it to `hook-may-have-started.json`; after the dispatcher returns, a bound, self-hashed `completion.json` is published create-once. Divergent existing markers return `RUN_CREATE_COMPLETION_MARKER_DIVERGED`. Success output is emitted only after completion-marker revalidation.

### Compatibility

- Legacy `createRun` behavior is unchanged; the capability is additive.
- No internal store formats are modified; markers live under the run's state directory.

### Testing

- `packages/babysitter-sdk/src/runtime/__tests__/createRunConvergent.test.ts` and `packages/babysitter-sdk/src/cli/__tests__/runCreateConvergent.test.ts`: state classification, kill-boundary/interruption cases, zero-hook-rerun proofs. 6/6 green.
- Package lint green.

### Pre-existing repo issues noted while validating (unrelated to this change)

1. Root `tsconfig.json` references `{ "path": "packages/adapters/adapters" }`, which does not exist in the repo and is produced by no build step — this breaks any root-config vitest collection (`tsconfck` ENOENT). The focused suites above were validated with a minimal out-of-tree vitest config. Suggest removing the stale reference in a separate cleanup.
2. `package-lock.json` is out of sync with `package.json` (missing rolldown/emnapi platform bindings), so `npm ci` fails at HEAD.
3. `packages/observer-dashboard` has a strict peer conflict (`lucide-react@0.344.0` peer wants react 16–18; repo resolves react 19), so fresh `npm install` requires `--legacy-peer-deps`.
4. 7 pre-existing environmental test failures and 2 MCP build errors exist at base commit `44a5d58b`, unrelated to this branch.
