### PR TITLE
fix(hooks): surface block decisions through the claude Stop renderer

### DIFF
--- a/packages/adapters/hooks/adapter-claude/src/__tests__/claude-adapter.test.ts
+++ b/packages/adapters/hooks/adapter-claude/src/__tests__/claude-adapter.test.ts
@@ -684,7 +684,10 @@ describe('renderClaudeOutput', () => {
       const output = renderClaudeOutput(merged, 'Stop');
 
       expect(output.decision).toBe('block');
-      expect(output.continue).toBe(false);
+      // A block omits the continue field entirely: the Stop decision-control
+      // schema only knows decision, and a block must not also signal that
+      // the turn can end.
+      expect(output.continue).toBeUndefined();
       expect(output.reason).toContain('Continue orchestration');
     });
   });

--- a/packages/adapters/hooks/adapter-claude/src/__tests__/claude-adapter.test.ts
+++ b/packages/adapters/hooks/adapter-claude/src/__tests__/claude-adapter.test.ts
@@ -3,6 +3,7 @@ import { createAdapter } from '../adapter';
 import { CLAUDE_PHASE_MAPPINGS, getClaudePhaseMapping, getSupportedPhases } from '../mappings';
 import { normalizeClaude, setAdapterName, parseStdin, buildPayload, isStopHookRecursion } from '../normalizer';
 import { renderClaudeOutput } from '../renderer';
+import { mergeResults, parseHookResult } from '@a5c-ai/hooks-adapter-core';
 import { resolveSessionId } from '../session-resolver';
 import * as fixtures from './fixtures/claude-payloads';
 
@@ -646,6 +647,45 @@ describe('renderClaudeOutput', () => {
         'Stop',
       );
       expect(output).toEqual({ reason: 'specific stop' });
+    });
+
+    it('emits a block decision when the handler blocked', () => {
+      const output = renderClaudeOutput(
+        { decision: 'block', reason: 'Babysitter iteration 3 | Continue orchestration.' },
+        'Stop',
+      );
+      expect(output).toEqual({
+        decision: 'block',
+        reason: 'Babysitter iteration 3 | Continue orchestration.',
+      });
+    });
+
+    it('keeps the handler reason when stopReason is an empty string', () => {
+      // The merge engine defaults stopReason to '', which must not shadow
+      // the real reason the SDK handler produced.
+      const output = renderClaudeOutput(
+        { decision: 'block', reason: 'real reason', stopReason: '' },
+        'Stop',
+      );
+      expect(output).toEqual({ decision: 'block', reason: 'real reason' });
+    });
+
+    it('survives the round trip from the SDK handler to adapter output', () => {
+      // The SDK stop handler writes exactly this to stdout; it must reach
+      // Claude Code as a block decision, not as continue:true.
+      const handlerOutput = JSON.stringify({
+        decision: 'block',
+        reason: 'Babysitter iteration 3 | Continue orchestration (run:iterate).',
+        systemMessage: 'Babysitter iteration 3/65000 [created]',
+      });
+
+      const result = parseHookResult(handlerOutput);
+      const merged = mergeResults([result]);
+      const output = renderClaudeOutput(merged, 'Stop');
+
+      expect(output.decision).toBe('block');
+      expect(output.continue).toBe(false);
+      expect(output.reason).toContain('Continue orchestration');
     });
   });
 

--- a/packages/adapters/hooks/adapter-claude/src/renderer.ts
+++ b/packages/adapters/hooks/adapter-claude/src/renderer.ts
@@ -198,17 +198,19 @@ function renderStopOutput(result: UnifiedHookResult): Record<string, unknown> {
   const output: Record<string, unknown> = {};
 
   // Claude Code holds an agent in its turn only on an explicit block
-  // decision, so surface it when a handler blocked the session.
+  // decision, so surface it when a handler blocked the session. The
+  // `continue` field is not part of the Stop decision-control
+  // schema, so a block omits it: emitting it (even as false) alongside
+  // `decision: "block"` could let the turn end normally.
   if (result.decision === 'block') {
     output['decision'] = 'block';
-  }
-
-  if (result.continueSession != null) {
+  } else if (result.continueSession != null) {
     output['continue'] = result.continueSession;
   }
 
   // The merge engine defaults stopReason to an empty string, which would
-  // otherwise shadow a real reason from the handler.
+  // otherwise shadow a real reason from the handler. Claude Code requires
+  // reason when decision is "block", so an empty stopReason must not win.
   if (result.stopReason != null && result.stopReason !== '') {
     output['reason'] = result.stopReason;
   } else if (result.reason != null) {

--- a/packages/adapters/hooks/adapter-claude/src/renderer.ts
+++ b/packages/adapters/hooks/adapter-claude/src/renderer.ts
@@ -25,6 +25,8 @@ export interface ClaudePostToolUseOutput {
 export interface ClaudeStopOutput {
   /** If true, the session continues instead of stopping. */
   continue?: boolean;
+  /** Block the agent in its turn so the orchestration loop can continue. */
+  decision?: 'block';
   /** Optional reason for the decision. */
   reason?: string;
   /** Follow-up message to send if continuing. */
@@ -195,11 +197,19 @@ function renderPostToolUseOutput(result: UnifiedHookResult): Record<string, unkn
 function renderStopOutput(result: UnifiedHookResult): Record<string, unknown> {
   const output: Record<string, unknown> = {};
 
+  // Claude Code holds an agent in its turn only on an explicit block
+  // decision, so surface it when a handler blocked the session.
+  if (result.decision === 'block') {
+    output['decision'] = 'block';
+  }
+
   if (result.continueSession != null) {
     output['continue'] = result.continueSession;
   }
 
-  if (result.stopReason != null) {
+  // The merge engine defaults stopReason to an empty string, which would
+  // otherwise shadow a real reason from the handler.
+  if (result.stopReason != null && result.stopReason !== '') {
     output['reason'] = result.stopReason;
   } else if (result.reason != null) {
     output['reason'] = result.reason;

--- a/packages/adapters/hooks/core/src/merge-engine/__tests__/merge-engine.test.ts
+++ b/packages/adapters/hooks/core/src/merge-engine/__tests__/merge-engine.test.ts
@@ -280,6 +280,18 @@ describe('mergeResults', () => {
       const merged = mergeResults([result(), result()]);
       expect(merged.continueSession).toBe(true);
     });
+
+    it('a block decision stops the session even without continueSession', () => {
+      // The SDK's stop handler emits { decision: 'block' } and never sets
+      // continueSession, so the merge must derive the stop from the decision.
+      const merged = mergeResults([
+        result({ decision: 'block', reason: 'hold the turn' }),
+        result({ decision: 'allow' }),
+      ]);
+      expect(merged.decision).toBe('block');
+      expect(merged.continueSession).toBe(false);
+      expect(merged.reason).toBe('hold the turn');
+    });
   });
 
   // -----------------------------------------------------------------------

--- a/packages/adapters/hooks/core/src/merge-engine/merge.ts
+++ b/packages/adapters/hooks/core/src/merge-engine/merge.ts
@@ -359,7 +359,11 @@ export function mergeResults(
     }
 
     // --- continueSession (typed field) ---
-    if (r.continueSession === false) {
+    // A block decision means the session must not continue on its own: the
+    // SDK's stop handler emits a block decision and never sets
+    // continueSession explicitly, so without this mapping the merged result
+    // would keep the session going and Claude Code would never hold the turn.
+    if (r.continueSession === false || extractDecision(r) === 'block') {
       continueSession = false;
     }
 


### PR DESCRIPTION
## Description

The Babysitter Claude Code plugin's Stop hook was computing the right decision and then losing it before Claude Code could see it. The SDK stop handler writes `{"decision":"block","reason":...}` to stdout, but two things in the adapter wrapper quietly discarded that:

1. `mergeResults` only stopped the session when a handler set `continueSession: false` explicitly. A block decision never mapped to that, so the merged result stayed `continueSession: true`.
2. `renderStopOutput` had no branch that could emit `decision` at all — it only produced `continue`/reason/followUpMessage/additionalContext. On top of that, the merge engine defaults `stopReason` to an empty string, which took precedence over the handler's real `reason` in the renderer.

Net effect: the wrapper answered `{"continue": true, "reason": ""}`, Claude Code never held the agent in its turn, and the continuation loop never fired. The agent stopped after one turn even when the run was unfinished (measured as 60/86 Terminal-Bench trials producing no orchestrated run at all).

### What changed

- `packages/adapters/hooks/core/src/merge-engine/merge.ts`: a handler's `decision: 'block'` now sets `continueSession = false`, same as an explicit false would.
- `packages/adapters/hooks/adapter-claude/src/renderer.ts`: `renderStopOutput` emits `decision: 'block'` when the merged decision is block, and an empty `stopReason` no longer shadows the real reason.
- `ClaudeStopOutput` type gained the `decision` field.
- Tests: merge-engine covers the block→stop mapping; the claude adapter covers the emitted block decision, the empty-stopReason case, and a full round trip from the SDK handler's stdout JSON through `parseHookResult` → `mergeResults` → `renderClaudeOutput`.

## How to test

1. `npx vitest run --config packages/adapters/hooks/core/vitest.config.ts packages/adapters/hooks/core/src/merge-engine/__tests__/merge-engine.test.ts`
2. `npx vitest run --config packages/adapters/hooks/adapter-claude/vitest.config.ts packages/adapters/hooks/adapter-claude/src/__tests__/claude-adapter.test.ts`

The round-trip test fails on the pre-fix code with `continue: true` (verified by hand) and passes after.

Checks I ran: the new tests fail for the right reason on the pre-fix code and pass on the fix; the full `npm run test:hooks-adapter` suite passes 426 tests across 23 files. The 5 remaining failures live in `handler-timeout.test.ts` and `propagation.test.ts` and reproduce on a clean checkout — they look like Windows async-process timing issues, unrelated to this change. ESLint is clean on the changed source files.

Fixes #1761
