### PR TITLE
fix: unblock the publish pipeline and release 6.0.3 (restores the observer dashboard on npm)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14262,7 +14262,6 @@
       "version": "10.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -14378,8 +14377,7 @@
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/aws-lambda": {
       "version": "8.10.161",
@@ -20313,8 +20311,7 @@
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-converter": {
       "version": "0.2.0",
@@ -26671,7 +26668,6 @@
       "version": "1.5.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -33040,7 +33036,6 @@
       "version": "27.5.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -33054,7 +33049,6 @@
       "version": "5.2.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -33610,8 +33604,7 @@
     "node_modules/react-is": {
       "version": "17.0.2",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-json-view-lite": {
       "version": "2.5.0",
@@ -46552,6 +46545,7 @@
       "devDependencies": {
         "@playwright/test": "^1.58.2",
         "@tailwindcss/postcss": "^4",
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.5.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "babysitter",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "babysitter",
-      "version": "6.0.2",
+      "version": "6.0.3",
       "license": "MIT",
       "workspaces": [
         "packages/genty/core",
@@ -46518,7 +46518,7 @@
     },
     "packages/observer-dashboard": {
       "name": "@a5c-ai/babysitter-observer-dashboard",
-      "version": "6.0.2",
+      "version": "6.0.3",
       "license": "MIT",
       "dependencies": {
         "@a5c-ai/babysitter-sdk": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babysitter",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "license": "MIT",
   "private": true,
   "workspaces": [

--- a/packages/observer-dashboard/package.json
+++ b/packages/observer-dashboard/package.json
@@ -90,6 +90,7 @@
   "devDependencies": {
     "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.5.2",

--- a/packages/observer-dashboard/package.json
+++ b/packages/observer-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a5c-ai/babysitter-observer-dashboard",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "description": "Real-time observability dashboard for babysitter orchestration runs",
   "private": false,
   "publishConfig": {


### PR DESCRIPTION
## Hotfix: restore the observer dashboard on npm (6.0.3)

**Merging this PR triggers a lockstep npm publish of ALL @a5c-ai/* packages at 6.0.3** — not a scoped observer release. `publish.yml` derives the publish version from the root `package.json` and `scripts/sync-workspace-versions.mjs` stamps it onto every workspace manifest before packing. That mechanism is why the root bump here is the load-bearing line.

### Why this is urgent
The last successful Publish run on main was **2026-07-03**. Since #1413 merged (2026-08-07), `Validate Observer And Compiler` fails on every main push, and `Prepare Publish` gates ALL `Publish Foundation` jobs on it — **no package in the monorepo can publish at all** until this lands. Every merge to main currently ships nothing, silently.

### What users see today
`npx @a5c-ai/babysitter-observer-dashboard@latest` (the `/babysitter:observe` path) serves **6.0.0**, an old "Compendium Edition" codebase that renders unusably. The dashboard merged in #1413 has never reached npm: the Publish run on the merge commit (run 31163538088) failed in `Validate Observer And Compiler` — `Cannot find module '@testing-library/dom'` — which silently skipped the entire publish chain.

### The two commits (atomic — do not cherry-pick apart)
1. **Declare `@testing-library/dom`** — the missing devDependency behind the CI failure. It resolves locally only via root hoisting, which CI's `npm ci` does not reproduce.
2. **Root + observer `6.0.2 → 6.0.3`** — 6.0.2 is burned: all 39 packages have different content under that number on npm since July 1. Critically, commit 1 alone would be dangerous: with root at 6.0.2, a green pipeline finds every version already published, skips publishing, and `dist-tag add`s `latest` onto the unvetted July-1 builds across the ecosystem.

### Verified
- 6.0.3 is free on npm for **all 39** published packages (`npm view <pkg>@6.0.3` → E404 for every one).
- 35 packages sit at `latest=6.0.0`; four (genty, kradle, hooks-adapter-antigravity, hooks-adapter-hermes) already drifted to `latest=6.0.2` — a successful 6.0.3 repairs that split.
- Observer package on this branch is byte-identical to main; gates on it: build/tsc exit 0, vitest 1297/1297, Playwright 175 passed / 0 failed against a production server, style parity vs the known-good standalone 0.14.2 (230/230 tokens, 42/42 computed styles, 0% pixel diff).
- Lockfile regenerated via npm (`--package-lock-only --workspaces --include-workspace-root`), never hand-edited: 7 peer-flag removals + 3 version lines.

### Recovery if the matrix partially fails
Publish matrices are `fail-fast: false` with exact-pinned internal deps. Re-running the workflow is safe: already-published packages hit the existing-version branch and no-op; the re-run completes the remainder.

### Post-merge checklist
- [ ] Publish run green end-to-end (previous failure mode: silent skip)
- [ ] `npm view @a5c-ai/babysitter-observer-dashboard dist-tags` shows `latest: 6.0.3`
- [ ] `npx -y @a5c-ai/babysitter-observer-dashboard@latest` renders the kanban dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)
