### PR TITLE
Fix generated Pi installer .cjs imports

### DIFF
--- a/packages/adapters/extensions/src/__tests__/piAgentEndHook.regression.test.ts
+++ b/packages/adapters/extensions/src/__tests__/piAgentEndHook.regression.test.ts
@@ -13,6 +13,7 @@
 
 import { execSync } from 'child_process';
 import * as fs from 'fs';
+import { createRequire } from 'module';
 import * as os from 'os';
 import * as path from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -94,6 +95,66 @@ describe('pi target ships agent_end wiring + proxied hook scripts (#948)', () =>
         entry.files.map((f) => f.path),
       );
       expect(packedPaths).toContain('hooks/babysitter-proxied-stop.js');
+    },
+    120_000,
+  );
+
+  it(
+    'packs Pi bin entry points that resolve the shipped install-shared.cjs (#1581)',
+    () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-1581-'));
+      tempDirs.push(tempDir);
+
+      const result = compile({
+        source: UNIFIED_PLUGIN_DIR,
+        target: 'pi',
+        output: path.join(tempDir, 'pi'),
+      });
+
+      expect(
+        result.status,
+        result.diagnostics
+          .filter((d) => d.level === 'error')
+          .map((d) => d.message)
+          .join('\n'),
+      ).not.toBe('error');
+
+      const binPaths = [
+        'bin/cli.cjs',
+        'bin/install.cjs',
+        'bin/uninstall.cjs',
+      ];
+      const sharedPath = path.join(
+        result.outputDir,
+        'bin',
+        'install-shared.cjs',
+      );
+      const packOutput = execSync('npm pack --dry-run --json', {
+        cwd: result.outputDir,
+        encoding: 'utf-8',
+      });
+      const packed = JSON.parse(packOutput) as NpmPackEntry[];
+      const packedPaths = packed.flatMap((entry) =>
+        entry.files.map((file) => file.path),
+      );
+
+      expect(packedPaths).toEqual(
+        expect.arrayContaining([...binPaths, 'bin/install-shared.cjs']),
+      );
+
+      for (const binPath of binPaths) {
+        const entryPath = path.join(result.outputDir, binPath);
+        const entrySource = fs.readFileSync(entryPath, 'utf-8');
+
+        expect(entrySource, binPath).toMatch(
+          /require\(\s*['"]\.\/install-shared\.cjs['"]\s*\)/,
+        );
+        expect(
+          fs.realpathSync(
+            createRequire(entryPath).resolve('./install-shared.cjs'),
+          ),
+        ).toBe(fs.realpathSync(sharedPath));
+      }
     },
     120_000,
   );

--- a/packages/adapters/extensions/src/binTemplates.ts
+++ b/packages/adapters/extensions/src/binTemplates.ts
@@ -26,7 +26,7 @@ const { spawnSync } = require('child_process');
 
 const PACKAGE_ROOT = path.resolve(__dirname, '..');
 let shared;
-try { shared = require('./install-shared'); } catch {}
+try { shared = require('./install-shared${ext}'); } catch {}
 
 function printUsage() {
   console.error([
@@ -121,12 +121,14 @@ export function generateInstallScript(
   _manifest: A5cPluginManifest,
   targetProfile: TargetProfile
 ): string {
+  const ext = getExt(targetProfile);
+
   if (targetProfile.componentSupport?.agents === 'native' && targetProfile.packageMetadata?.installLifecycle === 'plugin-scripts') {
     return `#!/usr/bin/env node
 'use strict';
 
 const path = require('path');
-const shared = require('./install-shared');
+const shared = require('./install-shared${ext}');
 
 const PACKAGE_ROOT = path.resolve(__dirname, '..');
 
@@ -168,7 +170,7 @@ main();
 'use strict';
 
 const path = require('path');
-const shared = require('./install-shared');
+const shared = require('./install-shared${ext}');
 
 const PACKAGE_ROOT = path.resolve(__dirname, '..');
 
@@ -233,13 +235,15 @@ export function generateUninstallScript(
   _manifest: A5cPluginManifest,
   targetProfile: TargetProfile
 ): string {
+  const ext = getExt(targetProfile);
+
   if (targetProfile.componentSupport?.agents === 'native' && targetProfile.packageMetadata?.installLifecycle === 'plugin-scripts') {
     return `#!/usr/bin/env node
 'use strict';
 
 const path = require('path');
 const fs = require('fs');
-const shared = require('./install-shared');
+const shared = require('./install-shared${ext}');
 
 function main() {
   const pluginRoot = shared.getHomePluginRoot();
@@ -288,7 +292,7 @@ main();
 
 const fs = require('fs');
 const path = require('path');
-const shared = require('./install-shared');
+const shared = require('./install-shared${ext}');
 
 const PACKAGE_ROOT = path.resolve(__dirname, '..');
 


### PR DESCRIPTION
Closes #1581

Fixes the authoritative extension-adapter templates so generated Pi CLI, install, and uninstall entry points resolve the emitted install-shared.cjs module. Adds packaged-entry-point regression coverage to prevent downstream sync drift.

Verification:
- targeted Pi packaged-entry-point regression
- full extensions-adapter test suite
- extensions-adapter build
- metadata verification