### PR TITLE
Adopt session-start bare runs in run:create

### DIFF
--- a/packages/babysitter-sdk/src/cli/__tests__/adoptSessionRun.test.ts
+++ b/packages/babysitter-sdk/src/cli/__tests__/adoptSessionRun.test.ts
@@ -1,0 +1,104 @@
+import { promises as fs } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createRunDir } from "../../storage/createRunDir";
+import { appendEvent } from "../../storage/journal";
+import { readRunMetadata, writeRunMetadata } from "../../storage/runFiles";
+import { getSessionFilePath } from "../../session/parse";
+import { writeSessionFile } from "../../session/write";
+import { findAdoptableSessionRun } from "../main/adoptSessionRun";
+
+describe("findAdoptableSessionRun", () => {
+  let rootDir: string;
+  let runsDir: string;
+  let stateDir: string;
+
+  beforeEach(async () => {
+    rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "adopt-session-run-"));
+    runsDir = path.join(rootDir, "runs");
+    stateDir = path.join(rootDir, "state");
+  });
+
+  afterEach(async () => {
+    await fs.rm(rootDir, { recursive: true, force: true });
+  });
+
+  it("rejects a bare run from another project", async () => {
+    const runId = "01AAAAAAAAAAAAAAAAAAAAAAAA";
+    const runDir = await createBoundRun(runId);
+    const metadata = await readRunMetadata(runDir);
+    metadata.cwd = path.join(rootDir, "other-project");
+    await writeRunMetadata(runDir, metadata);
+
+    await expect(findAdoptableSessionRun(defaultOptions(runId))).resolves.toBeUndefined();
+  });
+
+  it("rejects a terminal bare run", async () => {
+    const runId = "01BBBBBBBBBBBBBBBBBBBBBBBB";
+    const runDir = await createBoundRun(runId);
+    await appendEvent({
+      runDir,
+      eventType: "RUN_COMPLETED",
+      event: { runId },
+    });
+
+    await expect(findAdoptableSessionRun(defaultOptions(runId))).resolves.toBeUndefined();
+  });
+
+  it("rejects a session run that already has a process", async () => {
+    const runId = "01CCCCCCCCCCCCCCCCCCCCCCCC";
+    await createBoundRun(runId, {
+      processId: "existing/process",
+      entrypoint: { importPath: "process.mjs", exportName: "process" },
+    });
+
+    await expect(findAdoptableSessionRun(defaultOptions(runId))).resolves.toBeUndefined();
+  });
+
+  async function createBoundRun(
+    runId: string,
+    options: {
+      processId?: string;
+      entrypoint?: { importPath: string; exportName?: string };
+    } = {},
+  ): Promise<string> {
+    const processId = options.processId ?? "bare-run";
+    const entrypoint = options.entrypoint ?? { importPath: "bare-run" };
+    const runDir = path.join(runsDir, runId);
+    await createRunDir({
+      runsRoot: runsDir,
+      runId,
+      request: runId,
+      processId,
+      harness: "unified",
+      entrypoint,
+      processPath: entrypoint.importPath,
+    });
+    await appendEvent({
+      runDir,
+      eventType: "RUN_CREATED",
+      event: { runId, processId, entrypoint, harness: "unified" },
+    });
+    await writeSessionFile(getSessionFilePath(stateDir, `session-${runId}`), {
+      active: true,
+      iteration: 1,
+      maxIterations: 65_000,
+      runId,
+      runIds: [runId],
+      startedAt: "2026-08-11T00:00:00Z",
+      lastIterationAt: "2026-08-11T00:00:00Z",
+      iterationTimes: [],
+    }, "");
+    return runDir;
+  }
+
+  function defaultOptions(runId: string) {
+    return {
+      runsDir,
+      stateDir,
+      sessionId: `session-${runId}`,
+      harness: "unified",
+    };
+  }
+});

--- a/packages/babysitter-sdk/src/cli/__tests__/cliRuns.test.ts
+++ b/packages/babysitter-sdk/src/cli/__tests__/cliRuns.test.ts
@@ -8,6 +8,8 @@ import { readRunMetadata } from "../../storage/runFiles";
 import { DEFAULT_LAYOUT_VERSION, getStateFile } from "../../storage/paths";
 import { appendEvent, loadJournal } from "../../storage/journal";
 import { createRunDir } from "../../storage/createRunDir";
+import { createUnifiedAdapter } from "../../harness";
+import { getSessionFilePath, readSessionFile } from "../../session/parse";
 import { createStateCacheSnapshot, writeStateCache } from "../../runtime/replay/stateCache";
 import * as orchestrateIterationModule from "../../runtime/orchestrateIteration";
 import * as runFilesModule from "../../storage/runFiles";
@@ -31,6 +33,7 @@ describe("babysitter run:create CLI", () => {
     "AGENT_ENABLE_SESSION_PID_MARKERS",
     "BABYSITTER_ENABLE_SESSION_PID_MARKERS",
     "BABYSITTER_GLOBAL_STATE_DIR",
+    "BABYSITTER_STATE_DIR",
     "AGENT_TRUST_ENV_SESSION",
     "BABYSITTER_TRUST_ENV_SESSION",
     "CLAUDE_ENV_FILE",
@@ -49,6 +52,7 @@ describe("babysitter run:create CLI", () => {
       AGENT_TRUST_ENV_SESSION: process.env.AGENT_TRUST_ENV_SESSION,
       BABYSITTER_ENABLE_SESSION_PID_MARKERS: process.env.BABYSITTER_ENABLE_SESSION_PID_MARKERS,
       BABYSITTER_GLOBAL_STATE_DIR: process.env.BABYSITTER_GLOBAL_STATE_DIR,
+      BABYSITTER_STATE_DIR: process.env.BABYSITTER_STATE_DIR,
       BABYSITTER_TRUST_ENV_SESSION: process.env.BABYSITTER_TRUST_ENV_SESSION,
       CLAUDE_ENV_FILE: process.env.CLAUDE_ENV_FILE,
       CODEX_THREAD_ID: process.env.CODEX_THREAD_ID,
@@ -120,6 +124,121 @@ describe("babysitter run:create CLI", () => {
       inputsRef: "inputs.json",
       processRevision: "rev-42",
     });
+  });
+
+  it("adopts the session-start bare run for process-backed run:create", async () => {
+    const entryFile = await writeEntrypoint(
+      "processes/adopt-session.mjs",
+      `export async function process() { return "ok"; }\n`,
+    );
+    const stateDir = path.join(runsRoot, "state");
+    const sessionId = "unified-adoption-session";
+    const inputsPath = path.join(runsRoot, "adoption-inputs.json");
+    await fs.writeFile(inputsPath, JSON.stringify({ source: "regression" }), "utf8");
+
+    process.env.AGENT_SESSION_ID = sessionId;
+    process.env.BABYSITTER_STATE_DIR = stateDir;
+
+    await createUnifiedAdapter().handleSessionStartHook({
+      stateDir,
+      runsDir: runsRoot,
+      json: false,
+    });
+
+    const sessionBefore = await readSessionFile(getSessionFilePath(stateDir, sessionId));
+    expect(sessionBefore.state.runId).toBeTruthy();
+
+    const cli = createBabysitterCli();
+    const exitCode = await cli.run([
+      "run:create",
+      "--runs-dir",
+      runsRoot,
+      "--process-id",
+      "adoption/process",
+      "--entry",
+      `${entryFile}#process`,
+      "--harness",
+      "unified",
+      "--request",
+      "adoption/request",
+      "--prompt",
+      "adopt this run",
+      "--inputs",
+      inputsPath,
+      "--process-revision",
+      "rev-adopt",
+      "--non-interactive",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    const payload = readLastJsonLine(logSpy);
+    const runDirs = await listRunDirs();
+    expect(runDirs).toHaveLength(1);
+    expect(payload.runId).toBe(sessionBefore.state.runId);
+
+    const runDir = runDirs[0];
+    const metadata = await readRunMetadata(runDir);
+    expect(metadata.processId).toBe("adoption/process");
+    expect(metadata.request).toBe("adoption/request");
+    expect(metadata.prompt).toBe("adopt this run");
+    expect(metadata.processRevision).toBe("rev-adopt");
+    expect(metadata.nonInteractive).toBe(true);
+    expect(JSON.parse(await fs.readFile(path.join(runDir, "inputs.json"), "utf8"))).toEqual({
+      source: "regression",
+    });
+
+    const journal = await loadJournal(runDir);
+    expect(journal.map((event) => event.type)).toEqual(["RUN_CREATED", "PROCESS_ASSIGNED"]);
+    expect(journal[1].data).toMatchObject({
+      processId: "adoption/process",
+      prompt: "adopt this run",
+      previousEntrypoint: { importPath: "bare-run" },
+      inputsRef: "inputs.json",
+    });
+
+    const sessionAfter = await readSessionFile(getSessionFilePath(stateDir, sessionId));
+    expect(sessionAfter.state.runId).toBe(sessionBefore.state.runId);
+  });
+
+  it("keeps creating a new run when the session has an explicit run ID", async () => {
+    const entryFile = await writeEntrypoint(
+      "processes/explicit-run.mjs",
+      `export async function process() { return "ok"; }\n`,
+    );
+    const stateDir = path.join(runsRoot, "state");
+    const sessionId = "explicit-run-session";
+
+    process.env.AGENT_SESSION_ID = sessionId;
+    process.env.BABYSITTER_STATE_DIR = stateDir;
+    await createUnifiedAdapter().handleSessionStartHook({
+      stateDir,
+      runsDir: runsRoot,
+      json: false,
+    });
+    const session = await readSessionFile(getSessionFilePath(stateDir, sessionId));
+
+    const cli = createBabysitterCli();
+    const exitCode = await cli.run([
+      "run:create",
+      "--runs-dir",
+      runsRoot,
+      "--run-id",
+      "01ZZZZZZZZZZZZZZZZZZZZZZZZ",
+      "--process-id",
+      "explicit/process",
+      "--entry",
+      `${entryFile}#process`,
+      "--harness",
+      "unified",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect((await listRunDirs()).sort()).toEqual([
+      path.join(runsRoot, "01ZZZZZZZZZZZZZZZZZZZZZZZZ"),
+      path.join(runsRoot, session.state.runId),
+    ].sort());
   });
 
   it("supports machine-readable --json output", async () => {

--- a/packages/babysitter-sdk/src/cli/main/adoptSessionRun.ts
+++ b/packages/babysitter-sdk/src/cli/main/adoptSessionRun.ts
@@ -1,0 +1,85 @@
+import * as path from "node:path";
+import {
+  countPendingEffectsFromJournal,
+  deriveObservedRunState,
+  isTerminalRunState,
+} from "../../runtime/runLifecycleState";
+import { loadJournal } from "../../storage/journal";
+import { readRunMetadata } from "../../storage/runFiles";
+import type { RunMetadata } from "../../storage/types";
+import { getSessionFilePath, readSessionFile } from "../../session/parse";
+
+export interface AdoptableSessionRun {
+  runId: string;
+  runDir: string;
+  metadata: RunMetadata;
+}
+
+/**
+ * Find the active bare run created for the current session.
+ *
+ * Adoption is intentionally conservative: explicit run IDs, terminal runs,
+ * assigned runs, cross-project runs, and runs from another harness are left
+ * alone so callers retain the old create-a-new-run behavior.
+ */
+export async function findAdoptableSessionRun(options: {
+  runsDir: string;
+  stateDir?: string;
+  sessionId?: string;
+  runIdOverride?: string;
+  harness?: string;
+}): Promise<AdoptableSessionRun | undefined> {
+  if (!options.stateDir || !options.sessionId || options.runIdOverride) return undefined;
+
+  let session;
+  try {
+    session = await readSessionFile(getSessionFilePath(options.stateDir, options.sessionId));
+  } catch {
+    return undefined;
+  }
+  if (!session.state.active || !session.state.runId) return undefined;
+
+  const runsDir = path.resolve(options.runsDir);
+  const runId = session.state.runId;
+  const expectedRunDir = path.resolve(path.join(runsDir, runId));
+  const runDir = path.resolve(session.state.runDir ?? expectedRunDir);
+  if (runDir !== expectedRunDir) return undefined;
+
+  let metadata: RunMetadata;
+  try {
+    metadata = await readRunMetadata(runDir);
+  } catch {
+    return undefined;
+  }
+  if (metadata.runId !== runId || metadata.entrypoint.importPath !== "bare-run") return undefined;
+  if (options.harness && metadata.harness && metadata.harness !== options.harness) return undefined;
+  if (metadata.cwd && path.resolve(metadata.cwd) !== path.resolve(process.cwd())) return undefined;
+
+  let journal;
+  try {
+    journal = await loadJournal(runDir);
+  } catch {
+    return undefined;
+  }
+  if (journal.some((event) => event.type === "PROCESS_ASSIGNED")) return undefined;
+  const sessionIds = journal
+    .map((event) => event.data.sessionId)
+    .filter((value): value is string => typeof value === "string");
+  if (sessionIds.some((value) => value !== options.sessionId)) return undefined;
+  if (isTerminalRunState(deriveObservedRunState(journal, countPendingEffectsFromJournal(journal)))) {
+    return undefined;
+  }
+
+  return { runId, runDir, metadata };
+}
+
+export function resolveAdoptionStateDir(options: {
+  adapter?: { resolveStateDir(args: { stateDir?: string; pluginRoot?: string }): string | undefined } | null;
+  stateDir?: string;
+  pluginRoot?: string;
+}): string | undefined {
+  return options.adapter?.resolveStateDir({
+    stateDir: options.stateDir,
+    pluginRoot: options.pluginRoot,
+  });
+}

--- a/packages/babysitter-sdk/src/cli/main/assignProcess.ts
+++ b/packages/babysitter-sdk/src/cli/main/assignProcess.ts
@@ -1,0 +1,88 @@
+import * as path from "node:path";
+import { appendEvent } from "../../storage/journal";
+import { writeFileAtomic } from "../../storage/atomic";
+import { INPUTS_FILE } from "../../storage/paths";
+import { readRunMetadata, writeRunMetadata } from "../../storage/runFiles";
+import type { JsonRecord, RunMetadata } from "../../storage/types";
+import { withRunLock } from "../../storage/lock";
+import { hashProcessCodeFile } from "../../runtime/processCodeHash";
+
+export interface AssignProcessOptions {
+  runDir: string;
+  processId: string;
+  importPath: string;
+  exportName?: string;
+  processRevision?: string;
+  force?: boolean;
+  request?: string;
+  prompt?: string;
+  inputs?: unknown;
+  additionalMetadata?: JsonRecord;
+  owner: string;
+  /** Return without changing the run when the target is no longer bare. */
+  requireBare?: boolean;
+}
+
+export interface AssignProcessResult {
+  metadata: RunMetadata;
+  previousEntrypoint: RunMetadata["entrypoint"];
+}
+
+/**
+ * Attach a process to an existing run and record the transition in the journal.
+ * The caller can use requireBare for adoption paths that must not race with a
+ * separate process assignment.
+ */
+export async function assignProcessToRun(
+  options: AssignProcessOptions,
+): Promise<AssignProcessResult | undefined> {
+  return withRunLock(options.runDir, options.owner, async () => {
+    const current = await readRunMetadata(options.runDir);
+    const isBareRun = current.entrypoint.importPath === "bare-run";
+    if (!isBareRun && options.requireBare) return undefined;
+    if (!isBareRun && !options.force) {
+      throw new Error(
+        `Run already has a process assigned (entrypoint: ${current.entrypoint.importPath}).`,
+      );
+    }
+
+    const previousEntrypoint = { ...current.entrypoint };
+    current.entrypoint = {
+      importPath: options.importPath,
+      exportName: options.exportName,
+    };
+    current.processPath = options.importPath;
+    current.processId = options.processId;
+    current.processCodeHash = await hashProcessCodeFile(options.importPath);
+    if (options.processRevision !== undefined) {
+      current.processRevision = options.processRevision;
+    }
+    if (options.request !== undefined) current.request = options.request;
+    if (options.prompt !== undefined) current.prompt = options.prompt;
+    if (options.additionalMetadata) Object.assign(current, options.additionalMetadata);
+
+    await writeRunMetadata(options.runDir, current);
+    if (options.inputs !== undefined) {
+      await writeFileAtomic(
+        path.join(options.runDir, INPUTS_FILE),
+        `${JSON.stringify(options.inputs, null, 2)}\n`,
+      );
+    }
+
+    await appendEvent({
+      runDir: options.runDir,
+      eventType: "PROCESS_ASSIGNED",
+      event: {
+        processId: options.processId,
+        entrypoint: current.entrypoint,
+        previousEntrypoint,
+        force: options.force ?? false,
+        ...(options.prompt !== undefined ? { prompt: options.prompt } : {}),
+        ...(options.inputs !== undefined ? { inputsRef: INPUTS_FILE } : {}),
+        ...(current.processCodeHash ? { processCodeHash: current.processCodeHash } : {}),
+      },
+    });
+
+    return { metadata: current, previousEntrypoint };
+  });
+}

--- a/packages/babysitter-sdk/src/cli/main/runAssignProcess.ts
+++ b/packages/babysitter-sdk/src/cli/main/runAssignProcess.ts
@@ -1,7 +1,5 @@
 import * as path from "node:path";
-import { readRunMetadata, writeRunMetadata } from "../../storage/runFiles";
-import { appendEvent } from "../../storage/journal";
-import { withRunLock } from "../../storage/lock";
+import { readRunMetadata } from "../../storage/runFiles";
 import type { ParsedArgs } from "./types";
 import { collapseDoubledA5cRuns, resolveRunDir } from "./args";
 import {
@@ -11,7 +9,7 @@ import {
   validateProcessEntrypoint,
 } from "./runSupport";
 import { USAGE } from "./usage";
-import { hashProcessCodeFile } from "../../runtime/processCodeHash";
+import { assignProcessToRun } from "./assignProcess";
 
 export async function handleRunAssignProcess(parsed: ParsedArgs): Promise<number> {
   if (!parsed.runDirArg) {
@@ -103,34 +101,14 @@ export async function handleRunAssignProcess(parsed: ParsedArgs): Promise<number
     return 0;
   }
 
-  await withRunLock(runDir, "run:assign-process", async () => {
-    const current = await readRunMetadata(runDir);
-    const previousEntrypoint = { ...current.entrypoint };
-
-    current.entrypoint = {
-      importPath: absoluteImportPath,
-      exportName: entrypoint.exportName,
-    };
-    current.processPath = absoluteImportPath;
-    current.processId = processId;
-    current.processCodeHash = await hashProcessCodeFile(absoluteImportPath);
-    if (parsed.processRevision) {
-      current.processRevision = parsed.processRevision;
-    }
-
-    await writeRunMetadata(runDir, current);
-
-    await appendEvent({
-      runDir,
-      eventType: "PROCESS_ASSIGNED",
-      event: {
-        processId,
-        entrypoint: current.entrypoint,
-        previousEntrypoint,
-        force: parsed.sessionForce ?? false,
-        ...(current.processCodeHash ? { processCodeHash: current.processCodeHash } : {}),
-      },
-    });
+  await assignProcessToRun({
+    runDir,
+    processId,
+    importPath: absoluteImportPath,
+    exportName: entrypoint.exportName,
+    processRevision: parsed.processRevision,
+    force: parsed.sessionForce,
+    owner: "run:assign-process",
   });
 
   const updatedMetadata = await readRunMetadata(runDir);

--- a/packages/babysitter-sdk/src/cli/main/runCreate.ts
+++ b/packages/babysitter-sdk/src/cli/main/runCreate.ts
@@ -5,7 +5,7 @@ import { createRun } from "../../runtime/createRun";
 import { appendEvent, loadJournal } from "../../storage/journal";
 import { writeFileAtomic } from "../../storage/atomic";
 import { rebuildStateCache } from "../../runtime/replay/stateCache";
-import type { IterationMetadata } from "../../runtime/types";
+import type { CreateRunResult, IterationMetadata } from "../../runtime/types";
 import type { JournalEvent, JsonRecord } from "../../storage/types";
 import { nextUlid } from "../../storage/ulids";
 import {
@@ -18,6 +18,8 @@ import {
 import { discoverFromProcessFile, discoverSkillsInternal } from "../commands/skill";
 import { runIterate, type RunIterateResult } from "../commands/runIterate";
 import { getActiveProcessLibraryPath } from "../../processLibrary/active";
+import { callRuntimeHook } from "../../runtime/hooks/runtime";
+import { resolveProjectRootForRun } from "../../config";
 import { collapseDoubledA5cRuns, resolveRunDir } from "./args";
 import {
   formatEntrypointSpecifier,
@@ -31,6 +33,8 @@ import {
 import { formatIterationMetadata, readRunMetadataSafe } from "./runState";
 import type { ParsedArgs } from "./types";
 import { USAGE } from "./usage";
+import { assignProcessToRun } from "./assignProcess";
+import { findAdoptableSessionRun, resolveAdoptionStateDir } from "./adoptSessionRun";
 
 export async function handleRunCreate(parsed: ParsedArgs): Promise<number> {
   // --entry is optional for bare runs (no process attached)
@@ -111,24 +115,6 @@ export async function handleRunCreate(parsed: ParsedArgs): Promise<number> {
   }
 
   const requestedHarness = parsed.harness ?? (parsed.sessionId ? getAdapter().name : undefined);
-  const result = await createRun({
-    runsDir,
-    runId: parsed.runIdOverride,
-    request: parsed.requestId,
-    prompt: parsed.prompt,
-    harness: requestedHarness,
-    processRevision: parsed.processRevision,
-    ...(!isBareRun && absoluteImportPath && parsed.processId ? {
-      process: {
-        processId: parsed.processId,
-        importPath: absoluteImportPath,
-        exportName: entrypoint?.exportName,
-      },
-    } : {}),
-    inputs,
-    ...(parsed.interactive === false ? { metadata: { nonInteractive: true } } : {}),
-  });
-
   const detectedAdapter = parsed.harness ? getAdapterByName(parsed.harness) : getAdapter();
   const shouldBindSession = parsed.sessionId !== undefined || parsed.harness !== undefined || (detectedAdapter && detectedAdapter.name !== "custom");
   const adapter = shouldBindSession ? detectedAdapter : undefined;
@@ -142,9 +128,92 @@ export async function handleRunCreate(parsed: ParsedArgs): Promise<number> {
     return 1;
   }
 
+  const sessionId = adapter?.resolveSessionId(parsed);
+  const adoptionHarness = parsed.harness ?? adapter?.name;
+  const stateDir = adapter
+    ? resolveAdoptionStateDir({
+        adapter,
+        stateDir: parsed.stateDir,
+        pluginRoot: parsed.pluginRoot,
+      })
+    : undefined;
+  const adoptableRun = !isBareRun
+    ? await findAdoptableSessionRun({
+        runsDir,
+        stateDir,
+        sessionId,
+        runIdOverride: parsed.runIdOverride,
+        harness: adoptionHarness,
+      })
+    : undefined;
+
+  let adoptedRun = false;
+  let result: CreateRunResult | undefined;
+  if (adoptableRun && absoluteImportPath && parsed.processId) {
+    const adopted = await assignProcessToRun({
+      runDir: adoptableRun.runDir,
+      processId: parsed.processId,
+      importPath: absoluteImportPath,
+      exportName: entrypoint?.exportName,
+      processRevision: parsed.processRevision,
+      request: parsed.requestId ?? parsed.processId,
+      prompt: parsed.prompt,
+      inputs,
+      additionalMetadata: parsed.interactive === false ? { nonInteractive: true } : undefined,
+      owner: "run:create:adopt",
+      requireBare: true,
+    });
+    if (!adopted) {
+      const message = `Session run ${adoptableRun.runId} changed while it was being adopted. Retry run:create.`;
+      if (parsed.json) {
+        console.log(JSON.stringify({ error: "SESSION_RUN_CHANGED", message, runId: adoptableRun.runId }));
+      } else {
+        console.error(`[run:create] ${message}`);
+      }
+      return 1;
+    }
+    adoptedRun = true;
+    result = {
+      runId: adoptableRun.runId,
+      runDir: adoptableRun.runDir,
+      metadata: adopted.metadata,
+    };
+    await callRuntimeHook(
+      "on-run-start",
+      {
+        runId: result.runId,
+        processId: parsed.processId,
+        entry: formatEntrypointSpecifier(result.metadata.entrypoint),
+        inputs,
+      },
+      {
+        cwd: resolveProjectRootForRun(result.runDir, result.metadata.entrypoint.importPath),
+      },
+    );
+  }
+
+  if (!result) {
+    result = await createRun({
+      runsDir,
+      runId: parsed.runIdOverride,
+      request: parsed.requestId,
+      prompt: parsed.prompt,
+      harness: requestedHarness,
+      processRevision: parsed.processRevision,
+      ...(!isBareRun && absoluteImportPath && parsed.processId ? {
+        process: {
+          processId: parsed.processId,
+          importPath: absoluteImportPath,
+          exportName: entrypoint?.exportName,
+        },
+      } : {}),
+      inputs,
+      ...(parsed.interactive === false ? { metadata: { nonInteractive: true } } : {}),
+    });
+  }
+
   let sessionBound;
   if (adapter) {
-    const sessionId = adapter.resolveSessionId(parsed);
     sessionBound = sessionId
       ? await adapter.bindSession({
           sessionId,
@@ -173,6 +242,7 @@ export async function handleRunCreate(parsed: ParsedArgs): Promise<number> {
     adapter,
     sessionBound,
     runDir: result.runDir,
+    adopted: adoptedRun,
   })) {
     initialIteration = await runIterate({
       runDir: result.runDir,
@@ -257,6 +327,7 @@ async function shouldSeedInitialIterationAfterRunCreate(args: {
   adapter?: HarnessAdapter | null;
   sessionBound?: { sessionId?: string; error?: string; fatal?: boolean };
   runDir: string;
+  adopted?: boolean;
 }): Promise<boolean> {
   if (args.isBareRun) return false;
   if (args.adapter?.name !== "claude-code") return false;
@@ -264,7 +335,11 @@ async function shouldSeedInitialIterationAfterRunCreate(args: {
   if (!args.sessionBound?.sessionId || args.sessionBound.error || args.sessionBound.fatal) return false;
 
   const journal = await loadJournal(args.runDir);
-  return journal.length === 1 && journal[0]?.type === "RUN_CREATED";
+  if (journal.length === 1 && journal[0]?.type === "RUN_CREATED") return true;
+  return args.adopted === true
+    && journal.length === 2
+    && journal[0]?.type === "RUN_CREATED"
+    && journal[1]?.type === "PROCESS_ASSIGNED";
 }
 
 function summarizeDiscovery(

--- a/packages/babysitter-sdk/src/prompts/templates/run-creation.md
+++ b/packages/babysitter-sdk/src/prompts/templates/run-creation.md
@@ -1,7 +1,9 @@
 ### 2. Create run and bind session:
 
 If an existing bare run is reported in the **Existing Run State** section above,
-use `run:assign-process` (see below) instead of creating a new run.
+`run:create` will adopt it automatically when the active session, project, and
+runs directory match. If the command cannot safely adopt it, use
+`run:assign-process` (see below) instead of creating a new run.
 
 **For new runs:**
 
@@ -38,10 +40,11 @@ $CLI session:resume \
   --run-id <runId> --json
 ```
 
-**For assigning a process to an existing bare run:**
+**For manually assigning a process to an existing bare run:**
 
-When the session-start hook has already created a bare run (no `--entry`), use
-`run:assign-process` to attach the process definition, then bind the session:
+When automatic adoption is unavailable or you intentionally need to use a
+specific existing run, use `run:assign-process` to attach the process
+definition, then bind the session:
 
 ```bash
 # 1. Assign the process to the bare run
@@ -76,5 +79,5 @@ event to the run.
 
 **Common mistakes to avoid:**
 - wrong: Always creating a new run when a bare run already exists from session-start
-- correct: Check `.a5c/runs/` for existing bare runs and use `run:assign-process`
+- correct: Let `run:create` adopt the active bare run, or use `run:assign-process` for a manual fallback
 - wrong: Skipping `run:assign-process` and calling `run:iterate` on a bare run (will fail)


### PR DESCRIPTION
## Summary

- deterministically adopt the active session-start bare run in process-backed `run:create`
- share locked process-assignment logic with `run:assign-process`
- preserve process metadata, prompt, inputs, lifecycle hooks, and session binding
- keep explicit `--run-id` and unsafe cross-project/terminal/non-bare cases on the existing create-new path
- add regression coverage for adoption and the safety boundaries

Fixes #1726

## Testing

- `tsc -p packages/babysitter-sdk/tsconfig.json --noEmit`
- ESLint on changed production and test files (no errors)
- focused adoption and safety-boundary Vitest tests: 5 passed
- related CLI tests: 75 passed; 2 pre-existing macOS `/var` vs `/private/var` `realpath` assertion failures

The repository's sparse checkout is missing three unrelated Atlas blueprint files, so the template sync check could not run in this checkout.