### PR TITLE
fix(codex): make Codex lifecycle hooks reliable across install surfaces

### DIFF
--- a/packages/adapters/extensions/src/__tests__/bundleRegression.test.ts
+++ b/packages/adapters/extensions/src/__tests__/bundleRegression.test.ts
@@ -60,7 +60,7 @@ describe('bundle regression coverage', () => {
     expect(codexResult.verificationChecklist).toEqual(expect.arrayContaining([
       expect.stringContaining('package.json bin target exists: bin/cli.js'),
       expect.stringContaining('package.json script target exists: scripts/team-install.js'),
-      expect.stringContaining('hooks.json command target exists: hooks/babysitter-proxied-stop.sh'),
+      expect.stringContaining('hooks.json command target exists: hooks/babysitter-codex-stop.sh'),
       expect.stringContaining('.agents/plugins/marketplace.json marketplace entry source exists'),
     ]));
     expect(ompResult.verificationChecklist).toEqual(expect.arrayContaining([

--- a/packages/adapters/extensions/src/__tests__/transform.test.ts
+++ b/packages/adapters/extensions/src/__tests__/transform.test.ts
@@ -64,13 +64,17 @@ describe('generateClaudeCodeHooksJson', () => {
 });
 
 describe('generateCodexHooksJson', () => {
-  it('should generate codex format with matcher and direct script path', () => {
+  it('should generate env-guarded commands referencing the codex entry shims', () => {
     const json = generateCodexHooksJson(MANIFEST, CODEX_PROFILE);
     const parsed = JSON.parse(json);
 
-    expect(parsed.hooks.SessionStart[0].matcher).toBe('.*');
+    // Codex ignores matchers on lifecycle events; none is emitted.
+    expect(parsed.hooks.SessionStart[0].matcher).toBeUndefined();
     const cmd = parsed.hooks.SessionStart[0].hooks[0].command;
-    expect(cmd).toContain('hooks/session-start.sh');
+    // Commands resolve through the plugin-root env Codex sets for
+    // plugin-sourced hooks, and no-op when neither variable is present.
+    expect(cmd).toContain('${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}');
+    expect(cmd).toContain('hooks/test-plugin-codex-session-start.sh');
     expect(cmd).not.toContain('ADAPTER_NAME');
   });
 });

--- a/packages/adapters/extensions/src/binTemplates.ts
+++ b/packages/adapters/extensions/src/binTemplates.ts
@@ -287,22 +287,36 @@ main();
 'use strict';
 
 const fs = require('fs');
+const path = require('path');
 const shared = require('./install-shared');
+
+const PACKAGE_ROOT = path.resolve(__dirname, '..');
 
 function main() {
   const pluginRoot = shared.getHomePluginRoot();
 
   if (!fs.existsSync(pluginRoot)) {
     console.log(\`[\${shared.PLUGIN_NAME}] Plugin not installed at \${pluginRoot}\`);
-    return;
+  } else {
+    try {
+      fs.rmSync(pluginRoot, { recursive: true, force: true });
+      console.log(\`[\${shared.PLUGIN_NAME}] Uninstalled from \${pluginRoot}\`);
+    } catch (err) {
+      console.error(\`[\${shared.PLUGIN_NAME}] Failed to uninstall: \${err.message}\`);
+      process.exitCode = 1;
+      return;
+    }
   }
 
-  try {
-    fs.rmSync(pluginRoot, { recursive: true, force: true });
-    console.log(\`[\${shared.PLUGIN_NAME}] Uninstalled from \${pluginRoot}\`);
-  } catch (err) {
-    console.error(\`[\${shared.PLUGIN_NAME}] Failed to uninstall: \${err.message}\`);
-    process.exitCode = 1;
+  // Harness-specific cleanup (managed hooks/skills surfaces, marketplace
+  // entries) provided by the plugin's install surface, when present.
+  if (typeof shared.harnessUninstall === 'function') {
+    try {
+      shared.harnessUninstall(PACKAGE_ROOT);
+    } catch (err) {
+      console.error(\`[\${shared.PLUGIN_NAME}] Failed to clean up harness state: \${err.message}\`);
+      process.exitCode = 1;
+    }
   }
 }
 

--- a/packages/adapters/extensions/src/targets/adapters/codex.ts
+++ b/packages/adapters/extensions/src/targets/adapters/codex.ts
@@ -1,12 +1,14 @@
 // Codex harness output adapter
 
+import * as fs from 'fs';
+import * as path from 'path';
 import type { A5cPluginManifest, TargetProfile, TransformedFile, Diagnostic } from '../../types.js';
 import { BaseHarnessOutputAdapter } from './base.js';
 import {
   iterateHooks,
   slugify,
-  resolveCmd,
   getPattern,
+  resolveHookPath,
   resolveSdkConfig,
 } from './hooks-utils.js';
 import {
@@ -45,13 +47,23 @@ export class CodexAdapter extends BaseHarnessOutputAdapter {
     rawManifest?: A5cPluginManifest
   ): TransformedFile[] {
     const files: TransformedFile[] = [];
-    const codexPkg = generateCodexManifest(manifest, this.targetName);
+    const hasVersionsJson = fs.existsSync(path.join(_sourceDir, 'versions.json'));
+    const codexPkg = generateCodexManifest(manifest, this.targetName, { hasVersionsJson });
     files.push({ path: 'package.json', content: codexPkg });
     if (targetProfile.harnessManifestPath) {
       files.push({ path: targetProfile.harnessManifestPath, content: generateHarnessManifest(rawManifest || manifest, targetProfile) });
     }
     files.push({ path: '.app.json', content: JSON.stringify({ apps: {} }, null, 2) + '\n' });
     return files;
+  }
+
+  generateExtraTargetFiles(
+    _sourceDir: string,
+    manifest: A5cPluginManifest,
+    targetProfile: TargetProfile,
+    _diagnostics: Diagnostic[]
+  ): TransformedFile[] {
+    return generateCodexHookRuntimeFiles(manifest, targetProfile);
   }
 }
 
@@ -117,11 +129,16 @@ function activeExtraFileOutputs(manifest: ResolvedManifest, targetName: string):
   return out;
 }
 
-export function generateCodexManifest(manifest: ResolvedManifest, targetName = 'codex'): string {
+export function generateCodexManifest(
+  manifest: ResolvedManifest,
+  targetName = 'codex',
+  options: { hasVersionsJson?: boolean } = {}
+): string {
   const target: Pick<TargetProfile, 'name'> = { name: targetName };
   const extraOutputs = activeExtraFileOutputs(manifest, targetName);
   const hasAssets = [...extraOutputs].some((p) => p === 'assets/' || p.startsWith('assets/'));
   const hasPluginLock = extraOutputs.has('plugin.lock.json');
+  const hasTests = [...extraOutputs].some((p) => p.startsWith('test/'));
   const packageJson: Record<string, unknown> = {
     name: resolveTargetNpmPackageName(manifest, target),
     version: manifest.version,
@@ -144,8 +161,11 @@ export function generateCodexManifest(manifest: ResolvedManifest, targetName = '
       ...(manifest.hooks && Object.keys(manifest.hooks).length > 0 ? ['hooks/', 'hooks.json'] : []),
       'skills/',
       '.app.json',
+      // versions.json carries the SDK version pin the hook runtime reads.
+      ...(options.hasVersionsJson ? ['versions.json'] : []),
       'bin/',
       'scripts/',
+      ...(hasTests ? ['test/'] : []),
       ...(hasPluginLock ? ['plugin.lock.json'] : []),
       'README.md',
     ],
@@ -163,19 +183,252 @@ export function generateCodexManifest(manifest: ResolvedManifest, targetName = '
   return JSON.stringify(packageJson, null, 2) + '\n';
 }
 
+function toNativeSlug(native: string): string {
+  return native.replace(/[._]/g, '-').replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
+}
+
+export function codexEntryShimName(pluginName: string, native: string): string {
+  return `${pluginName}-codex-${toNativeSlug(native)}.sh`;
+}
+
+export function codexHookLibName(pluginName: string): string {
+  return `${pluginName}-codex-hook-lib.sh`;
+}
+
+export function codexSurfaceMarkerName(pluginName: string): string {
+  return `.${pluginName}-managed-surface`;
+}
+
+/**
+ * Codex runs plugin-sourced hook commands through the user's shell with the
+ * session cwd, exporting CLAUDE_PLUGIN_ROOT / PLUGIN_ROOT for the bundle.
+ * Each command resolves the entry shim through that env and no-ops cleanly
+ * when neither variable is set, so a config copy evaluated outside a plugin
+ * context never fails with exit 127 on every event. Codex ignores `matcher`
+ * on lifecycle events and treats an absent matcher as match-all, so none is
+ * emitted.
+ */
 export function generateCodexHooksJson(
   manifest: A5cPluginManifest,
   targetProfile: TargetProfile
 ): string {
   const hooks: Record<string, unknown> = {};
-  const pat = getPattern(manifest, targetProfile.name);
   const sdk = resolveSdkConfig(manifest);
+  const pat = getPattern(manifest, targetProfile.name);
 
   iterateHooks(manifest, targetProfile, (canonical, native, handler) => {
-    const slug = slugify(canonical);
-    const cmd = resolveCmd(handler, slug, targetProfile.adapterName, '.codex', manifest.name, native, sdk.proxyPackage, sdk.proxyBinary, pat);
-    hooks[native] = [{ matcher: '.*', hooks: [{ type: 'command', command: cmd }] }];
+    const handlerPath = resolveHookPath(handler, slugify(canonical), manifest.name, native, pat);
+    let cmd: string;
+    if (handler === 'proxy') {
+      cmd = `${sdk.proxyBinary} invoke --adapter ${targetProfile.adapterName} --json`;
+    } else if (!handlerPath) {
+      cmd = `echo '{}'`;
+    } else {
+      const shim = codexEntryShimName(manifest.name, native);
+      cmd = `if [ -n "\${CLAUDE_PLUGIN_ROOT:-\${PLUGIN_ROOT:-}}" ]; then exec bash "\${CLAUDE_PLUGIN_ROOT:-$PLUGIN_ROOT}/hooks/${shim}"; fi`;
+    }
+    hooks[native] = [{ hooks: [{ type: 'command', command: cmd }] }];
   });
 
   return JSON.stringify({ hooks }, null, 2) + '\n';
+}
+
+/**
+ * The Codex hook runtime: one shared lib plus one entry shim per hook. The
+ * shim decides which installed copy of the plugin owns the event (workspace
+ * .codex surface > Codex home surface > plugin bundle) so events fire exactly
+ * once, extends PATH so the SDK CLIs resolve under a minimal hook
+ * environment, and pipes the Codex payload through the hooks adapter into the
+ * plugin's own handler script. All failure paths exit 0 so a broken or
+ * partial install never breaks the Codex session.
+ */
+export function generateCodexHookRuntimeFiles(
+  manifest: A5cPluginManifest,
+  targetProfile: TargetProfile
+): TransformedFile[] {
+  const files: TransformedFile[] = [];
+  if (!manifest.hooks || targetProfile.supportedHooks.size === 0) return files;
+
+  const pat = getPattern(manifest, targetProfile.name);
+  const libName = codexHookLibName(manifest.name);
+  let hasShims = false;
+
+  iterateHooks(manifest, targetProfile, (canonical, native, handler) => {
+    const handlerPath = resolveHookPath(handler, slugify(canonical), manifest.name, native, pat);
+    if (!handlerPath) return;
+    hasShims = true;
+    const handlerName = handlerPath.replace(/^hooks\//, '');
+    const ensureSdk = canonical === 'SessionStart' ? ' ensure-sdk' : '';
+    files.push({
+      path: `hooks/${codexEntryShimName(manifest.name, native)}`,
+      content: `#!/bin/bash
+# ${native} — Codex entry shim for hooks/${handlerName}.
+set -uo pipefail
+BSIT_SCRIPT_DIR="$(cd "$(dirname "\${BASH_SOURCE[0]}")" && pwd)"
+BSIT_SCRIPT_NAME="$(basename "\${BASH_SOURCE[0]}")"
+. "$BSIT_SCRIPT_DIR/${libName}"
+bsit_invoke "${handlerName}"${ensureSdk}
+`,
+      executable: true,
+    });
+  });
+
+  if (hasShims) {
+    files.push({
+      path: `hooks/${libName}`,
+      content: generateCodexHookLib(manifest, targetProfile),
+      executable: true,
+    });
+  }
+  return files;
+}
+
+function generateCodexHookLib(
+  manifest: A5cPluginManifest,
+  targetProfile: TargetProfile
+): string {
+  const sdk = resolveSdkConfig(manifest);
+  const marker = codexSurfaceMarkerName(manifest.name);
+  const stateDirName = sdk.stateDir.replace(/^\.?/, '.').replace(/^\.\./, '.');
+  return `#!/bin/bash
+# Shared Codex hook runtime for the ${manifest.name} plugin. Sourced by the
+# ${manifest.name}-codex-*.sh entry shims; not executed directly.
+# Generated by the extensions-adapter compiler.
+
+BSIT_MARKER="${marker}"
+
+# Codex may run hooks with a minimal PATH (GUI launch, scrubbed env). Append
+# the common npm/node global bin locations so the SDK CLIs resolve.
+bsit_extend_path() {
+  local dir
+  for dir in \\
+    "\${HOME:-}/.local/bin" \\
+    "\${HOME:-}/.npm-global/bin" \\
+    "\${HOME:-}/.volta/bin" \\
+    "\${NVM_BIN:-}" \\
+    "/opt/homebrew/bin" \\
+    "/usr/local/bin"; do
+    [ -n "$dir" ] && [ -d "$dir" ] || continue
+    case ":$PATH:" in
+      *":$dir:"*) ;;
+      *) PATH="$PATH:$dir" ;;
+    esac
+  done
+  export PATH
+}
+
+# Print the hooks dir of the surface that owns this event, if any. Precedence:
+# nearest workspace surface walking up from the session cwd, then the Codex
+# home surface (\${CODEX_HOME:-$HOME/.codex}). A surface only counts when both
+# its marker and this event's shim exist, so a stale marker or half-removed
+# install can never silently swallow events.
+bsit_owning_surface() {
+  local script_name="$1" d dir
+  d="$PWD"
+  while :; do
+    if [ -f "$d/.codex/hooks/$BSIT_MARKER" ] && [ -f "$d/.codex/hooks/$script_name" ]; then
+      printf '%s\\n' "$d/.codex/hooks"
+      return 0
+    fi
+    [ "$d" = "/" ] && break
+    d="$(dirname "$d")"
+  done
+  dir="\${CODEX_HOME:-\${HOME:-}/.codex}/hooks"
+  if [ -f "$dir/$BSIT_MARKER" ] && [ -f "$dir/$script_name" ]; then
+    printf '%s\\n' "$dir"
+    return 0
+  fi
+  return 1
+}
+
+# Decide whether this copy of the shim should handle the event. Exactly one
+# copy runs: the owning surface if one is live, otherwise the plugin bundle.
+bsit_should_run() {
+  local script_name="$1" owner
+  if owner="$(bsit_owning_surface "$script_name")"; then
+    [ "$BSIT_SCRIPT_DIR" -ef "$owner" ]
+    return
+  fi
+  # No live surface is visible: the plugin-bundle copy handles the event. A
+  # surface copy invoked outside its install-time environment (its config was
+  # loaded, so no other copy will fire) also proceeds.
+  return 0
+}
+
+bsit_sdk_version() {
+  local f
+  for f in "$BSIT_SCRIPT_DIR/../versions.json" "$BSIT_SCRIPT_DIR/versions.json"; do
+    if [ -f "$f" ]; then
+      node -e "try{console.log(JSON.parse(require('fs').readFileSync(process.argv[1],'utf8')).sdkVersion||'latest')}catch{console.log('latest')}" "$f" 2>/dev/null && return 0
+    fi
+  done
+  echo latest
+}
+
+# Install the pinned SDK when missing. Attempts are stamped and retried at
+# most every 6 hours so an offline/unwritable machine does not pay two npm
+# registry timeouts on every session start.
+bsit_ensure_sdk() {
+  command -v ${sdk.cli} >/dev/null 2>&1 && return 0
+
+  local stamp_dir="\${HOME:-/tmp}/${stateDirName}" stamp now last
+  stamp="$stamp_dir/.codex-sdk-install-attempt"
+  now="$(date +%s 2>/dev/null || echo 0)"
+  last="$(cat "$stamp" 2>/dev/null || echo 0)"
+  case "$last" in *[!0-9]*) last=0 ;; esac
+  [ $((now - last)) -lt 21600 ] && return 1
+  mkdir -p "$stamp_dir" 2>/dev/null && printf '%s' "$now" > "$stamp" 2>/dev/null
+
+  local version
+  version="$(bsit_sdk_version)"
+  npm i -g "${sdk.package}@\${version}" --loglevel=error >/dev/null 2>&1 || \\
+    npm i -g "${sdk.package}@\${version}" --prefix "\${HOME:-}/.local" --loglevel=error >/dev/null 2>&1 || true
+  [ -d "\${HOME:-}/.local/bin" ] && export PATH="\${HOME:-}/.local/bin:$PATH"
+  command -v ${sdk.cli} >/dev/null 2>&1
+}
+
+# Resolve the ${sdk.proxyBinary} bin: PATH first, then next to the ${sdk.cli}
+# bin (${sdk.package} ships both bins from the same package).
+bsit_resolve_proxy() {
+  if command -v ${sdk.proxyBinary} >/dev/null 2>&1; then
+    command -v ${sdk.proxyBinary}
+    return 0
+  fi
+  local cli_bin sibling
+  cli_bin="$(command -v ${sdk.cli} 2>/dev/null)" || return 1
+  sibling="$(dirname "$cli_bin")/${sdk.proxyBinary}"
+  if [ -x "$sibling" ]; then
+    echo "$sibling"
+    return 0
+  fi
+  return 1
+}
+
+# bsit_invoke <handler-script-filename> [ensure-sdk]
+# Pipes the Codex hook payload (stdin) through the ${targetProfile.adapterName} hooks adapter
+# into the plugin's handler script. Exits 0 without output when another copy
+# owns the event or the SDK is unavailable, so a partial install never breaks
+# the session.
+bsit_invoke() {
+  local handler_name="$1" ensure_sdk="\${2:-}"
+
+  bsit_should_run "$BSIT_SCRIPT_NAME" || exit 0
+
+  bsit_extend_path
+
+  if [ -n "$ensure_sdk" ]; then
+    bsit_ensure_sdk || true
+  fi
+
+  local proxy_bin
+  if ! proxy_bin="$(bsit_resolve_proxy)"; then
+    echo "[${manifest.name}] $BSIT_SCRIPT_NAME skipped: ${sdk.cli}/${sdk.proxyBinary} CLI not found on PATH. Install with: npm install -g ${sdk.package}" >&2
+    exit 0
+  fi
+
+  exec "$proxy_bin" invoke --adapter ${targetProfile.adapterName} \\
+    --handler "bash \\"$BSIT_SCRIPT_DIR/$handler_name\\"" \\
+    --json
+}
+`;
 }

--- a/plugins/babysitter-unified/per-harness/codex/bin/install-surface.js
+++ b/plugins/babysitter-unified/per-harness/codex/bin/install-surface.js
@@ -41,11 +41,14 @@ const LEGACY_HOOK_SCRIPT_NAMES = [
   'babysitter-stop-hook.sh',
   'user-prompt-submit.sh',
 ];
-const MANAGED_HOOK_SCRIPT_NAMES = [
-  'babysitter-proxied-session-start.sh',
-  'babysitter-proxied-stop.sh',
-  'babysitter-proxied-user-prompt-submit.sh',
-];
+// Prefixes identifying files/commands the managed .codex surface owns:
+// babysitter-codex-* are the compiler-generated entry shims + runtime lib,
+// babysitter-proxied-* are the handler scripts (and the command format used
+// by older releases, which the idempotent merge must also replace).
+const MANAGED_HOOK_FILE_PREFIXES = ['babysitter-codex-', 'babysitter-proxied-'];
+// Marker consumed by the hook runtime lib: when a managed .codex surface is
+// installed, exactly one copy (the owning surface) handles each event.
+const MANAGED_SURFACE_MARKER = '.babysitter-managed-surface';
 const DEFAULT_MARKETPLACE = {
   name: 'local-plugins',
   interface: {
@@ -61,6 +64,7 @@ const PLUGIN_BUNDLE_ENTRIES = [
   'skills',
   '.app.json',
   'plugin.lock.json',
+  'versions.json',
   'README.md',
 ];
 
@@ -141,7 +145,9 @@ function copyPluginBundle(packageRoot, pluginRoot) {
   fs.rmSync(pluginRoot, { recursive: true, force: true });
   fs.mkdirSync(pluginRoot, { recursive: true });
   for (const entry of PLUGIN_BUNDLE_ENTRIES) {
-    copyRecursive(path.join(packageRoot, entry), path.join(pluginRoot, entry));
+    const src = path.join(packageRoot, entry);
+    if (!fs.existsSync(src)) continue;
+    copyRecursive(src, path.join(pluginRoot, entry));
   }
 }
 
@@ -386,7 +392,7 @@ function removeMarketplaceEntry(marketplacePath) {
     return;
   }
   const marketplace = readJson(marketplacePath);
-  if (!Array.isArray(marketplace.plugins)) {
+  if (!marketplace || !Array.isArray(marketplace.plugins)) {
     return;
   }
   marketplace.plugins = marketplace.plugins.filter((entry) => (
@@ -397,53 +403,58 @@ function removeMarketplaceEntry(marketplacePath) {
   writeJson(marketplacePath, marketplace);
 }
 
+function isManagedOrLegacyHook(hook) {
+  const command = String((hook && hook.command) || '');
+  return MANAGED_HOOK_FILE_PREFIXES.some((prefix) => command.includes(prefix)) ||
+    LEGACY_HOOK_SCRIPT_NAMES.some((name) => command.includes(name));
+}
+
+// Removes our hook entries from a matcher-group list. Entries with a shape we
+// do not recognize are not ours and pass through untouched.
+function stripManagedHooks(matchers) {
+  return (Array.isArray(matchers) ? matchers : [])
+    .map((matcher) => {
+      if (!matcher || typeof matcher !== 'object' || !Array.isArray(matcher.hooks)) {
+        return matcher;
+      }
+      const keptHooks = matcher.hooks.filter((hook) => !isManagedOrLegacyHook(hook));
+      return keptHooks.length > 0 ? { ...matcher, hooks: keptHooks } : null;
+    })
+    .filter(Boolean);
+}
+
+// Deletion guard for legacy skill/prompt names: only remove an artifact when
+// its content identifies it as ours, so a user's unrelated ~/.codex/skills/plan
+// or prompts/plan.md never gets purged just for sharing a generic name.
+function looksLikeBabysitterArtifact(artifactPath) {
+  try {
+    const stat = fs.statSync(artifactPath);
+    const probe = stat.isDirectory() ? path.join(artifactPath, 'SKILL.md') : artifactPath;
+    return /babysitter|a5c/i.test(fs.readFileSync(probe, 'utf8'));
+  } catch {
+    return false;
+  }
+}
+
 function removeLegacyCodexSurface(codexHome) {
   for (const skillName of LEGACY_SKILL_NAMES) {
-    fs.rmSync(path.join(codexHome, 'skills', skillName), { recursive: true, force: true });
+    const skillPath = path.join(codexHome, 'skills', skillName);
+    if (looksLikeBabysitterArtifact(skillPath)) {
+      fs.rmSync(skillPath, { recursive: true, force: true });
+    }
   }
   for (const promptName of LEGACY_PROMPT_NAMES) {
-    fs.rmSync(path.join(codexHome, 'prompts', promptName), { force: true });
+    const promptPath = path.join(codexHome, 'prompts', promptName);
+    if (looksLikeBabysitterArtifact(promptPath)) {
+      fs.rmSync(promptPath, { force: true });
+    }
   }
   for (const hookName of LEGACY_HOOK_SCRIPT_NAMES) {
     fs.rmSync(path.join(codexHome, 'hooks', hookName), { force: true });
   }
-
-  const hooksConfigPath = path.join(codexHome, 'hooks.json');
-  if (!fs.existsSync(hooksConfigPath)) {
-    return;
-  }
-  let hooksConfig;
-  try {
-    hooksConfig = readJson(hooksConfigPath);
-  } catch {
-    return;
-  }
-  if (!hooksConfig.hooks || typeof hooksConfig.hooks !== 'object') {
-    return;
-  }
-  for (const eventName of ['SessionStart', 'UserPromptSubmit', 'Stop']) {
-    const eventHooks = Array.isArray(hooksConfig.hooks[eventName]) ? hooksConfig.hooks[eventName] : [];
-    const filteredMatchers = eventHooks
-      .map((matcher) => {
-        const hooks = Array.isArray(matcher.hooks) ? matcher.hooks : [];
-        const keptHooks = hooks.filter((hook) => {
-          const command = String(hook.command || '');
-          return !LEGACY_HOOK_SCRIPT_NAMES.some((name) => command.includes(name));
-        });
-        return keptHooks.length > 0 ? { ...matcher, hooks: keptHooks } : null;
-      })
-      .filter(Boolean);
-    if (filteredMatchers.length > 0) {
-      hooksConfig.hooks[eventName] = filteredMatchers;
-    } else {
-      delete hooksConfig.hooks[eventName];
-    }
-  }
-  if (Object.keys(hooksConfig.hooks).length === 0) {
-    fs.rmSync(hooksConfigPath, { force: true });
-  } else {
-    writeJson(hooksConfigPath, hooksConfig);
-  }
+  // Legacy hooks.json entries are cleaned by mergeManagedHooksConfig
+  // (isManagedOrLegacyHook covers LEGACY_HOOK_SCRIPT_NAMES) in a single
+  // read-modify-write, so no separate pass happens here.
 }
 
 function installManagedSkills(packageRoot, codexHome) {
@@ -460,32 +471,66 @@ function installManagedSkills(packageRoot, codexHome) {
   }
 }
 
-function mergeManagedHooksConfig(packageRoot, codexHome) {
-  const managedHooks = readJson(path.join(packageRoot, 'hooks.json')).hooks || {};
+// Rewrites a managed hook command so a surface install references its own
+// entry-shim copy (the shipped command targets the plugin bundle via
+// ${CLAUDE_PLUGIN_ROOT}, which Codex only sets for plugin-sourced hooks).
+// Throws rather than writing a broken command into the user's hooks.json.
+function rewriteManagedHookCommand(command, hooksDir) {
+  const match = String(command || '').match(/babysitter-codex-[A-Za-z0-9_-]+\.sh/);
+  if (!match) {
+    throw new Error(`Managed hook command references no babysitter-codex-*.sh entry shim: ${command}`);
+  }
+  const normalizedDir = String(hooksDir).replace(/\\/g, '/');
+  if (/["$`\\]/.test(normalizedDir)) {
+    throw new Error(`Hooks directory contains characters unsafe for a shell command: ${normalizedDir}`);
+  }
+  return `bash "${normalizedDir}/${match[0]}"`;
+}
+
+// Merges the managed hook entries from hooks.json into <codexHome>/hooks.json.
+// Idempotent: previously installed managed/legacy entries are replaced, user
+// entries — including event values with shapes we don't recognize — are
+// preserved, as are unrelated top-level keys of the document.
+function mergeManagedHooksConfig(packageRoot, codexHome, hooksDir) {
+  const managedHooks = (readJson(path.join(packageRoot, 'hooks.json')) || {}).hooks || {};
   const hooksConfigPath = path.join(codexHome, 'hooks.json');
-  const existing = fs.existsSync(hooksConfigPath)
-    ? readJson(hooksConfigPath)
-    : { hooks: {} };
+  const existing = readJson(hooksConfigPath) || { hooks: {} };
   if (!existing.hooks || typeof existing.hooks !== 'object') {
     existing.hooks = {};
   }
 
-  for (const [eventName, matchers] of Object.entries(managedHooks)) {
-    const existingMatchers = Array.isArray(existing.hooks[eventName]) ? existing.hooks[eventName] : [];
-    const filteredMatchers = existingMatchers
-      .map((matcher) => {
-        const hooks = Array.isArray(matcher.hooks) ? matcher.hooks : [];
-        const keptHooks = hooks.filter((hook) => {
-          const command = String(hook.command || '');
-          return !LEGACY_HOOK_SCRIPT_NAMES.some((name) => command.includes(name));
-        });
-        return keptHooks.length > 0 ? { ...matcher, hooks: keptHooks } : null;
-      })
-      .filter(Boolean);
-    existing.hooks[eventName] = [...filteredMatchers, ...matchers];
+  const eventNames = new Set([
+    ...Object.keys(existing.hooks),
+    ...Object.keys(managedHooks),
+  ]);
+  for (const eventName of eventNames) {
+    const existingValue = existing.hooks[eventName];
+    if (existingValue !== undefined && !Array.isArray(existingValue)) {
+      continue;
+    }
+    const keptMatchers = stripManagedHooks(existingValue || []);
+    const managedMatchers = (managedHooks[eventName] || []).map((matcher) => ({
+      ...matcher,
+      hooks: (Array.isArray(matcher.hooks) ? matcher.hooks : []).map((hook) => (
+        hook && hook.command
+          ? { ...hook, command: rewriteManagedHookCommand(hook.command, hooksDir) }
+          : hook
+      )),
+    }));
+    const nextMatchers = [...keptMatchers, ...managedMatchers];
+    if (nextMatchers.length > 0) {
+      existing.hooks[eventName] = nextMatchers;
+    } else if (existingValue !== undefined) {
+      delete existing.hooks[eventName];
+    }
   }
 
   writeJson(hooksConfigPath, existing);
+}
+
+function isManagedHookFileName(fileName) {
+  return MANAGED_HOOK_FILE_PREFIXES.some((prefix) => fileName.startsWith(prefix)) ||
+    fileName === 'versions.json';
 }
 
 function installManagedHooks(packageRoot, codexHome) {
@@ -493,14 +538,86 @@ function installManagedHooks(packageRoot, codexHome) {
   const targetRoot = path.join(codexHome, 'hooks');
   fs.mkdirSync(targetRoot, { recursive: true });
 
-  for (const scriptName of MANAGED_HOOK_SCRIPT_NAMES) {
-    const sourcePath = path.join(sourceRoot, scriptName);
-    const targetPath = path.join(targetRoot, scriptName);
-    copyRecursive(sourcePath, targetPath);
-    ensureExecutable(targetPath);
+  // Copy everything the bundle ships under hooks/ (entry shims, the runtime
+  // lib, and the handler scripts the shims delegate to) so the surface can
+  // never reference a script that was not installed.
+  const copied = [];
+  for (const entry of fs.readdirSync(sourceRoot, { withFileTypes: true })) {
+    if (!entry.isFile()) continue;
+    const targetPath = path.join(targetRoot, entry.name);
+    fs.copyFileSync(path.join(sourceRoot, entry.name), targetPath);
+    if (entry.name.endsWith('.sh')) ensureExecutable(targetPath);
+    copied.push(entry.name);
   }
 
-  mergeManagedHooksConfig(packageRoot, codexHome);
+  // The hook runtime reads the pinned SDK version from versions.json next to
+  // the scripts when a surface copy runs outside the plugin bundle.
+  const versionsSource = path.join(packageRoot, 'versions.json');
+  if (fs.existsSync(versionsSource)) {
+    fs.copyFileSync(versionsSource, path.join(targetRoot, 'versions.json'));
+    copied.push('versions.json');
+  }
+  writeJson(path.join(targetRoot, MANAGED_SURFACE_MARKER), {
+    installedBy: '@a5c-ai/babysitter-codex',
+    files: copied,
+  });
+
+  // Commands are absolute: <codexHome>/hooks.json is evaluated against the
+  // Codex session cwd, which may be anywhere (including a workspace subdir).
+  // These files are machine-local — teammates rerun the installer.
+  mergeManagedHooksConfig(packageRoot, codexHome, targetRoot);
+}
+
+function removeManagedCodexSurface(codexHome, packageRoot) {
+  const targetRoot = path.join(codexHome, 'hooks');
+  const markerPath = path.join(targetRoot, MANAGED_SURFACE_MARKER);
+  const marker = readJson(markerPath);
+  // Marker first: if a later removal fails partway, the plugin-bundle hook
+  // copies stop deferring to this surface and events keep firing.
+  fs.rmSync(markerPath, { force: true });
+
+  const installedFiles = marker && Array.isArray(marker.files) ? marker.files : [];
+  const candidates = new Set(installedFiles.map((name) => path.basename(String(name))));
+  if (fs.existsSync(targetRoot)) {
+    for (const entry of fs.readdirSync(targetRoot)) {
+      if (isManagedHookFileName(entry)) candidates.add(entry);
+    }
+  }
+  for (const name of candidates) {
+    fs.rmSync(path.join(targetRoot, name), { force: true });
+  }
+
+  if (packageRoot) {
+    const skillsRoot = path.join(packageRoot, 'skills');
+    if (fs.existsSync(skillsRoot)) {
+      for (const entry of fs.readdirSync(skillsRoot, { withFileTypes: true })) {
+        if (!entry.isDirectory()) continue;
+        const installedSkill = path.join(codexHome, 'skills', entry.name);
+        if (looksLikeBabysitterArtifact(installedSkill)) {
+          fs.rmSync(installedSkill, { recursive: true, force: true });
+        }
+      }
+    }
+  }
+
+  const hooksConfigPath = path.join(codexHome, 'hooks.json');
+  const hooksConfig = readJson(hooksConfigPath);
+  if (!hooksConfig || !hooksConfig.hooks || typeof hooksConfig.hooks !== 'object') {
+    return;
+  }
+  for (const eventName of Object.keys(hooksConfig.hooks)) {
+    const existingValue = hooksConfig.hooks[eventName];
+    if (!Array.isArray(existingValue)) continue;
+    const keptMatchers = stripManagedHooks(existingValue);
+    if (keptMatchers.length > 0) {
+      hooksConfig.hooks[eventName] = keptMatchers;
+    } else {
+      delete hooksConfig.hooks[eventName];
+    }
+  }
+  // Write the document back even when hooks is empty: deleting the file would
+  // discard unrelated top-level keys the user (or Codex) may keep in it.
+  writeJson(hooksConfigPath, hooksConfig);
 }
 
 function installCodexSurface(packageRoot, codexHome) {
@@ -543,10 +660,20 @@ function harnessTeamInstall(packageRoot, pluginRoot, workspace) {
 }
 
 function harnessInstall(packageRoot, _pluginRoot) {
-  const codexConfigPath = path.join(getCodexHome(), 'config.toml');
+  const codexHome = getCodexHome();
+  const codexConfigPath = path.join(codexHome, 'config.toml');
   mergeCodexConfigFile(codexConfigPath);
+  // Global surface: install hooks into the Codex home so they fire even when
+  // the plugin bundle is only registered (not added) in the marketplace.
+  installCodexSurface(packageRoot, codexHome);
   ensureGlobalProcessLibrary(packageRoot);
   warnWindowsHooks();
+}
+
+function harnessUninstall(packageRoot) {
+  removeMarketplaceEntry(getHomeMarketplacePath());
+  removeManagedCodexSurface(getCodexHome(), packageRoot);
+  console.log('[' + PLUGIN_NAME + '] Removed managed Codex hooks and skills.');
 }
 
 function warnWindowsHooks() {

--- a/plugins/babysitter-unified/per-harness/codex/test/integration.test.js
+++ b/plugins/babysitter-unified/per-harness/codex/test/integration.test.js
@@ -1,0 +1,365 @@
+'use strict';
+
+// Self-tests for the compiled Codex bundle: hooks.json <-> hook runtime
+// consistency, managed-surface install/remove semantics, and exactly-once
+// event delivery across plugin-bundle / global / workspace copies.
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync, execFileSync } = require('child_process');
+
+const PACKAGE_ROOT = path.resolve(__dirname, '..');
+const shared = require('../bin/install-shared');
+
+const STOP_SHIM = 'babysitter-codex-stop.sh';
+const STOP_HANDLER = 'babysitter-proxied-stop.sh';
+const HOOK_LIB = 'babysitter-codex-hook-lib.sh';
+
+let passed = 0;
+function test(name, fn) {
+  fn();
+  passed += 1;
+  console.log(`ok - ${name}`);
+}
+
+function tmpdir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function readHooksConfig(codexHome) {
+  return JSON.parse(fs.readFileSync(path.join(codexHome, 'hooks.json'), 'utf8'));
+}
+
+function handlerCommands(hooksConfig) {
+  const commands = [];
+  for (const matchers of Object.values(hooksConfig.hooks || {})) {
+    if (!Array.isArray(matchers)) continue;
+    for (const matcher of matchers) {
+      for (const hook of matcher.hooks || []) {
+        commands.push(String(hook.command || ''));
+      }
+    }
+  }
+  return commands;
+}
+
+// Writes stub adapters-hooks/babysitter binaries; the adapters-hooks stub
+// records its argv and stdin so tests can assert the shim wiring.
+function writeStubBins(binDir, argsFile, stdinFile) {
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(binDir, 'adapters-hooks'),
+    `#!/bin/bash\nprintf '%s\\n' "$@" > "${argsFile}"\n${stdinFile ? `cat > "${stdinFile}"\n` : 'cat > /dev/null\n'}echo '{}'\n`,
+  );
+  fs.writeFileSync(path.join(binDir, 'babysitter'), '#!/bin/bash\nexit 0\n');
+  fs.chmodSync(path.join(binDir, 'adapters-hooks'), 0o755);
+  fs.chmodSync(path.join(binDir, 'babysitter'), 0o755);
+}
+
+// Copies the stop shim, runtime lib, and handler (and marker) into a
+// directory, emulating an installed surface.
+function writeSurfaceCopy(hooksDir, withMarker = true) {
+  fs.mkdirSync(hooksDir, { recursive: true });
+  for (const name of [HOOK_LIB, STOP_SHIM, STOP_HANDLER]) {
+    fs.copyFileSync(path.join(PACKAGE_ROOT, 'hooks', name), path.join(hooksDir, name));
+    fs.chmodSync(path.join(hooksDir, name), 0o755);
+  }
+  if (withMarker) {
+    fs.writeFileSync(path.join(hooksDir, shared.MANAGED_SURFACE_MARKER), '{}');
+  }
+}
+
+function runHook(scriptPath, { cwd, home, binDir, codexHome }) {
+  const env = { ...process.env, HOME: home, PATH: `${binDir}:${process.env.PATH}` };
+  if (codexHome) env.CODEX_HOME = codexHome;
+  else delete env.CODEX_HOME;
+  return spawnSync('bash', [scriptPath], { cwd, env, input: '{}', encoding: 'utf8' });
+}
+
+const EXPECTED_EVENTS = [
+  'SessionStart',
+  'SessionEnd',
+  'PreToolUse',
+  'PostToolUse',
+  'UserPromptSubmit',
+  'Stop',
+];
+
+test('hooks.json references entry shims that exist, next to their handlers and lib', () => {
+  const hooksConfig = JSON.parse(fs.readFileSync(path.join(PACKAGE_ROOT, 'hooks.json'), 'utf8'));
+  assert.deepStrictEqual(
+    Object.keys(hooksConfig.hooks).sort(),
+    [...EXPECTED_EVENTS].sort(),
+    'hooks.json events mismatch',
+  );
+  assert.ok(fs.existsSync(path.join(PACKAGE_ROOT, 'hooks', HOOK_LIB)), `missing hooks/${HOOK_LIB}`);
+  for (const command of handlerCommands(hooksConfig)) {
+    const match = command.match(/babysitter-codex-[A-Za-z0-9_-]+\.sh/);
+    assert.ok(match, `no entry shim referenced in: ${command}`);
+    const shimName = match[0];
+    assert.ok(
+      fs.existsSync(path.join(PACKAGE_ROOT, 'hooks', shimName)),
+      `missing hooks/${shimName}`,
+    );
+    // Each shim delegates to a handler that must ship next to it.
+    const shim = fs.readFileSync(path.join(PACKAGE_ROOT, 'hooks', shimName), 'utf8');
+    const handlerMatch = shim.match(/bsit_invoke "([^"]+)"/);
+    assert.ok(handlerMatch, `shim ${shimName} has no bsit_invoke call`);
+    assert.ok(
+      fs.existsSync(path.join(PACKAGE_ROOT, 'hooks', handlerMatch[1])),
+      `shim ${shimName} references missing handler hooks/${handlerMatch[1]}`,
+    );
+    assert.ok(
+      command.includes('${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}'),
+      `command must guard on the plugin-root env Codex sets: ${command}`,
+    );
+  }
+});
+
+test('every hook script passes bash -n', () => {
+  if (process.platform === 'win32') return;
+  for (const entry of fs.readdirSync(path.join(PACKAGE_ROOT, 'hooks'))) {
+    if (!entry.endsWith('.sh')) continue;
+    const result = spawnSync('bash', ['-n', path.join(PACKAGE_ROOT, 'hooks', entry)], { encoding: 'utf8' });
+    assert.strictEqual(result.status, 0, `bash -n failed for ${entry}: ${result.stderr}`);
+  }
+});
+
+test('installCodexSurface installs all hook files, marker, and absolute commands', () => {
+  const codexHome = tmpdir('bsit-codex-home-');
+  shared.installCodexSurface(PACKAGE_ROOT, codexHome);
+
+  for (const entry of fs.readdirSync(path.join(PACKAGE_ROOT, 'hooks'))) {
+    assert.ok(fs.existsSync(path.join(codexHome, 'hooks', entry)), `missing ${entry}`);
+  }
+  const markerPath = path.join(codexHome, 'hooks', shared.MANAGED_SURFACE_MARKER);
+  assert.ok(fs.existsSync(markerPath), 'missing surface marker');
+  const marker = JSON.parse(fs.readFileSync(markerPath, 'utf8'));
+  assert.ok(Array.isArray(marker.files) && marker.files.includes(STOP_SHIM), 'marker missing files list');
+  assert.ok(fs.existsSync(path.join(codexHome, 'hooks', 'versions.json')), 'missing versions.json copy');
+
+  const hooksConfig = readHooksConfig(codexHome);
+  assert.deepStrictEqual(Object.keys(hooksConfig.hooks).sort(), [...EXPECTED_EVENTS].sort());
+  const hookDir = path.join(codexHome, 'hooks').replace(/\\/g, '/');
+  for (const command of handlerCommands(hooksConfig)) {
+    assert.ok(!command.includes('CLAUDE_PLUGIN_ROOT'), `surface command not rewritten: ${command}`);
+    assert.ok(command.startsWith(`bash "${hookDir}/`), `surface command not absolute: ${command}`);
+  }
+});
+
+test('installCodexSurface is idempotent and preserves user hooks and unknown shapes', () => {
+  const codexHome = tmpdir('bsit-codex-home-');
+  fs.mkdirSync(codexHome, { recursive: true });
+  fs.writeFileSync(
+    path.join(codexHome, 'hooks.json'),
+    JSON.stringify({
+      $schema: 'https://example.com/hooks.schema.json',
+      hooks: {
+        PreToolUse: [{ matcher: '.*', hooks: [{ type: 'command', command: 'echo user-hook' }] }],
+        // Old-format managed entry from a previous release must be replaced.
+        Stop: [{ hooks: [{ type: 'command', command: 'adapters-hooks invoke --adapter codex --handler "bash .codex/hooks/babysitter-proxied-stop.sh" --json' }] }],
+        Notification: { enabled: true },
+      },
+    }, null, 2),
+  );
+
+  shared.installCodexSurface(PACKAGE_ROOT, codexHome);
+  shared.installCodexSurface(PACKAGE_ROOT, codexHome);
+
+  const hooksConfig = readHooksConfig(codexHome);
+  const commands = handlerCommands(hooksConfig);
+  assert.strictEqual(
+    commands.filter((c) => c.includes('babysitter-codex-pre-tool-use.sh')).length,
+    1,
+    'managed PreToolUse hook duplicated after reinstall',
+  );
+  assert.strictEqual(
+    commands.filter((c) => c.includes('babysitter-proxied-stop.sh')).length,
+    0,
+    'old-format managed Stop entry not replaced',
+  );
+  assert.strictEqual(
+    commands.filter((c) => c.includes('babysitter-codex-stop.sh')).length,
+    1,
+    'managed Stop hook missing or duplicated',
+  );
+  assert.strictEqual(commands.filter((c) => c === 'echo user-hook').length, 1, 'user hook lost');
+  assert.deepStrictEqual(hooksConfig.hooks.Notification, { enabled: true }, 'unknown-shaped event mutated');
+  assert.strictEqual(hooksConfig.$schema, 'https://example.com/hooks.schema.json', 'top-level key lost');
+});
+
+test('removeManagedCodexSurface removes managed hooks and skills, keeps user data and the file', () => {
+  const codexHome = tmpdir('bsit-codex-home-');
+  fs.mkdirSync(codexHome, { recursive: true });
+  fs.writeFileSync(
+    path.join(codexHome, 'hooks.json'),
+    JSON.stringify({
+      $schema: 'https://example.com/hooks.schema.json',
+      hooks: { Stop: [{ hooks: [{ type: 'command', command: 'echo user-stop' }] }] },
+    }, null, 2),
+  );
+  const userSkill = path.join(codexHome, 'skills', 'my-own-skill');
+  fs.mkdirSync(userSkill, { recursive: true });
+  fs.writeFileSync(path.join(userSkill, 'SKILL.md'), '# my own thing\n');
+
+  shared.installCodexSurface(PACKAGE_ROOT, codexHome);
+  shared.removeManagedCodexSurface(codexHome, PACKAGE_ROOT);
+
+  for (const entry of fs.readdirSync(path.join(codexHome, 'hooks'))) {
+    assert.ok(
+      !entry.startsWith('babysitter-codex-') && !entry.startsWith('babysitter-proxied-'),
+      `managed hook file not removed: ${entry}`,
+    );
+  }
+  assert.ok(!fs.existsSync(path.join(codexHome, 'hooks', shared.MANAGED_SURFACE_MARKER)), 'marker not removed');
+  assert.ok(!fs.existsSync(path.join(codexHome, 'skills', 'babysit')), 'managed skill not removed');
+  assert.ok(fs.existsSync(userSkill), 'user skill wrongly removed');
+
+  const hooksConfig = readHooksConfig(codexHome);
+  assert.deepStrictEqual(handlerCommands(hooksConfig), ['echo user-stop']);
+  assert.strictEqual(hooksConfig.$schema, 'https://example.com/hooks.schema.json', 'top-level key lost on uninstall');
+});
+
+test('legacy purge only deletes artifacts that identify as babysitter', () => {
+  const codexHome = tmpdir('bsit-codex-home-');
+  const userPrompt = path.join(codexHome, 'prompts', 'plan.md');
+  const userSkill = path.join(codexHome, 'skills', 'model');
+  fs.mkdirSync(path.dirname(userPrompt), { recursive: true });
+  fs.mkdirSync(userSkill, { recursive: true });
+  fs.writeFileSync(userPrompt, '# my personal planning prompt\n');
+  fs.writeFileSync(path.join(userSkill, 'SKILL.md'), '# my model helper\n');
+  const legacyPrompt = path.join(codexHome, 'prompts', 'call.md');
+  fs.writeFileSync(legacyPrompt, 'Invoke the babysitter orchestrator\n');
+
+  shared.removeLegacyCodexSurface(codexHome);
+
+  assert.ok(fs.existsSync(userPrompt), 'unrelated user prompt deleted');
+  assert.ok(fs.existsSync(userSkill), 'unrelated user skill deleted');
+  assert.ok(!fs.existsSync(legacyPrompt), 'babysitter legacy prompt kept');
+});
+
+test('rewriteManagedHookCommand fails loudly instead of writing broken commands', () => {
+  assert.throws(() => shared.rewriteManagedHookCommand('echo something-else', '/tmp/hooks'));
+  assert.throws(() => shared.rewriteManagedHookCommand(`bash x/${STOP_SHIM}`, '/tmp/we"ird'));
+  assert.strictEqual(
+    shared.rewriteManagedHookCommand(`bash "x/${STOP_SHIM}"`, '/tmp/hooks'),
+    `bash "/tmp/hooks/${STOP_SHIM}"`,
+  );
+});
+
+if (process.platform !== 'win32') {
+  test('entry shim pipes the event through adapters-hooks into its handler', () => {
+    const sandbox = tmpdir('bsit-hook-exec-');
+    const fakeHome = path.join(sandbox, 'home');
+    const binDir = path.join(sandbox, 'bin');
+    const argsFile = path.join(sandbox, 'args.txt');
+    const stdinFile = path.join(sandbox, 'stdin.txt');
+    fs.mkdirSync(fakeHome, { recursive: true });
+    writeStubBins(binDir, argsFile, stdinFile);
+
+    const shim = path.join(PACKAGE_ROOT, 'hooks', STOP_SHIM);
+    const stdout = execFileSync('bash', [shim], {
+      cwd: sandbox,
+      env: { ...process.env, HOME: fakeHome, PATH: `${binDir}:${process.env.PATH}` },
+      input: '{"event":"Stop"}',
+      encoding: 'utf8',
+    });
+    assert.strictEqual(stdout.trim(), '{}');
+    const args = fs.readFileSync(argsFile, 'utf8').trim().split('\n');
+    assert.deepStrictEqual(args, [
+      'invoke',
+      '--adapter',
+      'codex',
+      '--handler',
+      `bash "${path.join(PACKAGE_ROOT, 'hooks', STOP_HANDLER)}"`,
+      '--json',
+    ]);
+    assert.strictEqual(fs.readFileSync(stdinFile, 'utf8'), '{"event":"Stop"}');
+  });
+
+  test('plugin-bundle copy defers to a live home surface (including CODEX_HOME)', () => {
+    for (const useCodexHomeEnv of [false, true]) {
+      const sandbox = tmpdir('bsit-hook-dedup-');
+      const fakeHome = path.join(sandbox, 'home');
+      const codexHome = useCodexHomeEnv ? path.join(sandbox, 'custom-codex-home') : path.join(fakeHome, '.codex');
+      const surfaceHooks = path.join(codexHome, 'hooks');
+      const binDir = path.join(sandbox, 'bin');
+      const argsFile = path.join(sandbox, 'args.txt');
+      fs.mkdirSync(fakeHome, { recursive: true });
+      writeStubBins(binDir, argsFile);
+      writeSurfaceCopy(surfaceHooks);
+
+      const opts = { cwd: sandbox, home: fakeHome, binDir, codexHome: useCodexHomeEnv ? codexHome : undefined };
+      const result = runHook(path.join(PACKAGE_ROOT, 'hooks', STOP_SHIM), opts);
+      assert.strictEqual(result.status, 0, result.stderr);
+      assert.ok(!fs.existsSync(argsFile), `plugin copy ran despite live surface (CODEX_HOME=${useCodexHomeEnv})`);
+
+      const surfaceResult = runHook(path.join(surfaceHooks, STOP_SHIM), opts);
+      assert.strictEqual(surfaceResult.status, 0, surfaceResult.stderr);
+      assert.ok(fs.existsSync(argsFile), `surface copy did not run (CODEX_HOME=${useCodexHomeEnv})`);
+    }
+  });
+
+  test('workspace surface wins over home surface, and works from a subdirectory', () => {
+    const sandbox = tmpdir('bsit-hook-precedence-');
+    const fakeHome = path.join(sandbox, 'home');
+    const workspace = path.join(sandbox, 'ws');
+    const subdir = path.join(workspace, 'packages', 'api');
+    const homeHooks = path.join(fakeHome, '.codex', 'hooks');
+    const wsHooks = path.join(workspace, '.codex', 'hooks');
+    const binDir = path.join(sandbox, 'bin');
+    const argsFile = path.join(sandbox, 'args.txt');
+    fs.mkdirSync(subdir, { recursive: true });
+    writeStubBins(binDir, argsFile);
+    writeSurfaceCopy(homeHooks);
+    writeSurfaceCopy(wsHooks);
+
+    const opts = { cwd: subdir, home: fakeHome, binDir };
+    const homeResult = runHook(path.join(homeHooks, STOP_SHIM), opts);
+    assert.strictEqual(homeResult.status, 0, homeResult.stderr);
+    assert.ok(!fs.existsSync(argsFile), 'home surface ran despite workspace surface owning the event');
+    const pluginResult = runHook(path.join(PACKAGE_ROOT, 'hooks', STOP_SHIM), opts);
+    assert.strictEqual(pluginResult.status, 0, pluginResult.stderr);
+    assert.ok(!fs.existsSync(argsFile), 'plugin copy ran despite workspace surface owning the event');
+    const wsResult = runHook(path.join(wsHooks, STOP_SHIM), opts);
+    assert.strictEqual(wsResult.status, 0, wsResult.stderr);
+    assert.ok(fs.existsSync(argsFile), 'workspace surface did not run');
+  });
+
+  test('a stale marker without scripts does not swallow events', () => {
+    const sandbox = tmpdir('bsit-hook-stale-');
+    const fakeHome = path.join(sandbox, 'home');
+    const staleHooks = path.join(fakeHome, '.codex', 'hooks');
+    const binDir = path.join(sandbox, 'bin');
+    const argsFile = path.join(sandbox, 'args.txt');
+    fs.mkdirSync(staleHooks, { recursive: true });
+    fs.writeFileSync(path.join(staleHooks, shared.MANAGED_SURFACE_MARKER), '{}');
+    writeStubBins(binDir, argsFile);
+
+    const result = runHook(path.join(PACKAGE_ROOT, 'hooks', STOP_SHIM), {
+      cwd: sandbox, home: fakeHome, binDir,
+    });
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.ok(fs.existsSync(argsFile), 'plugin copy deferred to a dead surface (marker without scripts)');
+  });
+
+  test('entry shim survives a missing HOME', () => {
+    const sandbox = tmpdir('bsit-hook-nohome-');
+    const binDir = path.join(sandbox, 'bin');
+    const argsFile = path.join(sandbox, 'args.txt');
+    writeStubBins(binDir, argsFile);
+
+    const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}` };
+    delete env.HOME;
+    delete env.CODEX_HOME;
+    const result = spawnSync('bash', [path.join(PACKAGE_ROOT, 'hooks', STOP_SHIM)], {
+      cwd: sandbox, env, input: '{}', encoding: 'utf8',
+    });
+    assert.strictEqual(result.status, 0, `shim failed without HOME: ${result.stderr}`);
+    assert.ok(fs.existsSync(argsFile), 'shim did not invoke adapters-hooks without HOME');
+  });
+}
+
+console.log(`\n${passed} integration checks passed`);

--- a/plugins/babysitter-unified/per-harness/codex/test/packaged-install.test.js
+++ b/plugins/babysitter-unified/per-harness/codex/test/packaged-install.test.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const PACKAGE_ROOT = path.resolve(__dirname, '..');
+
+let passed = 0;
+function test(name, fn) {
+  fn();
+  passed += 1;
+  console.log(`ok - ${name}`);
+}
+
+test('npm pack includes the full plugin bundle', () => {
+  const result = spawnSync('npm', ['pack', '--dry-run', '--json'], {
+    cwd: PACKAGE_ROOT,
+    encoding: 'utf8',
+    timeout: 120000,
+  });
+  assert.strictEqual(result.status, 0, `npm pack failed: ${result.stderr}`);
+  // npm may prepend log noise; the JSON payload starts at the first '['.
+  const stdout = result.stdout.slice(result.stdout.indexOf('['));
+  const [pack] = JSON.parse(stdout);
+  const files = new Set(pack.files.map((f) => f.path));
+
+  const required = [
+    'package.json',
+    'hooks.json',
+    'versions.json',
+    '.codex-plugin/plugin.json',
+    'bin/cli.js',
+    'bin/install.js',
+    'bin/install-shared.js',
+    'bin/uninstall.js',
+    'hooks/babysitter-codex-hook-lib.sh',
+  ];
+  // Every entry shim referenced by hooks.json must ship in the tarball.
+  const hooksConfig = JSON.parse(fs.readFileSync(path.join(PACKAGE_ROOT, 'hooks.json'), 'utf8'));
+  for (const matchers of Object.values(hooksConfig.hooks)) {
+    for (const matcher of matchers) {
+      for (const hook of matcher.hooks || []) {
+        const match = String(hook.command || '').match(/babysitter-codex-[A-Za-z0-9_-]+\.sh/);
+        if (match) required.push(`hooks/${match[0]}`);
+      }
+    }
+  }
+  for (const file of required) {
+    assert.ok(files.has(file), `packaged tarball missing ${file}`);
+  }
+});
+
+test('cli entrypoint prints usage', () => {
+  const result = spawnSync(process.execPath, [path.join(PACKAGE_ROOT, 'bin', 'cli.js'), '--help'], {
+    encoding: 'utf8',
+  });
+  assert.strictEqual(result.status, 0);
+  const output = `${result.stdout}${result.stderr}`;
+  assert.ok(/install/i.test(output), 'usage text missing');
+});
+
+console.log(`\n${passed} packaged-install checks passed`);

--- a/plugins/babysitter-unified/plugin.json
+++ b/plugins/babysitter-unified/plugin.json
@@ -103,6 +103,10 @@
       "src/processes.ts": "file:per-harness/genty/src/processes.ts",
       "src/register.ts": "file:per-harness/genty/src/register.ts",
       "src/index.ts": "file:per-harness/genty/src/index.ts"
+    },
+    "codex-tests": {
+      "test/integration.test.js": "file:per-harness/codex/test/integration.test.js",
+      "test/packaged-install.test.js": "file:per-harness/codex/test/packaged-install.test.js"
     }
   },
   "harnessInstallSurfaceExportSets": {
@@ -162,7 +166,8 @@
         "codex-branding",
         "codex-support-files",
         "readme",
-        "codex-team-install"
+        "codex-team-install",
+        "codex-tests"
       ],
       "harnessManifest": {
         "skills": "./skills/",
@@ -210,7 +215,6 @@
         "LEGACY_SKILL_NAMES",
         "LEGACY_PROMPT_NAMES",
         "LEGACY_HOOK_SCRIPT_NAMES",
-        "MANAGED_HOOK_SCRIPT_NAMES",
         "getCodexHome",
         "getHomePluginRoot",
         "getHomeMarketplacePath",
@@ -229,7 +233,14 @@
         "removeLegacyCodexSurface",
         "installCodexSurface",
         "harnessInstall",
-        "harnessTeamInstall"
+        "harnessTeamInstall",
+        "MANAGED_HOOK_FILE_PREFIXES",
+        "MANAGED_SURFACE_MARKER",
+        "looksLikeBabysitterArtifact",
+        "stripManagedHooks",
+        "rewriteManagedHookCommand",
+        "removeManagedCodexSurface",
+        "harnessUninstall"
       ]
     },
     "cursor": {


### PR DESCRIPTION
## Summary

Codex lifecycle hooks frequently failed to fire — or fired twice — because the hook wiring made assumptions that don't hold in real Codex sessions. This PR fixes the Codex integration in both the **unified plugin compiler** (`packages/adapters/extensions`) and the **babysitter unified plugin** (`plugins/babysitter-unified`), verified against the Codex CLI source (`openai/codex` — `codex-rs/hooks`, `codex-rs/core-plugins`).

### Root causes fixed

1. **Hook commands referenced `bash .codex/hooks/<script>`** — a cwd-relative path that only exists after a workspace team-install. Codex runs plugin-sourced hook commands with `CLAUDE_PLUGIN_ROOT`/`PLUGIN_ROOT` env pointing at the bundle and the session cwd, so marketplace/global installs failed with exit 127 on every event (including every `PreToolUse`/`PostToolUse`).
2. **`install --global` wired no hooks at all** — `harnessInstall` only merged `config.toml`; the marketplace entry alone (`installation: AVAILABLE`) activates nothing until `codex plugin add`.
3. **Only 3 of the 6 declared hook scripts were installed** — `MANAGED_HOOK_SCRIPT_NAMES` was missing `pre-tool-use`, `post-tool-use`, and `session-end`, so team installs shipped `hooks.json` entries pointing at nonexistent files.
4. **Reinstalls duplicated hook entries** — the merge only filtered legacy names, so hooks fired multiple times after upgrades.
5. **Hard failures instead of graceful ones** — `adapters-hooks`/`babysitter` missing from PATH killed hooks with exit 127; `versions.json` wasn't shipped, so the SDK version pin silently fell back to `latest`.

### Compiler changes (`packages/adapters/extensions`)

- **`generateCodexHooksJson`** now emits env-guarded commands — `if [ -n "${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}" ]; then exec bash ".../hooks/<shim>"; fi` — which resolve through the env Codex actually sets and no-op cleanly outside a plugin context. Matchers are dropped (Codex ignores them on lifecycle events; absent = match-all).
- **New Codex hook runtime** (`generateCodexHookRuntimeFiles`): one shared lib + one entry shim per hook, generated for *any* plugin compiled to codex. The shim wraps the plugin's own unchanged handler script: shim → arbitration/PATH/binary resolution → `adapters-hooks invoke --adapter codex --handler "bash <handler>"`.
  - **Exactly-once delivery**: each event is claimed by the nearest live surface — workspace `.codex` (found by walking up from the session cwd, so subdirectory sessions work), then Codex home (honoring `CODEX_HOME`), then the plugin bundle. A surface only counts as live when both its marker and the event's shim exist, so a stale or half-removed install can never silently swallow events. Global + workspace + marketplace installs no longer double-fire.
  - **Never breaks the session**: PATH is extended with common npm bin dirs, the proxy bin resolves next to the SDK CLI, SDK auto-install attempts are rate-limited (6h stamp), missing `HOME` is tolerated, and every failure path exits 0 with a stderr note.
- `package.json` generation now ships `versions.json` (the SDK pin the runtime reads) and `test/` when present.
- Default uninstall bin template gains a `harnessUninstall` extension point (mirroring `harnessInstall`).

### Unified plugin changes (`plugins/babysitter-unified`)

- **`per-harness/codex/bin/install-surface.js`**:
  - `harnessInstall` (global) now installs the managed hook surface into the Codex home. ⚠️ *Intentional behavior change: previously global installs wired no hooks.*
  - `installManagedHooks` copies **everything** under `hooks/` (readdir-based — kills the list-drift bug), records the file list in the surface marker, and writes absolute-path commands (cwd-relative commands broke from workspace subdirectories).
  - `mergeManagedHooksConfig` is idempotent: replaces managed/legacy entries (including the old `adapters-hooks invoke ... .codex/hooks/...` command format from previous releases) and preserves user hooks, unrecognized event shapes, and unrelated top-level `hooks.json` keys.
  - `removeManagedCodexSurface` removes the marker *first* (a partial failure can't strand a dead surface), removes installed skills, and writes `hooks.json` back instead of deleting the file.
  - The legacy skill/prompt purge is content-guarded — it no longer deletes a user's own `~/.codex/prompts/plan.md` or `skills/model` just for sharing a generic name.
  - New `harnessUninstall` wires marketplace + surface + skills cleanup into the generated uninstall script.
- **`plugin.json`**: updated codex `harnessInstallSurfaceExports`; new `codex-tests` extraFileSet so the bundle ships the self-tests its generated `npm test` scripts already referenced (previously those files were never emitted).
- **New `per-harness/codex/test/`**: 14 checks covering hooks.json↔runtime consistency, surface precedence (incl. `CODEX_HOME` and subdirectory sessions), merge idempotency, stale markers, missing `HOME`, ownership-guarded purge, and tarball completeness.

### Notes for reviewers

- The downstream sync repo `a5c-ai/babysitter-codex` will be regenerated with the new `babysitter-codex-*` shim naming on the next release; the idempotent merge recognizes both old and new command formats, so existing installs get cleaned up on upgrade.
- Codex gates newly discovered hooks behind a trust prompt (`/hooks` in the TUI) and requires `[features] hooks = true` (the installer merges this); Windows hooks require Codex CLI >= 0.119.0 (warned at install).

## Testing

- [x] `npm test` — full `packages/adapters/extensions` suite: **86 tests pass** (12 files), including the updated `transform.test.ts` / `bundleRegression.test.ts` expectations for the new command shape.
- [x] Compiled `babysitter-unified` → codex with `verifyOutput`: status OK, all `hooks.json command target exists: hooks/babysitter-codex-*.sh` checks pass.
- [x] Ran the **emitted bundle's** self-tests: **14/14 pass**, including executing the generated shims end-to-end against stub `adapters-hooks`/`babysitter` binaries for: plugin-bundle deferring to a live surface (with and without `CODEX_HOME`), workspace surface beating home surface from a subdirectory session, stale marker not swallowing events, and missing-`HOME` survival.
- Evidence: see commit message of 5b85ebe for the validation transcript summary.

## Docs impact

- [x] No user-facing docs changes needed in this repo (the generated per-harness README gains a troubleshooting section via the sync repo; happy to add monorepo docs if maintainers prefer)
