### PR TITLE
ci: move Live Stack, Issue Triage, version checks, QA Daily to ubuntu-latest

### DIFF
--- a/.github/workflows/agent-version-check.yml
+++ b/.github/workflows/agent-version-check.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   check-versions:
     name: Check Agent Versions
-    runs-on: ubuntu-latest-l
+    runs-on: ubuntu-latest
     steps:
       - name: Generate a5c GitHub App token
         id: a5c-token

--- a/.github/workflows/issue-triage-dispatch.yml
+++ b/.github/workflows/issue-triage-dispatch.yml
@@ -41,7 +41,7 @@ jobs:
       (github.event_name == 'workflow_dispatch') ||
       (github.event_name == 'issues' && github.event.action == 'opened') ||
       startsWith(github.event.comment.body, '/triage')
-    runs-on: ubuntu-latest-l
+    runs-on: ubuntu-latest
     steps:
       - name: Generate a5c GitHub App token
         id: a5c-token

--- a/.github/workflows/live-stack.yml
+++ b/.github/workflows/live-stack.yml
@@ -15,10 +15,10 @@ on:
         type: string
         default: ''
       os:
-        description: 'Runner OS (ubuntu-latest-l, macos-latest, windows-latest).'
+        description: 'Runner OS (ubuntu-latest, macos-latest, windows-latest).'
         required: false
         type: string
-        default: 'ubuntu-latest-l'
+        default: 'ubuntu-latest'
       matrix:
         description: 'JSON array of test combinations. Each entry: {agent, model, mode, install, live}. Empty = use push defaults.'
         required: false
@@ -41,7 +41,7 @@ concurrency:
 jobs:
   build_all:
     name: Build All
-    runs-on: ${{ inputs.os || 'ubuntu-latest-l' }}
+    runs-on: ${{ inputs.os || 'ubuntu-latest' }}
     permissions:
       contents: read
     defaults:
@@ -140,7 +140,7 @@ jobs:
         id: matrix
         env:
           DISPATCH_MATRIX: ${{ inputs.matrix }}
-          LIVE_STACK_OS: ${{ inputs.os || 'ubuntu-latest-l' }}
+          LIVE_STACK_OS: ${{ inputs.os || 'ubuntu-latest' }}
         run: |
           set -euo pipefail
 
@@ -316,7 +316,7 @@ jobs:
   live_stack_vanilla_ni:
     needs: [build_all, setup]
     name: "Live Stack (${{ inputs.os || 'ubuntu' }}, vanilla, ${{ matrix.scenario.agent }}/${{ matrix.scenario.model }}, ${{ matrix.interaction_mode.id }})"
-    runs-on: ${{ inputs.os || 'ubuntu-latest-m' }}
+    runs-on: ${{ inputs.os || 'ubuntu-latest' }}
     permissions:
       contents: read
       actions: read
@@ -537,7 +537,7 @@ jobs:
   live_stack_vanilla_interactive:
     needs: [build_all, setup]
     name: "Live Stack (${{ inputs.os || 'ubuntu' }}, vanilla, ${{ matrix.scenario.agent }}/${{ matrix.scenario.model }}, ${{ matrix.interaction_mode.id }})"
-    runs-on: ${{ inputs.os || 'ubuntu-latest-m' }}
+    runs-on: ${{ inputs.os || 'ubuntu-latest' }}
     permissions:
       contents: read
       actions: read
@@ -552,7 +552,7 @@ jobs:
   live_stack_bp_interactive:
     needs: [build_all, setup]
     name: "Live Stack (${{ inputs.os || 'ubuntu' }}, bp/${{ matrix.scenario.process_mode || 'predefined' }}, ${{ matrix.scenario.agent }}/${{ matrix.scenario.model }}, ${{ matrix.interaction_mode.id }})"
-    runs-on: ${{ inputs.os || 'ubuntu-latest-m' }}
+    runs-on: ${{ inputs.os || 'ubuntu-latest' }}
     permissions:
       contents: read
       actions: read
@@ -567,7 +567,7 @@ jobs:
   live_stack_bp_bridged:
     needs: [build_all, setup]
     name: "Live Stack (${{ inputs.os || 'ubuntu' }}, bp/${{ matrix.scenario.process_mode || 'predefined' }}, ${{ matrix.scenario.agent }}/${{ matrix.scenario.model }}, ${{ matrix.interaction_mode.id }})"
-    runs-on: ${{ inputs.os || 'ubuntu-latest-m' }}
+    runs-on: ${{ inputs.os || 'ubuntu-latest' }}
     permissions:
       contents: read
       actions: read
@@ -648,7 +648,7 @@ jobs:
           echo "# Live Stack Report" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "**Commit:** \`${{ github.sha }}\` on \`${{ github.ref_name }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "**OS:** \`${{ inputs.os || 'ubuntu-latest-l' }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "**OS:** \`${{ inputs.os || 'ubuntu-latest' }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "**Run:** [#${RUN_ID}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${RUN_ID})" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/model-version-check.yml
+++ b/.github/workflows/model-version-check.yml
@@ -32,7 +32,7 @@ concurrency:
 jobs:
   check-versions:
     name: Check Model Versions
-    runs-on: ubuntu-latest-l
+    runs-on: ubuntu-latest
     steps:
       - name: Generate a5c GitHub App token
         id: a5c-token

--- a/.github/workflows/qa-daily.yml
+++ b/.github/workflows/qa-daily.yml
@@ -36,7 +36,7 @@ jobs:
   # ──────────────────────────────────────────────────────────────────────
   comprehensive-qa:
     name: Comprehensive QA
-    runs-on: ubuntu-latest-l
+    runs-on: ubuntu-latest
     steps:
       - name: Generate a5c GitHub App token
         id: a5c-token
@@ -86,7 +86,7 @@ jobs:
             - modes: ni, bridged-interactive, interactive, bridged-hooks
             - install: vanilla, bp
             - process_mode: predefined, create, resume
-            - os (dispatch separately): ubuntu-latest-l, macos-latest, windows-latest
+            - os (dispatch separately): ubuntu-latest, macos-latest, windows-latest
 
             STEP 3 — DISPATCH LIVE-STACK:
             For each OS needed, dispatch separately:
@@ -118,7 +118,7 @@ jobs:
   # ──────────────────────────────────────────────────────────────────────
   triage-sweep:
     name: Triage Sweep
-    runs-on: ubuntu-latest-l
+    runs-on: ubuntu-latest
     steps:
       - name: Generate a5c GitHub App token
         id: a5c-token
@@ -167,7 +167,7 @@ jobs:
   # ──────────────────────────────────────────────────────────────────────
   changelog-update:
     name: Changelog & Wiki Update
-    runs-on: ubuntu-latest-l
+    runs-on: ubuntu-latest
     steps:
       - name: Generate a5c GitHub App token
         id: a5c-token
@@ -238,7 +238,7 @@ jobs:
   # ──────────────────────────────────────────────────────────────────────
   pr-review-sweep:
     name: PR Review Sweep
-    runs-on: ubuntu-latest-l
+    runs-on: ubuntu-latest
     steps:
       - name: Generate a5c GitHub App token
         id: a5c-token


### PR DESCRIPTION
FinOps: 100% of paid GitHub Actions spend (~$1,026/mo) is 8-core Linux minutes in this repo; Live Stack alone ~39k min/mo. This moves 5 workflows to the included 2-core runner. Jobs will run slower; Live Stack may need matrix/timeout tuning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVVtxJKYYnwM3FzMqiZ7VJ