### PR TITLE
fix(prompts): stop naming AskUserQuestion on harnesses that do not have it

### DIFF
--- a/packages/atlas/graph/extensions/plugin-artifacts/plugin-target-codex.yaml
+++ b/packages/atlas/graph/extensions/plugin-artifacts/plugin-target-codex.yaml
@@ -69,12 +69,20 @@ attributes:
   promptCapabilities:
     - hooks
     - stop-hook
-    - ask-user-question
+    # 'ask-user-question' removed: Codex exposes no such tool (see
+    # interactiveToolName below). No template gates on this capability today,
+    # so this changes no rendered output — it stops the declaration from being
+    # a false premise for anything that gates on it later.
     - task-tool
     - breakpoint-routing
   loopControlTerm: stop-hook
   hookDriven: true
-  interactiveToolName: "AskUserQuestion tool"
+  # Codex has no agent-callable question tool. Its only structured-input
+  # mechanism is MCP elicitation, which an MCP server invokes rather than the
+  # model, so interactive asks are plain-text turn endings. Naming a tool the
+  # harness lacks made agents read "no AskUserQuestion tool" as "I am
+  # non-interactive" and auto-approve breakpoints. See issue #1758.
+  interactiveToolName: ""
   sessionEnvVarsDescription: "PID-scoped session marker (authoritative); CODEX_THREAD_ID/CODEX_SESSION_ID and AGENT_SESSION_ID are fallbacks"
   hasIntentFidelityChecks: true
   hasNonNegotiables: true

--- a/packages/atlas/graph/extensions/plugin-artifacts/plugin-target-copilot-cli.yaml
+++ b/packages/atlas/graph/extensions/plugin-artifacts/plugin-target-copilot-cli.yaml
@@ -68,7 +68,9 @@ attributes:
     - breakpoint-routing
   loopControlTerm: in-turn
   hookDriven: false
-  interactiveToolName: "AskUserQuestion tool"
+  # No agent-callable question tool; verified against the installed CLI.
+  # Interactive asks are plain-text turn endings. See issue #1758.
+  interactiveToolName: ""
   sessionEnvVarsDescription: "PID-scoped session marker (authoritative); COPILOT_ENV_FILE / COPILOT_SESSION_ID and AGENT_SESSION_ID are fallbacks"
   hasIntentFidelityChecks: false
   hasNonNegotiables: false

--- a/packages/atlas/graph/extensions/plugin-artifacts/plugin-target-cursor.yaml
+++ b/packages/atlas/graph/extensions/plugin-artifacts/plugin-target-cursor.yaml
@@ -63,7 +63,9 @@ attributes:
     - breakpoint-routing
   loopControlTerm: stop-hook
   hookDriven: true
-  interactiveToolName: "AskUserQuestion tool"
+  # No agent-callable question tool; verified against the installed CLI.
+  # Interactive asks are plain-text turn endings. See issue #1758.
+  interactiveToolName: ""
   sessionEnvVarsDescription: "conversation_id from hook stdin (authoritative per-request); PID-scoped session marker; AGENT_SESSION_ID fallback"
   hasIntentFidelityChecks: false
   hasNonNegotiables: false

--- a/packages/atlas/graph/extensions/plugin-artifacts/plugin-target-gemini-cli.yaml
+++ b/packages/atlas/graph/extensions/plugin-artifacts/plugin-target-gemini-cli.yaml
@@ -58,7 +58,9 @@ attributes:
     - breakpoint-routing
   loopControlTerm: stop-hook
   hookDriven: true
-  interactiveToolName: "AskUserQuestion tool"
+  # No agent-callable question tool; verified against the installed CLI.
+  # Interactive asks are plain-text turn endings. See issue #1758.
+  interactiveToolName: ""
   sessionEnvVarsDescription: "PID-scoped session marker (authoritative); GEMINI_SESSION_ID and AGENT_SESSION_ID are fallbacks"
   hasIntentFidelityChecks: false
   hasNonNegotiables: false

--- a/packages/atlas/graph/extensions/plugin-artifacts/plugin-target-pi.yaml
+++ b/packages/atlas/graph/extensions/plugin-artifacts/plugin-target-pi.yaml
@@ -59,7 +59,9 @@ attributes:
     - stop-hook
   loopControlTerm: stop-hook
   hookDriven: true
-  interactiveToolName: "AskUserQuestion"
+  # No agent-callable question tool; verified against the installed CLI.
+  # Interactive asks are plain-text turn endings. See issue #1758.
+  interactiveToolName: ""
   sessionEnvVarsDescription: "PID-scoped session marker (authoritative); PI_SESSION_ID and AGENT_SESSION_ID are fallbacks"
   hasIntentFidelityChecks: false
   hasNonNegotiables: false

--- a/packages/babysitter-sdk/src/harness/adapters/codex.ts
+++ b/packages/babysitter-sdk/src/harness/adapters/codex.ts
@@ -17,7 +17,12 @@ function buildConfig(): AdapterConfig {
     pluginRootEnvVars: ["CODEX_PLUGIN_ROOT", "AGENT_PLUGIN_ROOT"],
     sessionIdEnvVars: ["CODEX_THREAD_ID", "CODEX_SESSION_ID", "AGENT_SESSION_ID"],
     pluginRootVar: "${CODEX_PLUGIN_ROOT}",
-    interactiveToolName: "AskUserQuestion tool",
+    // Codex has no agent-callable question tool. Its only structured-input
+    // mechanism is MCP elicitation, which is invoked by an MCP server rather
+    // than by the model, so interactive asks are plain-text turn endings.
+    // Naming a tool the harness lacks made agents classify themselves
+    // non-interactive and auto-approve breakpoints. See issue #1758.
+    interactiveToolName: "",
     sessionEnvVars: "CODEX_THREAD_ID/CODEX_SESSION_ID and AGENT_SESSION_ID",
     hasIntentFidelityChecks: true,
     hasNonNegotiables: true,

--- a/packages/babysitter-sdk/src/harness/adapters/cursor.ts
+++ b/packages/babysitter-sdk/src/harness/adapters/cursor.ts
@@ -21,7 +21,9 @@ function buildConfig(): AdapterConfig {
     pluginRootEnvVars: ["CURSOR_PLUGIN_ROOT"],
     sessionIdEnvVars: ["AGENT_SESSION_ID"],
     pluginRootVar: "${CURSOR_PLUGIN_ROOT}",
-    interactiveToolName: "AskUserQuestion tool",
+    // No agent-callable question tool; verified against the installed CLI.
+    // Interactive asks are plain-text turn endings. See issue #1758.
+    interactiveToolName: "",
     sessionEnvVars: "AGENT_SESSION_ID",
     hasIntentFidelityChecks: false,
     hasNonNegotiables: false,

--- a/packages/babysitter-sdk/src/harness/adapters/gemini-cli.ts
+++ b/packages/babysitter-sdk/src/harness/adapters/gemini-cli.ts
@@ -17,7 +17,9 @@ function buildConfig(): AdapterConfig {
     pluginRootEnvVars: ["GEMINI_EXTENSION_PATH", "BABYSITTER_EXTENSION_PATH"],
     sessionIdEnvVars: ["GEMINI_SESSION_ID", "AGENT_SESSION_ID"],
     pluginRootVar: "${GEMINI_EXTENSION_PATH}",
-    interactiveToolName: "AskUserQuestion tool",
+    // No agent-callable question tool; verified against the installed CLI.
+    // Interactive asks are plain-text turn endings. See issue #1758.
+    interactiveToolName: "",
     sessionEnvVars: "GEMINI_SESSION_ID and AGENT_SESSION_ID",
     hasIntentFidelityChecks: false,
     hasNonNegotiables: false,

--- a/packages/babysitter-sdk/src/harness/adapters/github-copilot.ts
+++ b/packages/babysitter-sdk/src/harness/adapters/github-copilot.ts
@@ -34,7 +34,9 @@ function buildConfig(): AdapterConfig {
     pluginRootEnvVars: ["CLAUDE_PLUGIN_DATA", "COPILOT_PLUGIN_ROOT"],
     sessionIdEnvVars: ["AGENT_SESSION_ID", "COPILOT_SESSION_ID"],
     pluginRootVar: "${COPILOT_PLUGIN_ROOT}",
-    interactiveToolName: "AskUserQuestion tool",
+    // No agent-callable question tool; verified against the installed CLI.
+    // Interactive asks are plain-text turn endings. See issue #1758.
+    interactiveToolName: "",
     sessionEnvVars: "AGENT_SESSION_ID and COPILOT_SESSION_ID",
     hasIntentFidelityChecks: false,
     hasNonNegotiables: false,

--- a/packages/babysitter-sdk/src/harness/adapters/pi.ts
+++ b/packages/babysitter-sdk/src/harness/adapters/pi.ts
@@ -18,7 +18,9 @@ function buildConfig(): AdapterConfig {
     pluginRootEnvVars: ["PI_PLUGIN_ROOT"],
     sessionIdEnvVars: ["PI_SESSION_ID", "AGENT_SESSION_ID"],
     pluginRootVar: "${PI_PLUGIN_ROOT}",
-    interactiveToolName: "AskUserQuestion",
+    // No agent-callable question tool; verified against the installed CLI.
+    // Interactive asks are plain-text turn endings. See issue #1758.
+    interactiveToolName: "",
     sessionEnvVars: "PI_SESSION_ID and AGENT_SESSION_ID",
     hasIntentFidelityChecks: false,
     hasNonNegotiables: false,

--- a/packages/babysitter-sdk/src/prompts/__tests__/composer.test.ts
+++ b/packages/babysitter-sdk/src/prompts/__tests__/composer.test.ts
@@ -445,10 +445,15 @@ describe('interactive vs non-interactive', () => {
     expect(output).toContain('no AskUserQuestion tool');
   });
 
-  it('PI context uses its own interactiveToolName', () => {
+  // Was 'PI context uses its own interactiveToolName', asserting it contained
+  // 'AskUserQuestion'. Pi does not expose such a tool: its only occurrence of
+  // that string is a hardcoded list commented "Claude Code 2.x tool names",
+  // used for Anthropic API mapping, and pi-coding-agent's own dist/cli.js has
+  // none. The old assertion passed while encoding the premise this fixes.
+  it('PI context does not name the Claude Code question tool', () => {
     const ctx = createPromptContextFromCatalog('pi');
     const output = composeBabysitSkillPrompt(ctx);
-    expect(output).toContain('AskUserQuestion');
+    expect(output).not.toContain('AskUserQuestion');
   });
 
   // Regression: issue #1758. Codex has no agent-callable question tool, so
@@ -469,8 +474,19 @@ describe('interactive vs non-interactive', () => {
   // Regression: issue #1758, second defect. breakpoint-handling.md interpolated
   // interactiveToolName raw, so harnesses that leave it empty rendered
   // "if the  itself throws an error" with a doubled space and dangling article.
+  // Verified against each installed CLI: none exposes an agent-callable
+  // question tool. openclaw / antigravity-cli / omp are deliberately absent —
+  // not installed locally, so not verified and not changed.
+  it.each(['codex', 'cursor', 'copilot-cli', 'gemini-cli', 'pi'])(
+    '%s never names the Claude Code question tool',
+    (harness) => {
+      const output = composeBabysitSkillPrompt(createPromptContextFromCatalog(harness));
+      expect(output).not.toContain('AskUserQuestion');
+    },
+  );
+
   it('harnesses without a named question tool render a well-formed error clause', () => {
-    for (const harness of ['codex', 'opencode', 'genty'] as const) {
+    for (const harness of ['codex', 'cursor', 'copilot-cli', 'gemini-cli', 'pi', 'opencode', 'genty'] as const) {
       const output = composeBabysitSkillPrompt(createPromptContextFromCatalog(harness));
       expect(output, `${harness} should not render an empty tool name`)
         .not.toContain('if the  itself throws an error');

--- a/packages/babysitter-sdk/src/prompts/__tests__/composer.test.ts
+++ b/packages/babysitter-sdk/src/prompts/__tests__/composer.test.ts
@@ -451,6 +451,40 @@ describe('interactive vs non-interactive', () => {
     expect(output).toContain('AskUserQuestion');
   });
 
+  // Regression: issue #1758. Codex has no agent-callable question tool, so
+  // naming one let agents read "no AskUserQuestion tool" as "I am
+  // non-interactive" and auto-approve breakpoints.
+  it('codex context never names the Claude Code question tool', () => {
+    const ctx = createPromptContextFromCatalog('codex');
+    const output = composeBabysitSkillPrompt(ctx);
+    expect(output).not.toContain('AskUserQuestion');
+  });
+
+  it('codex context renders the non-interactive header without a tool clause', () => {
+    const ctx = createPromptContextFromCatalog('codex');
+    const output = composeBabysitSkillPrompt(ctx);
+    expect(output).toContain('Non-interactive mode (running with -p flag)');
+  });
+
+  // Regression: issue #1758, second defect. breakpoint-handling.md interpolated
+  // interactiveToolName raw, so harnesses that leave it empty rendered
+  // "if the  itself throws an error" with a doubled space and dangling article.
+  it('harnesses without a named question tool render a well-formed error clause', () => {
+    for (const harness of ['codex', 'opencode', 'genty'] as const) {
+      const output = composeBabysitSkillPrompt(createPromptContextFromCatalog(harness));
+      expect(output, `${harness} should not render an empty tool name`)
+        .not.toContain('if the  itself throws an error');
+      expect(output, `${harness} should fall back to a generic noun`)
+        .toContain('if the question tool itself throws an error');
+    }
+  });
+
+  it('claude-code error clause still names its actual tool', () => {
+    const ctx = createPromptContextFromCatalog('claude-code');
+    const output = composeBabysitSkillPrompt(ctx);
+    expect(output).toContain('if the AskUserQuestion tool itself throws an error');
+  });
+
   it('interactive=undefined shows both interactive and non-interactive sections', () => {
     const ctx = createPromptContextFromCatalog('claude-code', { interactive: undefined });
     const output = composeBabysitSkillPrompt(ctx);

--- a/packages/babysitter-sdk/src/prompts/parts/breakpointHandling.ts
+++ b/packages/babysitter-sdk/src/prompts/parts/breakpointHandling.ts
@@ -7,5 +7,14 @@ import type { PromptContext } from '../types';
  * and posting examples.
  */
 export function renderBreakpointHandling(ctx: PromptContext): string {
-  return renderTemplate(resolveTemplatePath('breakpoint-handling.md'), ctx);
+  // Harnesses without a named question tool leave interactiveToolName empty.
+  // Interpolating it raw produced "if the  itself throws an error"; fall back
+  // to a generic noun so the sentence reads correctly on every harness.
+  // Mirrors the guard in parts/interview.ts.
+  const augmentedCtx = {
+    ...ctx,
+    interactiveToolName: ctx.interactiveToolName || 'question tool',
+  };
+
+  return renderTemplate(resolveTemplatePath('breakpoint-handling.md'), augmentedCtx);
 }


### PR DESCRIPTION
Fixes #1758.

Five harnesses were described to themselves as having `AskUserQuestion`, a Claude Code tool they do not expose — and that description feeds directly into breakpoint mode detection. Two defects, fixed together because the obvious fix for the first lands you in the second.

> **Correction to the issue.** #1758 named `harness/adapters/codex.ts:20` as the root cause. That file is real and wrong, but the `instructions:*` CLI resolves context through `createPromptContextForHarness` → `createPromptContextFromCatalog` → the **atlas graph YAML**, which is what actually changes the output. Both are fixed here. See *Two sources of truth* at the bottom.

## 1 — Harnesses were told they have a tool they lack

The interview section renders the non-interactive header as *"running with -p flag **or no AskUserQuestion tool**"*, and §5.1.0 defines non-interactive mode partly by the absence of a question tool:

> Use non-interactive handling only when execution context is explicitly non-interactive (for example **no question tool** / explicit non-interactive run).

…then two lines later:

> Never auto-approve breakpoints when mode is ambiguous. Treat ambiguity as interactive and ask explicitly.

So an agent on any of these harnesses can correctly reason *"I have no AskUserQuestion tool, therefore I am non-interactive"* and auto-approve breakpoints — the outcome §5.1.0 exists to prevent, and the one guarding the `contrib` processes' gates before irreversible `gh` actions.

Each harness below was verified against its **installed CLI**, not assumed:

| harness | evidence | changed |
|---|---|---|
| `codex` | 0 hits for `AskUserQuestion` / `ask_user` / `request_user_approval` in the `codex-darwin-arm64` binary (0.147.0), while its real tools are present — `shell` 89, `apply_patch` 34, `update_plan` 27, `view_image` 6, `web_search` 6 | ✅ `""` |
| `cursor` | 0 hits across the agent payload — the `cursor-agent` on PATH is a shell wrapper, so the real JS bundle was scanned | ✅ `""` |
| `copilot-cli` | 0 hits across the Homebrew Cellar tree (1.34.1) | ✅ `""` |
| `gemini-cli` | 0 hits in `@google/gemini-cli` | ✅ `""` |
| `pi` | 0 hits in `pi-coding-agent`'s own `dist/cli.js`; its only occurrences are in a hardcoded list commented *"Claude Code 2.x tool names"* used for Anthropic API mapping | ✅ `""` |
| `claude-code` | genuinely has the tool | untouched |
| `openclaw`, `antigravity-cli`, `omp` | **not installed here — unverified** | untouched |

Set in both the graph YAML and the `derivePromptContext` adapters. `derivePromptContext` uses `??`, so an explicit `""` is preserved rather than falling back to the default.

Empty is the *safe* direction: the defect is that naming an absent tool lets an agent infer non-interactivity. An empty name removes the inference rather than relocating it — the header simply reads `(running with -p flag)`.

Also dropped `ask-user-question` from the codex `promptCapabilities`. **No template gates on that capability today, so this changes no rendered output** — it stops the declaration being a false premise for anything that gates on it later. Only `claude-code` and `codex` declared it.

**`pi` and `oh-my-pi` (`omp`) are distinct harnesses.** Only `pi` was verified; `omp` is untouched.

## 2 — `breakpoint-handling.md` had no empty-name handling

`templates/breakpoint-handling.md:37` interpolated the value raw:

```md
- Only use `--status error` if the {{interactiveToolName}} itself throws an error.
```

while `parts/interview.ts` already guarded the empty case. So every harness leaving the name empty renders a broken sentence **on main today**, before this PR:

```
- Only use `--status error` if the  itself throws an error.
```

(doubled space, dangling article). Reproduce on main:

```sh
for h in codex opencode genty; do
  echo "=== $h ==="
  babysitter instructions:babysit-skill --harness $h --interactive \
    | grep -n "itself throws an error\|Non-interactive mode (running"
done
```

This is why the two defects ship together: setting any harness's name to `""` without this would move it out of defect 1 and straight into defect 2. `parts/breakpointHandling.ts` now falls back to the generic noun `question tool`, mirroring `parts/interview.ts`.

## Result

| harness | before | after |
|---|---|---|
| `codex`, `cursor`, `copilot-cli`, `gemini-cli`, `pi` | `if the AskUserQuestion tool itself throws` | `if the question tool itself throws` |
| `opencode`, `genty` | `if the  itself throws` ❌ | `if the question tool itself throws` |
| `claude-code` | `if the AskUserQuestion tool itself throws` | unchanged |

Claude Code output is byte-identical — the fallback only engages on an empty name.

## Tests

`prompts/__tests__/composer.test.ts`, **125 passed**:

- `codex` / `cursor` / `copilot-cli` / `gemini-cli` / `pi` never contain `AskUserQuestion` (parameterised)
- codex renders `Non-interactive mode (running with -p flag)` with no tool clause
- those five plus `opencode` / `genty` never render `if the  itself throws an error`, and do render the generic fallback
- claude-code still names its actual tool — guards against over-correcting

**One existing test was inverted.** `'PI context uses its own interactiveToolName'` asserted the output *contained* `AskUserQuestion`; it passed while encoding the exact premise this PR removes. It now asserts the opposite, with a comment recording the evidence.

The new assertions fail on main and pass here. Note the catalog is generated from the graph YAML, so `packages/atlas` needs a rebuild for changes to reach the tests.

`npm run build` in `packages/babysitter-sdk` fails on `TS2307: Cannot find module '@a5c-ai/tasks-adapter'` in `externalAgentEffect.ts` — a monorepo build-order issue that **reproduces identically on unmodified main** (verified by stashing). Unrelated to this change.

## Two sources of truth (not fixed here)

`interactiveToolName` is declared in both `packages/atlas/graph/.../plugin-target-<h>.yaml` and `packages/babysitter-sdk/src/harness/adapters/<h>.ts`, with nothing keeping them in sync. Compounding it, `hooks/promptContexts.ts` is marked `@deprecated` in favour of `derivePromptContext.ts`, yet its own docstring directs new code to `createPromptContextForHarness()` — an alias re-exported from that same deprecated file, and what the CLI calls. Worth reconciling; too large for this PR.

Relatedly, `derivePromptContext.ts:187-189` defaults `interactiveToolName` to `"AskUserQuestion tool"` for any harness reporting `supportsInteractiveMode`, so the Claude Code tool name is the silent fallback repo-wide. I have not changed that default, since it affects harnesses I cannot test.

**`openclaw`, `antigravity-cli` and `omp` still declare the tool.** I could not install them to check, and removing a *working* question tool would break their breakpoints — strictly worse than the bug. Happy to extend if a maintainer can confirm, or to split those into a follow-up.
